### PR TITLE
feat(mobile): 에러 화면 및 Not Found 화면 추가 

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from '@src/bootstrap/providers/auth-provider';
+import { useErrorReporter } from '@src/bootstrap/providers/di-provider';
 import { resetAuthClient } from '@src/shared/infra/http/auth-client';
 import { HStack } from '@src/shared/ui/HStack/HStack';
 import { Result } from '@src/shared/ui/Result/Result';
@@ -37,9 +38,12 @@ interface ErrorBoundaryProps {
   retry: () => void;
 }
 
-export function ErrorBoundary({ retry }: ErrorBoundaryProps) {
+export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   const { setStatus } = useAuth();
   const queryClient = useQueryClient();
+  const errorReporter = useErrorReporter();
+
+  errorReporter.captureException(error, { feature: 'error_boundary' });
 
   const handleLogout = () => {
     setStatus('unauthenticated');

--- a/apps/mobile/app/+not-found.tsx
+++ b/apps/mobile/app/+not-found.tsx
@@ -9,7 +9,19 @@ export default function NotFoundScreen() {
       <Result
         icon={<DocsIcon width={72} height={72} />}
         title="페이지를 찾을 수 없어요"
-        button={<Result.Button onPress={() => router.back()}>돌아가기</Result.Button>}
+        button={
+          <Result.Button
+            onPress={() => {
+              if (router.canGoBack()) {
+                router.back();
+              } else {
+                router.replace('/feed');
+              }
+            }}
+          >
+            돌아가기
+          </Result.Button>
+        }
       />
     </StyledSafeAreaView>
   );


### PR DESCRIPTION
## 📋 개요

에러 발생 시 사용자가 화면에 갇히는 문제를 해결하기 위해 ErrorBoundary 에러 화면과 Not Found 화면을 추가합니다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `app/(app)/_layout.tsx`에 Expo Router `ErrorBoundary` export 추가 (재시도 + 로그아웃 버튼)
- `app/+not-found.tsx` 신규 생성 (돌아가기 버튼)
- 에러 화면의 로그아웃은 로컬 클린업만 수행 (API 호출 없음, 네트워크 에러에서도 탈출 가능)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #249

## 스크린샷 
<img width="200" height="600" alt="Simulator Screenshot - iPhone SE 3 (iOS 16 4) - 2026-03-02 at 16 08 23" src="https://github.com/user-attachments/assets/0f0390df-decf-46a5-b83a-6916d1a01164" />
<img width="200" height="600" alt="Simulator Screenshot - iPhone SE 3 (iOS 16 4) - 2026-03-02 at 16 14 06" src="https://github.com/user-attachments/assets/f7e44a1c-c197-48c0-84f4-786a4ce5e7c3" />
