### PR TITLE
chore: pnpm 9 → 10 마이그레이션

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,16 @@
     "tsx": "^4.21.0",
     "turbo": "^2.8.8"
   },
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc",
   "engines": {
     "node": ">=20.0.0"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@suites/di.nestjs",
+      "@suites/doubles.jest"
+    ],
     "overrides": {}
   }
 }


### PR DESCRIPTION
## Summary

- pnpm 9.15.4 → 10.29.3 major 업데이트
- `onlyBuiltDependencies` 설정 추가 — pnpm 10에서는 보안상 모든 패키지의 lifecycle 스크립트(postinstall 등)가 기본 차단됨. 명시적으로 허용한 패키지만 실행 가능
- lockfile 포맷 변경 없음 (pnpm 9도 이미 v9.0 사용)

## Test plan
- [x] `pnpm install` 정상 동작
- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test` 통과 (API 1114개 + Mobile 88개)