### PR TITLE
fix(mobile): 회원가입 비밀번호 입력 UI 간격 불일치 수정

### DIFF
--- a/apps/mobile/src/features/auth/presentations/components/SignUpPasswordForm.tsx
+++ b/apps/mobile/src/features/auth/presentations/components/SignUpPasswordForm.tsx
@@ -121,6 +121,7 @@ export const SignUpPasswordForm = ({ onNextStep }: SignUpPasswordFormProps) => {
                     returnKeyType="next"
                     isInvalid={!!errors.password}
                     errorMessage={errors.password?.message}
+                    renderErrorMessage={false}
                     onSubmitEditing={() => {
                       if (isPasswordValid) handleNext();
                     }}


### PR DESCRIPTION
## 📋 개요

회원가입 비밀번호 설정 단계에서 `비밀번호` 입력 필드가 에러 메시지가 없어도 고정 에러 슬롯을 렌더링해 생기던 여백을 제거해,
비밀번호 변경/재설정 화면과 UI 간격을 일치시킵니다.

## 🏷️ 변경 유형

- [ ] ✨ `feat` - 새로운 기능 추가
- [x] 🐛 `fix` - 버그 수정
- [ ] 📝 `docs` - 문서 수정
- [ ] 💄 `style` - 코드 포맷팅, 세미콜론 누락 등 (코드 변경 없음)
- [ ] ♻️ `refactor` - 코드 리팩토링
- [ ] ⚡ `perf` - 성능 개선
- [ ] ✅ `test` - 테스트 추가/수정
- [ ] 🔧 `build` - 빌드 시스템 또는 외부 종속성 변경
- [ ] 👷 `ci` - CI 설정 파일 및 스크립트 변경
- [ ] 🔨 `chore` - 기타 변경사항 (빌드 프로세스, 도구 설정 등)
- [ ] ⏪ `revert` - 이전 커밋 되돌리기

## 📦 영향 범위

- [ ] `apps/api` - NestJS 백엔드
- [x] `apps/mobile` - Expo 모바일 앱
- [ ] `packages/validators` - Zod 스키마
- [ ] `packages/utils` - 공유 유틸리티
- [ ] `packages/errors` - 에러 정의
- [ ] `tooling/*` - 개발 도구 설정 (biome, jest, typescript)
- [ ] 기타:

## 📝 변경 내용

- `SignUpPasswordForm`의 `비밀번호` 입력(`PasswordInput`)에 `renderErrorMessage={false}`를 추가
- 에러 미존재 시 공백 에러 슬롯으로 인해 생기던 입력 필드 하단 여백 제거
- 비밀번호 변경/재설정 화면과 동일한 비밀번호 입력 간격 정책으로 정렬

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [ ] `pnpm check` (Biome) 검사를 통과했습니다
- [ ] 변경사항에 대한 테스트를 작성/수정했습니다
- [ ] 모든 테스트가 통과합니다 (`pnpm test`)
- [ ] 빌드가 성공합니다 (`pnpm build`)
- [x] 필요한 경우 문서를 업데이트했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #279.
