### PR TITLE
fix(api): Discord 웹훅 알림 중복 발송, 날짜 포맷 깨짐 및 알림 내용 개선 (#230)

### DIFF
--- a/apps/api/src/modules/admin-notification/listeners/user-registration.listener.spec.ts
+++ b/apps/api/src/modules/admin-notification/listeners/user-registration.listener.spec.ts
@@ -30,6 +30,20 @@ describe("UserRegistrationListener", () => {
 		registeredAt: "2026-02-09T00:00:00.000Z",
 	};
 
+	/** send 호출의 첫 번째 인자 반환 */
+	function getSendArg() {
+		return notifier.send.mock.calls[0]?.[0];
+	}
+
+	/** 특정 이름의 필드 반환 */
+	function getField(name: string) {
+		return getSendArg()?.fields?.find((f: { name: string }) => f.name === name);
+	}
+
+	// =========================================================================
+	// 기본 동작
+	// =========================================================================
+
 	it("회원가입 이벤트를 받으면 알림을 발송한다", async () => {
 		// When
 		await listener.handleUserRegistered(basePayload);
@@ -48,9 +62,20 @@ describe("UserRegistrationListener", () => {
 		);
 	});
 
+	it("body에 사용자 이메일이 볼드로 포함되어야 한다", async () => {
+		// When
+		await listener.handleUserRegistered(basePayload);
+
+		// Then
+		expect(getSendArg().body).toContain("**test@example.com**");
+	});
+
 	it("소셜 로그인 provider를 한국어 라벨로 변환한다", async () => {
 		// Given
-		const payload = { ...basePayload, provider: "google" as const };
+		const payload: UserRegisteredEventPayload = {
+			...basePayload,
+			provider: "google",
+		};
 
 		// When
 		await listener.handleUserRegistered(payload);
@@ -64,6 +89,68 @@ describe("UserRegistrationListener", () => {
 			}),
 		);
 	});
+
+	// =========================================================================
+	// 기기 추정 정보
+	// =========================================================================
+
+	it("Apple 가입 시 기기 추정 정보가 iOS로 표시되어야 한다", async () => {
+		// Given
+		const payload: UserRegisteredEventPayload = {
+			...basePayload,
+			provider: "apple",
+		};
+
+		// When
+		await listener.handleUserRegistered(payload);
+
+		// Then
+		expect(getField("기기 (추정)")?.value).toContain("iOS");
+	});
+
+	it("Google 가입 시 기기 추정 정보가 Android로 표시되어야 한다", async () => {
+		// Given
+		const payload: UserRegisteredEventPayload = {
+			...basePayload,
+			provider: "google",
+		};
+
+		// When
+		await listener.handleUserRegistered(payload);
+
+		// Then
+		expect(getField("기기 (추정)")?.value).toContain("Android");
+	});
+
+	it("이메일 가입 시 기기 추정 필드가 없어야 한다", async () => {
+		// Given
+		const payload: UserRegisteredEventPayload = {
+			...basePayload,
+			provider: "credential",
+		};
+
+		// When
+		await listener.handleUserRegistered(payload);
+
+		// Then
+		expect(getField("기기 (추정)")).toBeUndefined();
+	});
+
+	// =========================================================================
+	// 날짜 포맷
+	// =========================================================================
+
+	it("가입 시각이 Discord timestamp 형식으로 포맷되어야 한다", async () => {
+		// When
+		await listener.handleUserRegistered(basePayload);
+
+		// Then
+		expect(getField("가입 시각")?.value).toMatch(/^<t:\d+:f>$/);
+	});
+
+	// =========================================================================
+	// 에러 처리
+	// =========================================================================
 
 	it("알림 발송 실패해도 예외가 전파되지 않는다", async () => {
 		// Given

--- a/apps/api/src/modules/admin-notification/listeners/user-registration.listener.ts
+++ b/apps/api/src/modules/admin-notification/listeners/user-registration.listener.ts
@@ -10,12 +10,32 @@ import {
 	type AdminNotifier,
 } from "../providers/admin-notifier.interface";
 
+/**
+ * ISO 날짜 문자열을 Discord 타임스탬프 포맷으로 변환
+ */
+function formatDate(isoString: string): string {
+	try {
+		const unixSeconds = Math.floor(new Date(isoString).getTime() / 1000);
+		return `<t:${unixSeconds}:f>`;
+	} catch {
+		return isoString;
+	}
+}
+
 const PROVIDER_LABELS: Record<string, string> = {
 	credential: "이메일",
 	apple: "Apple",
 	google: "Google",
 	kakao: "Kakao",
 	naver: "Naver",
+};
+
+/**
+ * 가입 방식 → 기기 추정 라벨 (Apple/Google만 추정 가능)
+ */
+const PROVIDER_DEVICE_LABELS: Record<string, string> = {
+	apple: "🍎 iOS (추정)",
+	google: "🤖 Android (추정)",
 };
 
 /**
@@ -44,21 +64,31 @@ export class UserRegistrationListener {
 		try {
 			const providerLabel =
 				PROVIDER_LABELS[payload.provider] ?? payload.provider;
+			const deviceLabel = PROVIDER_DEVICE_LABELS[payload.provider];
+
+			const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+				{ name: "이메일", value: payload.email, inline: true },
+				{ name: "가입 방식", value: providerLabel, inline: true },
+			];
+
+			if (deviceLabel) {
+				fields.push({ name: "기기 (추정)", value: deviceLabel, inline: true });
+			}
+
+			fields.push(
+				{ name: "사용자 ID", value: payload.userId, inline: false },
+				{
+					name: "가입 시각",
+					value: formatDate(payload.registeredAt),
+					inline: false,
+				},
+			);
 
 			const result = await this.adminNotifier.send({
 				title: "새로운 회원가입",
-				body: "새로운 사용자가 가입했습니다.",
+				body: `**${payload.email}** 님이 가입했습니다.`,
 				color: 0x57f287,
-				fields: [
-					{ name: "이메일", value: payload.email, inline: true },
-					{ name: "가입 방식", value: providerLabel, inline: true },
-					{ name: "사용자 ID", value: payload.userId, inline: false },
-					{
-						name: "가입 시각",
-						value: payload.registeredAt,
-						inline: false,
-					},
-				],
+				fields,
 			});
 
 			if (result.success) {

--- a/apps/api/src/modules/subscription/listeners/subscription-notification.listener.spec.ts
+++ b/apps/api/src/modules/subscription/listeners/subscription-notification.listener.spec.ts
@@ -46,6 +46,16 @@ describe("SubscriptionNotificationListener", () => {
 		currency: "KRW",
 	};
 
+	/** send 호출의 첫 번째 인자 반환 */
+	function getSendArg() {
+		return notifier.send.mock.calls[0]?.[0];
+	}
+
+	/** 특정 이름의 필드 반환 */
+	function getField(name: string) {
+		return getSendArg()?.fields?.find((f: { name: string }) => f.name === name);
+	}
+
 	// =========================================================================
 	// 이벤트 타입별 제목/이모지
 	// =========================================================================
@@ -87,11 +97,30 @@ describe("SubscriptionNotificationListener", () => {
 		);
 	});
 
+	it("알 수 없는 이벤트 타입 → DEFAULT_META 사용", async () => {
+		// Given
+		const payload: SubscriptionEventPayload = {
+			...basePayload,
+			eventType: "UNKNOWN_EVENT_TYPE",
+		};
+
+		// When
+		await listener.handleSubscriptionEvent(payload);
+
+		// Then
+		expect(notifier.send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "📋 구독 이벤트",
+				color: 0x7289da,
+			}),
+		);
+	});
+
 	// =========================================================================
 	// 필드 구성 검증
 	// =========================================================================
 
-	it("필드에 이메일, 상품, 스토어, 금액, 만료일, 사용자 ID가 포함되어야 한다", async () => {
+	it("필드에 이메일, 상품, 스토어, 기기, 금액, 만료일, 사용자 ID가 포함되어야 한다", async () => {
 		// Given
 		const payload: SubscriptionEventPayload = { ...basePayload };
 
@@ -106,41 +135,94 @@ describe("SubscriptionNotificationListener", () => {
 						name: "이메일",
 						value: "test@example.com",
 					}),
-					expect.objectContaining({
-						name: "상품",
-						value: "premium_monthly",
-					}),
-					expect.objectContaining({
-						name: "스토어",
-						value: "Apple App Store",
-					}),
-					expect.objectContaining({
-						name: "금액",
-					}),
-					expect.objectContaining({
-						name: "만료일",
-					}),
-					expect.objectContaining({
-						name: "사용자 ID",
-						value: "user-123",
-					}),
+					expect.objectContaining({ name: "상품", value: "premium_monthly" }),
+					expect.objectContaining({ name: "스토어", value: "Apple App Store" }),
+					expect.objectContaining({ name: "기기" }),
+					expect.objectContaining({ name: "금액" }),
+					expect.objectContaining({ name: "만료일" }),
+					expect.objectContaining({ name: "사용자 ID", value: "user-123" }),
 				]),
 			}),
 		);
 	});
 
 	// =========================================================================
