### PR TITLE
refactor(mobile): 알림 설정 리마인드 시간 선택 UX 개선 (#245)

### DIFF
--- a/apps/mobile/app/(app)/settings/notifications.tsx
+++ b/apps/mobile/app/(app)/settings/notifications.tsx
@@ -1,10 +1,13 @@
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { getPreferenceQueryOptions } from '@src/features/auth/presentations/queries/get-preference-query-options';
 import { updatePreferenceMutationOptions } from '@src/features/auth/presentations/queries/update-preference-mutation-options';
+import { PickerHeader } from '@src/features/todo/presentations/components/PickerHeader';
 import { UserPolicy } from '@src/features/user/models/user.model';
 import { getMeQueryOptions } from '@src/features/user/presentations/queries/get-me-query-options';
+import { KeyboardBottomSheet } from '@src/shared/ui/BottomSheet';
 import { HStack } from '@src/shared/ui/HStack/HStack';
 import { ArrowRightIcon } from '@src/shared/ui/Icon';
+import { useOverlay } from '@src/shared/ui/Overlay';
 import { usePremiumDialog } from '@src/shared/ui/PremiumDialog';
 import { QueryErrorBoundary } from '@src/shared/ui/QueryErrorBoundary/QueryErrorBoundary';
 import { StyledSafeAreaView } from '@src/shared/ui/SafeAreaView/SafeAreaView';
@@ -23,7 +26,7 @@ import {
   SkeletonGroup,
 } from 'heroui-native';
 import { Suspense, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { Platform, ScrollView, View } from 'react-native';
 
 const NotificationSettingsScreen = () => {
   return (
@@ -112,9 +115,7 @@ function PushSettingsSection() {
     <VStack p={16} gap={12} className="bg-white rounded-2xl">
       <ControlField
         isSelected={preference.pushEnabled}
-        onSelectedChange={(enabled) => {
-          updateMutation.mutate({ pushEnabled: enabled });
-        }}
+        onSelectedChange={(enabled) => updateMutation.mutate({ pushEnabled: enabled })}
         isDisabled={updateMutation.isPending}
       >
         <View className="flex-1">
@@ -129,9 +130,7 @@ function PushSettingsSection() {
       <ControlField
         isSelected={preference.nightPushEnabled}
         onSelectedChange={(enabled) => {
-          if (!preference.pushEnabled) {
-            return;
-          }
+          if (!preference.pushEnabled) return;
           updateMutation.mutate({ nightPushEnabled: enabled });
         }}
         isDisabled={updateMutation.isPending || !preference.pushEnabled}
@@ -152,9 +151,6 @@ function PushSettingsSection() {
 
 function ReminderSection() {
   const { data: preference } = useSuspenseQuery(getPreferenceQueryOptions());
-  const { data: user } = useSuspenseQuery(getMeQueryOptions());
-  const updateMutation = useMutation(updatePreferenceMutationOptions());
-  const isPremium = UserPolicy.isPremiumUser(user);
 
   return (
     <VStack gap={8}>
@@ -170,30 +166,16 @@ function ReminderSection() {
       <VStack p={16} gap={12} className="bg-white rounded-2xl">
         <ReminderTimeRow
           label="오전 리마인드"
-          hour={preference.morningReminderHour}
-          minute={preference.morningReminderMinute}
           description="오전 시간대(0:00~11:59)에 오늘의 할일을 알려줘요"
-          disabled={!preference.pushEnabled || updateMutation.isPending}
-          isPremium={isPremium}
           field="morning"
-          onTimeChange={(hour, minute) =>
-            updateMutation.mutate({ morningReminderHour: hour, morningReminderMinute: minute })
-          }
         />
 
         <Separator className="bg-gray-2" />
 
         <ReminderTimeRow
           label="오후 리마인드"
-          hour={preference.eveningReminderHour}
-          minute={preference.eveningReminderMinute}
           description="오후 시간대(12:00~23:59)에 남은 할일을 알려줘요"
-          disabled={!preference.pushEnabled || updateMutation.isPending}
-          isPremium={isPremium}
           field="evening"
-          onTimeChange={(hour, minute) =>
-            updateMutation.mutate({ eveningReminderHour: hour, eveningReminderMinute: minute })
-          }
         />
       </VStack>
     </VStack>
@@ -202,32 +184,35 @@ function ReminderSection() {
 
 interface ReminderTimeRowProps {
   label: string;
-  hour: number;
-  minute: number;
   description: string;
-  disabled: boolean;
-  isPremium: boolean;
   field: 'morning' | 'evening';
-  onTimeChange: (hour: number, minute: number) => void;
 }
 
-function ReminderTimeRow({
-  label,
-  hour,
-  minute,
-  description,
-  disabled,
-  isPremium,
-  field,
-  onTimeChange,
-}: ReminderTimeRowProps) {
+function ReminderTimeRow({ label, description, field }: ReminderTimeRowProps) {
+  const { data: preference } = useSuspenseQuery(getPreferenceQueryOptions());
+  const { data: user } = useSuspenseQuery(getMeQueryOptions());
+  const updateMutation = useMutation(updatePreferenceMutationOptions());
   const premiumDialog = usePremiumDialog();
-  const [open, setOpen] = useState(false);
+  const overlay = useOverlay();
+  const [androidPickerOpen, setAndroidPickerOpen] = useState(false);
+
+  const isPremium = UserPolicy.isPremiumUser(user);
+  const disabled = !preference.pushEnabled || updateMutation.isPending;
+  const hour =
+    field === 'morning' ? preference.morningReminderHour : preference.eveningReminderHour;
+  const minute =
+    field === 'morning' ? preference.morningReminderMinute : preference.eveningReminderMinute;
+
+  const handleTimeChange = (h: number, m: number) => {
+    const input =
+      field === 'morning'
+        ? { morningReminderHour: h, morningReminderMinute: m }
+        : { eveningReminderHour: h, eveningReminderMinute: m };
+    updateMutation.mutate(input);
+  };
 
   const handlePress = () => {
-    if (disabled) {
-      return;
-    }
+    if (disabled) return;
 
     if (!isPremium) {
       premiumDialog.open({
@@ -236,7 +221,19 @@ function ReminderTimeRow({
       return;
     }
 
-    setOpen(true);
+    if (Platform.OS === 'android') {
+      setAndroidPickerOpen(true);
+      return;
+    }
+
+    openTimePickerBottomSheet({
+      label,
+      field,
+      hour,
+      minute,
+      overlay,
+      onConfirm: handleTimeChange,
+    });
   };
 
   return (
@@ -261,23 +258,85 @@ function ReminderTimeRow({
         </HStack>
       </PressableFeedback>
 
-      {open && (
+      {androidPickerOpen && (
         <DateTimePicker
           value={timeToDate(hour, minute)}
           minimumDate={timeToDate(field === 'morning' ? 0 : 12, 0)}
           maximumDate={timeToDate(field === 'morning' ? 11 : 23, 59)}
-          onChange={(_event, date) => {
-            setOpen(false);
-            if (date) {
-              onTimeChange(date.getHours(), date.getMinutes());
+          onChange={(event, date) => {
+            setAndroidPickerOpen(false);
+
+            if (event.type === 'set' && date) {
+              handleTimeChange(date.getHours(), date.getMinutes());
             }
           }}
           mode="time"
           display="spinner"
           minuteInterval={1}
-          locale={Intl.DateTimeFormat().resolvedOptions().locale}
         />
       )}
     </VStack>
   );
+}
+
+function openTimePickerBottomSheet({
+  label,
+  field,
+  hour,
+  minute,
+  overlay,
+  onConfirm,
+}: {
+  label: string;
+  field: 'morning' | 'evening';
+  hour: number;
+  minute: number;
+  overlay: ReturnType<typeof useOverlay>;
+  onConfirm: (hour: number, minute: number) => void;
+}) {
+  let tempDate = timeToDate(hour, minute);
+
+  overlay.open(({ isOpen, close, exit }) => (
+    <KeyboardBottomSheet
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          close();
+          exit();
+        }
+      }}
+    >
+      <VStack gap={24}>
+        <PickerHeader
+          title={label}
+          onCancel={() => {
+            close();
+            exit();
+          }}
+          onConfirm={() => {
+            onConfirm(tempDate.getHours(), tempDate.getMinutes());
+            close();
+            exit();
+          }}
+        />
+        <View style={{ height: 216 }}>
+          <DateTimePicker
+            value={tempDate}
+            minimumDate={timeToDate(field === 'morning' ? 0 : 12, 0)}
+            maximumDate={timeToDate(field === 'morning' ? 11 : 23, 59)}
+            onChange={(_event, date) => {
+              if (date) {
+                tempDate = date;
+              }
+            }}
+            mode="time"
+            display="spinner"
+            minuteInterval={1}
+            locale={Intl.DateTimeFormat().resolvedOptions().locale}
+            style={{ height: 216 }}
+          />
+        </View>
+      </VStack>
+    </KeyboardBottomSheet>
+  ));
 }

--- a/apps/mobile/src/features/auth/presentations/queries/update-preference-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/update-preference-mutation-options.ts
@@ -1,6 +1,9 @@
+import { ErrorCode } from '@aido/errors';
 import type { UpdatePreferenceInput } from '@aido/validators';
 import { useAuthService } from '@src/bootstrap/providers/di-provider';
+import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
+import { useAppToast } from '@src/shared/hooks/useAppToast';
 import { mutationOptions, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 
@@ -10,6 +13,7 @@ import { AUTH_QUERY_KEYS } from '../constants/auth-query-keys.constant';
 export const updatePreferenceMutationOptions = () => {
   const authService = useAuthService();
   const queryClient = useQueryClient();
+  const toast = useAppToast();
 
   return mutationOptions({
     mutationFn: async (input: UpdatePreferenceInput) => {
@@ -32,12 +36,25 @@ export const updatePreferenceMutationOptions = () => {
       // 서버 응답으로 캐시를 정확하게 업데이트 (invalidate 대신 직접 업데이트로 블링킹 방지)
       queryClient.setQueryData<Preference>(AUTH_QUERY_KEYS.preference(), data);
     },
-    onError: (_error, _input, context) => {
+    onError: (error, _input, context) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
 
       if (context?.previousData) {
         queryClient.setQueryData(AUTH_QUERY_KEYS.preference(), context.previousData);
       }
+
+      if (isApiError(error)) {
+        if (error.hasCode(ErrorCode.PREFERENCE_1701)) {
+          toast.error('리마인드 시간 변경은 프리미엄 기능이에요');
+          return;
+        }
+        if (error.hasCode(ErrorCode.PREFERENCE_1702)) {
+          toast.error('시간 범위가 올바르지 않아요');
+          return;
+        }
+      }
+
+      toast.error(error, { fallback: '설정 변경에 실패했어요' });
     },
   });
 };


### PR DESCRIPTION
## 📋 개요

알림 설정 화면의 리마인드 시간 선택 UX를 개선하고, 컴포넌트 설계 규칙에 맞게 리팩토링합니다.

## 🏷️ 변경 유형

- [x] ♻️ `refactor` - 코드 리팩토링

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

### UX 개선
- **iOS**: 시간 선택 시 BottomSheet + PickerHeader(확인 버튼) 패턴 적용 — 스크롤 후 바로 적용되던 문제 해결
- **Android**: 네이티브 DateTimePicker 다이얼로그 사용 (OK/CANCEL 내장)
- 플랫폼별 최적의 UX 제공

### 컴포넌트 리팩토링 (설계 규칙 준수)
- `ReminderTimeRow`가 `useSuspenseQuery`로 데이터 직접 구독 (Props Drilling 제거: 8개 → 3개)
- `openTimePickerBottomSheet` 헬퍼 함수 추출 (핸들러 4줄+ 분리 규칙)
- `ReminderSection` 단순화 — description 분기만 담당

### 에러 처리 보강
- `updatePreferenceMutationOptions`에 비즈니스 에러 토스트 추가
  - `PREFERENCE_1701`: 프리미엄 기능 안내
  - `PREFERENCE_1702`: 시간 범위 오류 안내
- 에러 발생 시 haptic 피드백 + optimistic update 롤백

## 🧪 테스트

### 테스트 방법

1. iOS: 오전/오후 리마인드 탭 → BottomSheet에서 시간 스크롤 → 확인 버튼으로 저장
2. Android: 오전/오후 리마인드 탭 → 네이티브 다이얼로그에서 시간 선택 → OK로 저장
3. 비프리미엄 유저: 프리미엄 다이얼로그 표시 확인
4. 푸시 비활성화 상태: disabled UI 정상 동작 확인

### 테스트 결과

- [x] `pnpm lint` 통과
- [x] `pnpm typecheck` 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm lint` (Biome) 검사를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] 플랫폼별(iOS/Android) UX 검증 완료

## 🔗 관련 이슈

Closes #245