### PR TITLE
fix(mobile): iOS 첫 홈화면 진입 시 탭 레이아웃 높이 어긋남 수정

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/_layout.tsx
@@ -5,28 +5,48 @@ import { isGlassEffectAPIAvailable, isLiquidGlassAvailable } from 'expo-glass-ef
 import * as Haptics from 'expo-haptics';
 import { Tabs } from 'expo-router';
 import { Icon, Label, NativeTabs } from 'expo-router/unstable-native-tabs';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { AccessibilityInfo, Platform } from 'react-native';
 
 import { useResolveClassNames } from 'uniwind';
 
 function useLiquidGlassAvailable() {
-  const glassSupported =
-    Platform.OS === 'ios' && isLiquidGlassAvailable() && isGlassEffectAPIAvailable();
+  const glassSupported = useMemo(
+    () => Platform.OS === 'ios' && isLiquidGlassAvailable() && isGlassEffectAPIAvailable(),
+    [],
+  );
 
   const [available, setAvailable] = useState(glassSupported);
 
   useEffect(() => {
     if (!glassSupported) return;
+
+    let isMounted = true;
+
     const check = async () => {
       try {
         const reduce = await AccessibilityInfo.isReduceTransparencyEnabled();
-        if (reduce) setAvailable(false);
+        if (isMounted) {
+          setAvailable(!reduce);
+        }
       } catch (error) {
         console.warn('[TabsLayout] Failed to check reduce transparency:', error);
       }
     };
+
     check();
+
+    const subscription = AccessibilityInfo.addEventListener(
+      'reduceTransparencyChanged',
+      (reduceEnabled) => {
+        setAvailable(!reduceEnabled);
+      },
+    );
+
+    return () => {
+      isMounted = false;
+      subscription.remove();
+    };
   }, [glassSupported]);
 
   return available;


### PR DESCRIPTION
## 📋 개요

iOS에서 로그인 직후 탭 화면 진입 시 `useLiquidGlassAvailable()` 훅의 비동기 체크로 인해 `return null`이 발생하여 탭 바 없이 자식 화면이 레이아웃되는 문제를 수정합니다.

-> 시뮬레이터에서는 오류가 없었어서 실제 문제가 이 원인이 맞는지는 체크가 필요하나, 이 작업 이전에는 해당 문제가 없었던 것 같아 이 부분을 수정합니다 

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `useLiquidGlassAvailable` 훅에서 동기 API(`isLiquidGlassAvailable`, `isGlassEffectAPIAvailable`)로 초기값 즉시 결정
- `ready` 상태 및 `return null` 제거로 첫 렌더부터 탭 바 렌더
- 접근성(투명도 줄이기) 체크는 비동기로 유지하되, glass → fallback 전환만 담당

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm build
```

### 테스트 결과

- [x] 빌드 및 타입체크 통과
- [ ] 수동 테스트: 회원가입/로그인 직후 홈화면 진입 → 탭 레이아웃 높이 정상
- [ ] 수동 테스트: 앱 나갔다 들어오기 → 동일하게 정상
- [ ] 수동 테스트: iOS 26+ / iOS 26 미만 양쪽 확인

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #248

## 💬 추가 정보

### 근본 원인

커밋 `f2a1890`에서 Liquid Glass 가용성 체크를 위해 `useLiquidGlassAvailable()` 훅을 추가하면서, iOS에서 첫 렌더 시 `return null`을 반환하게 됨. 이로 인해 탭 바 없이 자식 화면이 레이아웃되고, 이후 탭 바가 나타나도 높이가 어긋난 채로 유지됨.

`isLiquidGlassAvailable()`과 `isGlassEffectAPIAvailable()`은 동기 함수(네이티브 모듈 캐싱)이므로 비동기로 감쌀 필요가 없었음. 비동기인 것은 `AccessibilityInfo.isReduceTransparencyEnabled()`뿐이며, 이를 위해 전체 탭 바 렌더를 블로킹할 필요가 없음.