### PR TITLE
fix(api): 12시 알림 중복 전송 수정 - forRoot() 이중 등록 제거

### DIFF
--- a/apps/api/src/modules/admin-notification/admin-notification.module.spec.ts
+++ b/apps/api/src/modules/admin-notification/admin-notification.module.spec.ts
@@ -1,0 +1,50 @@
+import { EventEmitterModule } from "@nestjs/event-emitter";
+import { ScheduleModule } from "@nestjs/schedule";
+
+import { AdminNotificationModule } from "./admin-notification.module";
+import { DailySignupSummaryJob } from "./jobs/daily-signup-summary.job";
+import { UserRegistrationListener } from "./listeners/user-registration.listener";
+import { ADMIN_NOTIFIER } from "./providers/admin-notifier.interface";
+
+describe("AdminNotificationModule", () => {
+	let moduleImports: any[];
+	let moduleProviders: any[];
+
+	beforeEach(() => {
+		const metadata = Reflect.getMetadata("imports", AdminNotificationModule);
+		moduleImports = metadata ?? [];
+
+		const providers = Reflect.getMetadata("providers", AdminNotificationModule);
+		moduleProviders = providers ?? [];
+	});
+
+	it("ScheduleModule을 import하지 않아야 한다 (SchedulerModule에서 forRoot 등록됨)", () => {
+		// Given - 모듈의 imports 메타데이터
+		// When & Then - ScheduleModule이 포함되지 않음을 확인
+		const hasScheduleModule = moduleImports.some(
+			(imp: any) => imp === ScheduleModule || imp?.module === ScheduleModule,
+		);
+		expect(hasScheduleModule).toBe(false);
+	});
+
+	it("EventEmitterModule을 import하지 않아야 한다 (AppModule에서 forRoot 등록됨)", () => {
+		// Given - 모듈의 imports 메타데이터
+		// When & Then - EventEmitterModule이 포함되지 않음을 확인
+		const hasEventEmitterModule = moduleImports.some(
+			(imp: any) =>
+				imp === EventEmitterModule || imp?.module === EventEmitterModule,
+		);
+		expect(hasEventEmitterModule).toBe(false);
+	});
+
+	it("필수 providers가 등록되어 있어야 한다", () => {
+		// Given - 모듈의 providers 메타데이터
+		// When
+		const providerTokens = moduleProviders.map((p: any) => p?.provide ?? p);
+
+		// Then - 필수 provider 토큰들이 모두 등록됨
+		expect(providerTokens).toContain(ADMIN_NOTIFIER);
+		expect(providerTokens).toContain(UserRegistrationListener);
+		expect(providerTokens).toContain(DailySignupSummaryJob);
+	});
+});

--- a/apps/api/src/modules/admin-notification/admin-notification.module.ts
+++ b/apps/api/src/modules/admin-notification/admin-notification.module.ts
@@ -1,6 +1,4 @@
 import { Module } from "@nestjs/common";
-import { EventEmitterModule } from "@nestjs/event-emitter";
-import { ScheduleModule } from "@nestjs/schedule";
 
 import { DatabaseModule } from "@/database";
 
@@ -10,11 +8,7 @@ import { ADMIN_NOTIFIER } from "./providers/admin-notifier.interface";
 import { DiscordWebhookProvider } from "./providers/discord-webhook.provider";
 
 @Module({
-	imports: [
-		EventEmitterModule.forRoot(),
-		ScheduleModule.forRoot(),
-		DatabaseModule,
-	],
+	imports: [DatabaseModule],
 	providers: [
 		{
 			provide: ADMIN_NOTIFIER,


### PR DESCRIPTION
## 📋 개요

`AdminNotificationModule`에서 `EventEmitterModule.forRoot()`와 `ScheduleModule.forRoot()`가 이중 등록되어 12시 알림이 2번 전송되는 버그 수정

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드

## 📝 변경 내용

- `AdminNotificationModule`에서 불필요한 `EventEmitterModule.forRoot()`, `ScheduleModule.forRoot()` import 제거
- `DatabaseModule`만 import하도록 정리 (`forRoot()`는 각각 `AppModule`, `SchedulerModule`에서 1회 등록)
- 모듈 메타데이터 검증 단위 테스트 추가 (`admin-notification.module.spec.ts`)

## 🧪 테스트

### 테스트 방법

```bash
pnpm test -- --testPathPattern="admin-notification.module"
```

### 테스트 결과

- [x] 단위 테스트 통과
- [x] lint 통과
- [x] typecheck 통과
- [x] build 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #205