### PR TITLE
feat(api,validators): 회원가입 기본 알림/마케팅 동의 활성화

### DIFF
--- a/apps/api/src/modules/auth/repositories/user-preference.repository.spec.ts
+++ b/apps/api/src/modules/auth/repositories/user-preference.repository.spec.ts
@@ -87,8 +87,8 @@ describe("UserPreferenceRepository", () => {
 			// Given
 			const expectedPreference = UserPreferenceBuilder.create("user-123")
 				.withId("new-pref-123")
-				.withPushDisabled()
-				.withNightPushEnabled(false)
+				.withPushEnabled(true)
+				.withNightPushEnabled(true)
 				.build();
 			db.userPreference.create.mockResolvedValue(expectedPreference);
 
@@ -100,8 +100,8 @@ describe("UserPreferenceRepository", () => {
 			expect(db.userPreference.create).toHaveBeenCalledWith({
 				data: {
 					userId: "user-123",
-					pushEnabled: false,
-					nightPushEnabled: false,
+					pushEnabled: true,
+					nightPushEnabled: true,
 				},
 			});
 		});
@@ -138,8 +138,8 @@ describe("UserPreferenceRepository", () => {
 			const mockTx = createMockTxClient();
 			const expectedPreference = UserPreferenceBuilder.create("user-123")
 				.withId("tx-pref-123")
-				.withPushDisabled()
-				.withNightPushEnabled(false)
+				.withPushEnabled(true)
+				.withNightPushEnabled(true)
 				.build();
 			mockTx.userPreference.create.mockResolvedValue(expectedPreference);
 
@@ -155,8 +155,8 @@ describe("UserPreferenceRepository", () => {
 			expect(mockTx.userPreference.create).toHaveBeenCalledWith({
 				data: {
 					userId: "user-123",
-					pushEnabled: false,
-					nightPushEnabled: false,
+					pushEnabled: true,
+					nightPushEnabled: true,
 				},
 			});
 			expect(db.userPreference.create).not.toHaveBeenCalled();
@@ -172,7 +172,7 @@ describe("UserPreferenceRepository", () => {
 			const expectedPreference = UserPreferenceBuilder.create("user-123")
 				.withId("new-pref-123")
 				.withPushEnabled(true)
-				.withNightPushEnabled(false)
+				.withNightPushEnabled(true)
 				.build();
 			db.userPreference.upsert.mockResolvedValue(expectedPreference);
 
@@ -186,7 +186,7 @@ describe("UserPreferenceRepository", () => {
 				create: {
 					userId: "user-123",
 					pushEnabled: true,
-					nightPushEnabled: false,
+					nightPushEnabled: true,
 				},
 				update: {
 					pushEnabled: true,
@@ -215,7 +215,7 @@ describe("UserPreferenceRepository", () => {
 				where: { userId: "user-123" },
 				create: {
 					userId: "user-123",
-					pushEnabled: false,
+					pushEnabled: true,
 					nightPushEnabled: true,
 				},
 				update: {

--- a/apps/api/src/modules/auth/repositories/user-preference.repository.ts
+++ b/apps/api/src/modules/auth/repositories/user-preference.repository.ts
@@ -34,8 +34,8 @@ export class UserPreferenceRepository {
 		return client.userPreference.create({
 			data: {
 				userId,
-				pushEnabled: data?.pushEnabled ?? false,
-				nightPushEnabled: data?.nightPushEnabled ?? false,
+				pushEnabled: data?.pushEnabled ?? true,
+				nightPushEnabled: data?.nightPushEnabled ?? true,
 				...(data?.timezone !== undefined && { timezone: data.timezone }),
 				...(data?.morningReminderHour !== undefined && {
 					morningReminderHour: data.morningReminderHour,
@@ -57,8 +57,8 @@ export class UserPreferenceRepository {
 			where: { userId },
 			create: {
 				userId,
-				pushEnabled: data.pushEnabled ?? false,
-				nightPushEnabled: data.nightPushEnabled ?? false,
+				pushEnabled: data.pushEnabled ?? true,
+				nightPushEnabled: data.nightPushEnabled ?? true,
 				...(data.timezone !== undefined && { timezone: data.timezone }),
 				...(data.morningReminderHour !== undefined && {
 					morningReminderHour: data.morningReminderHour,

--- a/apps/api/src/modules/auth/services/auth.service.ts
+++ b/apps/api/src/modules/auth/services/auth.service.ts
@@ -136,12 +136,12 @@ export class AuthService {
 					},
 				});
 
-				// 푸시 알림 설정 초기화 (기본값: 모두 OFF)
+				// 푸시 알림 설정 초기화 (기본값: 모두 ON)
 				await tx.userPreference.create({
 					data: {
 						userId: newUser.id,
-						pushEnabled: false,
-						nightPushEnabled: false,
+						pushEnabled: true,
+						nightPushEnabled: true,
 					},
 				});
 

--- a/apps/api/src/modules/auth/services/oauth.service.spec.ts
+++ b/apps/api/src/modules/auth/services/oauth.service.spec.ts
@@ -215,6 +215,7 @@ describe("OAuthService", () => {
 			async (callback: TransactionCallback) => {
 				const mockTx = {
 					userConsent: { create: jest.fn() },
+					userPreference: { create: jest.fn() },
 				};
 				return callback(mockTx as never);
 			},

--- a/apps/api/src/modules/auth/services/oauth.service.ts
+++ b/apps/api/src/modules/auth/services/oauth.service.ts
@@ -1101,7 +1101,16 @@ export class OAuthService {
 					userId: user.id,
 					termsAgreedAt: currentTime,
 					privacyAgreedAt: currentTime,
-					marketingAgreedAt: null,
+					marketingAgreedAt: currentTime,
+				},
+			});
+
+			// 푸시 알림 설정 초기화 (기본값: 모두 ON)
+			await tx.userPreference.create({
+				data: {
+					userId: user.id,
+					pushEnabled: true,
+					nightPushEnabled: true,
 				},
 			});
 

--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -1273,9 +1273,9 @@ describe("Auth (e2e)", () => {
 			expect(response.body.success).toBe(true);
 			expect(response.body.data).toHaveProperty("pushEnabled");
 			expect(response.body.data).toHaveProperty("nightPushEnabled");
-			// 기본값은 false
-			expect(response.body.data.pushEnabled).toBe(false);
-			expect(response.body.data.nightPushEnabled).toBe(false);
+			// 기본값은 true
+			expect(response.body.data.pushEnabled).toBe(true);
+			expect(response.body.data.nightPushEnabled).toBe(true);
 		});
 
 		it("PATCH /auth/preference - 푸시 설정 활성화", async () => {
@@ -1291,7 +1291,7 @@ describe("Auth (e2e)", () => {
 			// Then - 응답 검증
 			expect(response.body.success).toBe(true);
 			expect(response.body.data.pushEnabled).toBe(true);
-			expect(response.body.data.nightPushEnabled).toBe(false);
+			expect(response.body.data.nightPushEnabled).toBe(true);
 		});
 
 		it("PATCH /auth/preference - 야간 푸시 설정 활성화", async () => {
@@ -1392,8 +1392,8 @@ describe("Auth (e2e)", () => {
 			// 회원가입 시 동의했으므로 termsAgreedAt, privacyAgreedAt은 값이 있음
 			expect(response.body.data.termsAgreedAt).not.toBeNull();
 			expect(response.body.data.privacyAgreedAt).not.toBeNull();
-			// 마케팅 동의는 기본적으로 없음
-			expect(response.body.data.marketingAgreedAt).toBeNull();
+			// 마케팅 동의는 기본적으로 활성화됨
+			expect(response.body.data.marketingAgreedAt).not.toBeNull();
 		});
 
 		it("PATCH /auth/consent/marketing - 마케팅 동의 활성화", async () => {

--- a/packages/validators/src/domains/auth/auth.request.ts
+++ b/packages/validators/src/domains/auth/auth.request.ts
@@ -42,8 +42,8 @@ export const registerSchema = z
       .describe('개인정보처리방침 동의 (필수, true만 허용)'),
     marketingAgreed: z
       .boolean()
-      .default(false)
-      .describe('마케팅 정보 수신 동의 (선택, 기본값: false)'),
+      .default(true)
+      .describe('마케팅 정보 수신 동의 (선택, 기본값: true)'),
   })
   .refine((data) => data.password === data.passwordConfirm, {
     message: '비밀번호가 일치하지 않습니다',


### PR DESCRIPTION
## ⚠️ Breaking Changes
- 회원가입 기본 정책이 변경됩니다: 푸시(일반/야간)와 마케팅 수신 동의가 기본 활성화됩니다.
- 가입 직후 `marketingAgreedAt`가 null이 아닌 값으로 저장됩니다.

## 📋 개요
회원가입 기본 정책을 제품 요구사항에 맞게 ON 기준으로 통일했습니다. credential/OAuth 가입 경로 모두 동일한 기본값을 적용하고, 관련 validator/테스트를 함께 갱신했습니다.

## 🏷️ 변경 유형
- [x] ✨ `feat` - 새로운 기능 추가
- [ ] 🐛 `fix` - 버그 수정
- [ ] 📝 `docs` - 문서 수정
- [ ] 💄 `style` - 코드 포맷팅, 세미콜론 누락 등 (코드 변경 없음)
- [ ] ♻️ `refactor` - 코드 리팩토링
- [ ] ⚡ `perf` - 성능 개선
- [ ] ✅ `test` - 테스트 추가/수정
- [ ] 🔧 `build` - 빌드 시스템 또는 외부 종속성 변경
- [ ] 👷 `ci` - CI 설정 파일 및 스크립트 변경
- [ ] 🔨 `chore` - 기타 변경사항 (빌드 프로세스, 도구 설정 등)
- [ ] ⏪ `revert` - 이전 커밋 되돌리기

## 📦 영향 범위
- [x] `apps/api` - NestJS 백엔드
- [ ] `apps/mobile` - Expo 모바일 앱
- [x] `packages/validators` - Zod 스키마
- [ ] `packages/utils` - 공유 유틸리티
- [ ] `packages/errors` - 에러 정의
- [ ] `tooling/*` - 개발 도구 설정 (biome, jest, typescript)
- [ ] 기타:

## 📝 변경 내용
- credential 가입 시 `userPreference` 기본값을 `pushEnabled=true`, `nightPushEnabled=true`로 변경
- OAuth 신규 가입 시 `userPreference` 생성을 추가하고 기본값을 ON으로 통일
- OAuth 신규 가입 시 `marketingAgreedAt` 기본값을 가입 시각으로 저장하도록 변경
- `registerSchema.marketingAgreed` 기본값을 `true`로 변경
- 단위 테스트 및 e2e 기대값을 정책 변경에 맞춰 갱신

## 🧪 테스트
### 테스트 방법
```bash
pnpm --filter @aido/api lint
pnpm --filter @aido/api typecheck
pnpm --filter @aido/validators build
pnpm --filter @aido/api test -- src/modules/auth/repositories/user-preference.repository.spec.ts src/modules/auth/services/auth.service.spec.ts src/modules/auth/services/oauth.service.spec.ts
pnpm --filter @aido/api test:e2e -- auth.e2e-spec.ts -t "푸시 설정 관리|약관 동의 관리"
```

### 테스트 결과
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과
- [x] 수동 테스트 완료

## 🔗 관련 이슈
Closes #143