-	// 에러 처리
+	// body 포맷
 	// =========================================================================
 
-	it("발송 실패해도 예외가 전파되지 않는다", async () => {
+	it("body에 사용자 이메일이 볼드로 포함되어야 한다", async () => {
 		// Given
-		notifier.send.mockRejectedValue(new Error("Network error"));
+		const payload: SubscriptionEventPayload = { ...basePayload };
 
-		// When & Then
-		await expect(
-			listener.handleSubscriptionEvent(basePayload),
-		).resolves.not.toThrow();
+		// When
+		await listener.handleSubscriptionEvent(payload);
+
+		// Then
+		expect(getSendArg().body).toContain("**test@example.com**");
+	});
+
+	// =========================================================================
+	// 기기 정보
+	// =========================================================================
+
+	it("APP_STORE 이벤트에 기기 정보가 iOS로 표시되어야 한다", async () => {
+		// Given
+		const payload: SubscriptionEventPayload = {
+			...basePayload,
+			store: "APP_STORE",
+		};
+
+		// When
+		await listener.handleSubscriptionEvent(payload);
+
+		// Then
+		expect(getField("기기")?.value).toContain("iOS");
+	});
+
+	it("PLAY_STORE 이벤트에 기기 정보가 Android로 표시되어야 한다", async () => {
+		// Given
+		const payload: SubscriptionEventPayload = {
+			...basePayload,
+			store: "PLAY_STORE",
+		};
+
+		// When
+		await listener.handleSubscriptionEvent(payload);
+
+		// Then
+		expect(getField("기기")?.value).toContain("Android");
+	});
+
+	it("store가 없으면 기기 필드가 없어야 한다", async () => {
+		// Given
+		const payload: SubscriptionEventPayload = {
+			...basePayload,
+			store: undefined,
+		};
+
+		// When
+		await listener.handleSubscriptionEvent(payload);
+
+		// Then
+		expect(getField("기기")).toBeUndefined();
+	});
+
+	// =========================================================================
+	// 날짜 포맷 (Discord 타임스탬프)
+	// =========================================================================
+
+	it("만료일이 Discord timestamp 형식으로 포맷되어야 한다", async () => {
+		// Given
+		const payload: SubscriptionEventPayload = {
+			...basePayload,
+			expiresAt: "2026-02-26T00:33:00.000Z",
+		};
+
+		// When
+		await listener.handleSubscriptionEvent(payload);
+
+		// Then
+		expect(getField("만료일")?.value).toMatch(/^<t:\d+:f>$/);
 	});
 
 	// =========================================================================
@@ -159,13 +241,7 @@ describe("SubscriptionNotificationListener", () => {
 		await listener.handleSubscriptionEvent(payload);
 
 		// Then
-		const sendCall = notifier.send.mock.calls[0]?.[0];
-		const priceField = sendCall?.fields?.find(
-			(f: { name: string }) => f.name === "금액",
-		);
-		expect(priceField).toBeDefined();
-		// KRW 포맷: ₩4,900 형태
-		expect(priceField.value).toMatch(/4,900|₩/);
+		expect(getField("금액")?.value).toMatch(/4,900|₩/);
 	});
 
 	// =========================================================================
@@ -197,25 +273,16 @@ describe("SubscriptionNotificationListener", () => {
 	});
 
 	// =========================================================================
-	// 알 수 없는 이벤트 타입
+	// 에러 처리
 	// =========================================================================
 
-	it("알 수 없는 이벤트 타입 → DEFAULT_META 사용", async () => {
+	it("발송 실패해도 예외가 전파되지 않는다", async () => {
 		// Given
-		const payload: SubscriptionEventPayload = {
-			...basePayload,
-			eventType: "UNKNOWN_EVENT_TYPE",
-		};
+		notifier.send.mockRejectedValue(new Error("Network error"));
 
-		// When
-		await listener.handleSubscriptionEvent(payload);
-
-		// Then
-		expect(notifier.send).toHaveBeenCalledWith(
-			expect.objectContaining({
-				title: "📋 구독 이벤트",
-				color: 0x7289da,
-			}),
-		);
+		// When & Then
+		await expect(
+			listener.handleSubscriptionEvent(basePayload),
+		).resolves.not.toThrow();
 	});
 });

--- a/apps/api/src/modules/subscription/listeners/subscription-notification.listener.ts
+++ b/apps/api/src/modules/subscription/listeners/subscription-notification.listener.ts
@@ -91,6 +91,17 @@ const STORE_LABELS: Record<string, string> = {
 };
 
 /**
+ * 스토어 → 기기 추정 라벨
+ */
+const DEVICE_LABELS: Record<string, string> = {
+	APP_STORE: "🍎 iOS",
+	PLAY_STORE: "🤖 Android",
+	STRIPE: "🌐 Web",
+	AMAZON: "📦 Amazon",
+	PROMOTIONAL: "🎁 프로모션",
+};
+
+/**
  * 가격 포맷
  */
 function formatPrice(price: number, currency?: string): string {
@@ -108,19 +119,15 @@ function formatPrice(price: number, currency?: string): string {
 }
 
 /**
- * ISO 날짜 문자열을 읽기 쉬운 형식으로 변환
+ * ISO 날짜 문자열을 Discord 타임스탬프 포맷으로 변환
+ *
+ * Discord가 사용자의 로컬 시간대에 맞춰 자동 렌더링합니다.
+ * @see https://discord.com/developers/docs/reference#message-formatting-formats
  */
 function formatDate(isoString: string): string {
 	try {
-		const date = new Date(isoString);
-		return date.toLocaleString("ko-KR", {
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-			timeZone: "Asia/Seoul",
-		});
+		const unixSeconds = Math.floor(new Date(isoString).getTime() / 1000);
+		return `<t:${unixSeconds}:f>`;
 	} catch {
 		return isoString;
 	}
@@ -170,6 +177,12 @@ export class SubscriptionNotificationListener {
 				fields.push({ name: "스토어", value: storeLabel, inline: true });
 			}
 
+			// 기기 (스토어 기반 추정)
+			if (payload.store) {
+				const deviceLabel = DEVICE_LABELS[payload.store] ?? payload.store;
+				fields.push({ name: "기기", value: deviceLabel, inline: true });
+			}
+
 			// 금액
 			if (payload.price != null) {
 				fields.push({
@@ -206,7 +219,7 @@ export class SubscriptionNotificationListener {
 
 			const result = await this.adminNotifier.send({
 				title: `${meta.emoji} ${meta.title}`,
-				body: `구독 이벤트가 발생했습니다. (${payload.eventType})`,
+				body: `**${payload.email}** 님의 구독 이벤트 (${payload.eventType})`,
 				color: meta.color,
 				fields,
 			});

--- a/apps/api/src/modules/subscription/subscription.service.spec.ts
+++ b/apps/api/src/modules/subscription/subscription.service.spec.ts
@@ -191,7 +191,7 @@ describe("SubscriptionService", () => {
 			);
 		});
 
-		it("멱등성: 이미 존재하는 구독이면 create를 호출하지 않는다", async () => {
+		it("멱등성: 이미 존재하는 구독이면 create를 호출하지 않고 이벤트도 발행하지 않는다", async () => {
 			// Given
 			subscriptionRepository.findByRevenueCatId.mockResolvedValue({
 				id: "sub-1",
@@ -205,8 +205,11 @@ describe("SubscriptionService", () => {
 			// When
 			await service.handleWebhookEvent(payload);
 
-			// Then
+			// Then — DB 미변경, 캐시 미무효화, 이벤트 미발행
 			expect(subscriptionRepository.create).not.toHaveBeenCalled();
+			expect(cacheService.invalidateSubscription).not.toHaveBeenCalled();
+			expect(cacheService.invalidateUserProfile).not.toHaveBeenCalled();
+			expect(eventEmitter.emit).not.toHaveBeenCalled();
 		});
 
 		it("purchased_at_ms가 누락되면 에러를 던진다", async () => {
@@ -342,7 +345,7 @@ describe("SubscriptionService", () => {
 			);
 		});
 
-		it("멱등성: 동일 expiresAt이고 ACTIVE이면 updateStatus를 호출하지 않는다", async () => {
+		it("멱등성: 동일 expiresAt이고 ACTIVE이면 updateStatus를 호출하지 않고 이벤트도 발행하지 않는다", async () => {
 			// Given
 			const expiresAtMs = Date.now() + 30 * 24 * 60 * 60 * 1000;
 			const expiresAt = new Date(expiresAtMs);
@@ -360,8 +363,11 @@ describe("SubscriptionService", () => {
 			// When
 			await service.handleWebhookEvent(payload);
 
-			// Then
+			// Then — DB 미변경, 캐시 미무효화, 이벤트 미발행
 			expect(subscriptionRepository.updateStatus).not.toHaveBeenCalled();
+			expect(cacheService.invalidateSubscription).not.toHaveBeenCalled();
+			expect(cacheService.invalidateUserProfile).not.toHaveBeenCalled();
+			expect(eventEmitter.emit).not.toHaveBeenCalled();
 		});
 	});
 

--- a/apps/api/src/modules/subscription/subscription.service.ts
+++ b/apps/api/src/modules/subscription/subscription.service.ts
@@ -219,13 +219,13 @@ export class SubscriptionService {
 	 * INITIAL_PURCHASE: 최초 구매
 	 *
 	 * Subscription 레코드 생성 + User 상태 ACTIVE
-	 * 멱등성: 동일 transactionId 구독이 이미 있으면 skip
+	 * 멱등성: 동일 transactionId 구독이 이미 있으면 skip → null 반환 (이벤트 미발행)
 	 */
 	async #handleInitialPurchase(
 		userId: string,
 		email: string,
 		event: RevenueCatWebhookPayload["event"],
-	): Promise<SubscriptionEventPayload> {
+	): Promise<SubscriptionEventPayload | null> {
 		const transactionId = this.#resolveTransactionId(event);
 
 		if (!event.purchased_at_ms) {
@@ -244,7 +244,7 @@ export class SubscriptionService {
 		const startedAt = new Date(event.purchased_at_ms);
 		const expiresAt = new Date(event.expiration_at_ms);
 
-		await this.database.$transaction(async (tx) => {
+		const skipped = await this.database.$transaction(async (tx) => {
 			// 멱등성 가드: 중복 webhook 재전송 대비
 			const existing = await this.subscriptionRepository.findByRevenueCatId(
 				transactionId,
@@ -254,7 +254,7 @@ export class SubscriptionService {
 				this.#logger.log(
 					`Subscription already exists for transactionId=${transactionId}, skipping create`,
 				);
-				return;
+				return true;
 			}
 
 			await this.subscriptionRepository.create(
@@ -278,7 +278,12 @@ export class SubscriptionService {
 				},
 				tx,
 			);
+			return false;
 		});
+
+		if (skipped) {
+			return null;
+		}
 
 		this.#logger.log(
 			`Initial purchase processed: userId=${userId}, productId=${event.product_id}, transactionId=${transactionId}`,
@@ -302,12 +307,13 @@ export class SubscriptionService {
 	 * RENEWAL: 갱신
 	 *
 	 * Subscription 갱신 + User 상태 ACTIVE + expiresAt 업데이트
+	 * 멱등성: 동일 expiresAt으로 이미 갱신되었으면 skip → null 반환 (이벤트 미발행)
 	 */
 	async #handleRenewal(
 		userId: string,
 		email: string,
 		event: RevenueCatWebhookPayload["event"],
-	): Promise<SubscriptionEventPayload> {
+	): Promise<SubscriptionEventPayload | null> {
 		const transactionId = this.#resolveTransactionId(event);
 
 		if (!event.expiration_at_ms) {
@@ -319,7 +325,7 @@ export class SubscriptionService {
 
 		const expiresAt = new Date(event.expiration_at_ms);
 
-		await this.database.$transaction(async (tx) => {
+		const skipped = await this.database.$transaction(async (tx) => {
 			// 멱등성 가드: 동일 expiresAt으로 이미 갱신되었으면 skip
 			const existing = await this.subscriptionRepository.findByRevenueCatId(
 				transactionId,
@@ -338,7 +344,7 @@ export class SubscriptionService {
 				this.#logger.log(
 					`Already renewed with same expiresAt, skipping: transactionId=${transactionId}`,
 				);
-				return;
+				return true;
 			}
 
 			await this.subscriptionRepository.updateStatus(
@@ -360,7 +366,12 @@ export class SubscriptionService {
 				},
 				tx,
 			);
+			return false;
 		});
+
+		if (skipped) {
+			return null;
+		}
 
 		this.#logger.log(
 			`Renewal processed: userId=${userId}, transactionId=${transactionId}, newExpiresAt=${expiresAt.toISOString()}`,


### PR DESCRIPTION
## 📋 개요

Discord 웹훅으로 전송되는 구독/가입 알림의 중복 발송, 날짜 포맷 깨짐, 알림 내용 부족 문제를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드

## 📝 변경 내용

### 중복 알림 수정
- `#handleInitialPurchase`, `#handleRenewal`에서 멱등성 가드로 skip 시 `null` 반환하여 이벤트 발행 차단
- RevenueCat 웹훅 재시도 시 동일 구독에 대한 중복 Discord 알림 방지

### 날짜 포맷 수정
- `toLocaleString("ko-KR")` → Discord 네이티브 타임스탬프 `<t:UNIX:f>` 형식으로 변경
- 사용자 로컬 시간대에 맞춰 자동 렌더링, 줄바꿈 문제 해결

### 알림 내용 개선
- **구독 알림**: 기기 정보(iOS/Android) 추가, 사용자 이메일 볼드 표시, 스토어/금액/만료일 필드 구성
- **가입 알림**: Apple/Google 로그인 시 기기 추정 정보 추가, 이메일 볼드 표시, 가입 시각 Discord 타임스탬프 적용

## 🧪 테스트

### 테스트 방법

```bash
cd apps/api && npx jest --testPathPattern="(subscription-notification.listener|user-registration.listener|subscription.service)\.spec" --no-coverage
```

### 테스트 결과

- [x] 리스너 단위 테스트 21개 통과 (subscription-notification.listener 12개 + user-registration.listener 9개)
- [x] subscription.service 멱등성 테스트 보강 및 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #230