### PR TITLE
feat(mobile): Google 소셜 로그인 구현

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,4 +1,5 @@
 import { exchangeCodeMutationOptions } from '@src/features/auth/presentations/queries/exchange-code-mutation-options';
+import { openGoogleLoginMutationOptions } from '@src/features/auth/presentations/queries/open-google-login-mutation-options';
 import { openKakaoLoginMutationOptions } from '@src/features/auth/presentations/queries/open-kakao-login-mutation-options';
 import { openNaverLoginMutationOptions } from '@src/features/auth/presentations/queries/open-naver-login-mutation-options';
 import { Button } from '@src/shared/ui/Button/Button';
@@ -42,6 +43,17 @@ const LoginScreen = () => {
     });
   };
 
+  const googleLoginMutation = useMutation(openGoogleLoginMutationOptions());
+  const handleGoogleLogin = () => {
+    googleLoginMutation.mutate(undefined, {
+      onSuccess: (code) => {
+        if (code) {
+          exchangeCodeMutation.mutate({ code });
+        }
+      },
+    });
+  };
+
   return (
     <StyledSafeAreaView className="flex-1 bg-white">
       <VStack flex={1} px={16}>
@@ -70,7 +82,8 @@ const LoginScreen = () => {
             <SocialLoginButton
               icon={<GoogleIcon width={20} height={20} />}
               label="Google로 계속하기"
-              onPress={() => {}}
+              onPress={handleGoogleLogin}
+              isLoading={googleLoginMutation.isPending || exchangeCodeMutation.isPending}
               className="bg-white border border-gray-200"
             />
           </VStack>

--- a/apps/mobile/src/features/auth/presentations/queries/open-google-login-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/open-google-login-mutation-options.ts
@@ -1,0 +1,10 @@
+import { useAuthService } from '@src/bootstrap/providers/di-provider';
+import { mutationOptions } from '@tanstack/react-query';
+
+export const openGoogleLoginMutationOptions = () => {
+  const authService = useAuthService();
+
+  return mutationOptions({
+    mutationFn: () => authService.openGoogleLogin(),
+  });
+};

--- a/apps/mobile/src/features/auth/repositories/auth.repository.impl.ts
+++ b/apps/mobile/src/features/auth/repositories/auth.repository.impl.ts
@@ -66,6 +66,10 @@ export class AuthRepositoryImpl implements AuthRepository {
     return `${ENV.API_URL}/v1/auth/naver/start?redirect_uri=${encodeURIComponent(redirectUri)}`;
   }
 
+  getGoogleAuthUrl(redirectUri: string): string {
+    return `${ENV.API_URL}/v1/auth/google/start?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  }
+
   async getPreference() {
     const { data } = await this._authHttpClient.get('v1/auth/preference');
 

--- a/apps/mobile/src/features/auth/repositories/auth.repository.ts
+++ b/apps/mobile/src/features/auth/repositories/auth.repository.ts
@@ -21,6 +21,8 @@ export interface AuthRepository {
 
   getNaverAuthUrl(redirectUri: string): string;
 
+  getGoogleAuthUrl(redirectUri: string): string;
+
   getPreference(): Promise<PreferenceResponse>;
 
   updatePreference(input: UpdatePreferenceInput): Promise<UpdatePreferenceResponse>;

--- a/apps/mobile/src/features/auth/services/auth.service.ts
+++ b/apps/mobile/src/features/auth/services/auth.service.ts
@@ -18,7 +18,7 @@ import type { AuthTokens, User } from '../models/auth.model';
 import type { AuthRepository } from '../repositories/auth.repository';
 import { toAuthTokens, toUser } from './auth.mapper';
 
-type OAuthProvider = 'kakao' | 'naver';
+type OAuthProvider = 'kakao' | 'naver' | 'google';
 
 export class AuthService {
   constructor(private readonly _authRepository: AuthRepository) {}
@@ -33,6 +33,7 @@ export class AuthService {
       path: match(provider)
         .with('kakao', () => 'auth/kakao')
         .with('naver', () => 'auth/naver')
+        .with('google', () => 'auth/google')
         .exhaustive(),
     });
 
@@ -68,6 +69,7 @@ export class AuthService {
     const authUrl = match(provider)
       .with('kakao', () => this._authRepository.getKakaoAuthUrl(redirectUri))
       .with('naver', () => this._authRepository.getNaverAuthUrl(redirectUri))
+      .with('google', () => this._authRepository.getGoogleAuthUrl(redirectUri))
       .exhaustive();
 
     // createTask: false → Android에서 새 태스크 생성 안 함 → iOS와 동일하게 URL 캡처
@@ -102,6 +104,8 @@ export class AuthService {
   openKakaoLogin = (): Promise<string> => this.openOAuthLogin('kakao');
 
   openNaverLogin = (): Promise<string> => this.openOAuthLogin('naver');
+
+  openGoogleLogin = (): Promise<string> => this.openOAuthLogin('google');
 
   // Auth API Methods
   exchangeCode = async (request: ExchangeCodeInput): Promise<AuthTokens> => {


### PR DESCRIPTION
## 개요

카카오/네이버와 동일한 Web Browser OAuth 방식으로 Google 소셜 로그인을 모바일 앱에 추가합니다.

## 변경 사항

### 수정 파일
- `auth.repository.ts` - `getGoogleAuthUrl` 인터페이스 추가
- `auth.repository.impl.ts` - `getGoogleAuthUrl` 구현
- `auth.service.ts` - `OAuthProvider` 타입에 `'google'` 추가, ts-pattern match에 google case 추가
- `login.tsx` - Google 버튼 핸들러 연결

### 새로 생성 파일
- `open-google-login-mutation-options.ts` - mutation options

## 기술적 세부사항

- 기존 카카오/네이버와 동일한 Web Browser OAuth 플로우 사용
- `ts-pattern`의 `match().exhaustive()` 패턴으로 타입 안전성 보장
- Repository → Service → Presentation 계층 구조 준수

## 테스트

- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과

## 관련 이슈

Closes #87