### PR TITLE
fix(mobile): 인증 코드 입력 UI에서 불필요한 separator 제거

### DIFF
--- a/apps/mobile/app/(auth)/forgot-password.tsx
+++ b/apps/mobile/app/(auth)/forgot-password.tsx
@@ -219,9 +219,6 @@ function VerificationCodeStep({ onNext }: VerificationCodeStepProps) {
               <InputOTP.Slot index={0} />
               <InputOTP.Slot index={1} />
               <InputOTP.Slot index={2} />
-            </InputOTP.Group>
-            <InputOTP.Separator />
-            <InputOTP.Group>
               <InputOTP.Slot index={3} />
               <InputOTP.Slot index={4} />
               <InputOTP.Slot index={5} />

--- a/apps/mobile/src/features/auth/presentations/components/SignUpVerificationForm.tsx
+++ b/apps/mobile/src/features/auth/presentations/components/SignUpVerificationForm.tsx
@@ -111,9 +111,6 @@ export const SignUpVerificationForm = () => {
                   <InputOTP.Slot index={0} />
                   <InputOTP.Slot index={1} />
                   <InputOTP.Slot index={2} />
-                </InputOTP.Group>
-                <InputOTP.Separator />
-                <InputOTP.Group>
                   <InputOTP.Slot index={3} />
                   <InputOTP.Slot index={4} />
                   <InputOTP.Slot index={5} />


### PR DESCRIPTION
## 📋 개요

인증 코드(OTP) 입력 시 `123-456` 형태로 표시되던 중간 대시(separator)를 제거하여 `123456` 형태로 연속 표시되도록 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `forgot-password.tsx`: `InputOTP.Separator` 및 중복 `InputOTP.Group` 제거
- `SignUpVerificationForm.tsx`: `InputOTP.Separator` 및 중복 `InputOTP.Group` 제거


## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #264

## 💬 추가 정보

- 두 파일 모두 동일한 패턴의 변경 (6줄 삭제)
- `InputOTP.Group`을 하나로 통합하고 `InputOTP.Separator`를 제거
<img width="200" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2026-03-03 at 20 19 48" src="https://github.com/user-attachments/assets/535e122a-141c-469f-b332-2bd214fe4b4f" />
