### PR TITLE
feat(mobile): 타입 안전한 이벤트 트래킹 레이어 구축 및 mutation 통합 (#308)

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/_layout.tsx
@@ -1,12 +1,13 @@
 import ListIconSvg from '@assets/icons/ic_list.svg';
 import PersonIconSvg from '@assets/icons/ic_person.svg';
+import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { useTheme } from '@src/shared/providers/theme-provider';
 import { isGlassEffectAPIAvailable, isLiquidGlassAvailable } from 'expo-glass-effect';
 import * as Haptics from 'expo-haptics';
 import { Tabs } from 'expo-router';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { useEffect, useMemo, useState } from 'react';
 import { AccessibilityInfo, Platform } from 'react-native';
-
 import { useResolveClassNames } from 'uniwind';
 
 function useLiquidGlassAvailable() {
@@ -58,19 +59,22 @@ export default function TabsLayout() {
 
 function IOSLiquidGlassTabs() {
   const activeStyle = useResolveClassNames('text-main');
+  const { resolvedTheme } = useTheme();
 
   return (
-    <NativeTabs tintColor={activeStyle.color} minimizeBehavior="onScrollDown">
-      <NativeTabs.Trigger name="feed">
-        <NativeTabs.Trigger.Label>할 일</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon sf="list.bullet" />
-      </NativeTabs.Trigger>
+    <ThemeProvider value={resolvedTheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <NativeTabs tintColor={activeStyle.color} minimizeBehavior="onScrollDown">
+        <NativeTabs.Trigger name="feed">
+          <NativeTabs.Trigger.Label>할 일</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon sf="list.bullet" />
+        </NativeTabs.Trigger>
 
-      <NativeTabs.Trigger name="mypage">
-        <NativeTabs.Trigger.Label>마이</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon sf="person.fill" />
-      </NativeTabs.Trigger>
-    </NativeTabs>
+        <NativeTabs.Trigger name="mypage">
+          <NativeTabs.Trigger.Label>마이</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon sf="person.fill" />
+        </NativeTabs.Trigger>
+      </NativeTabs>
+    </ThemeProvider>
   );
 }
 

--- a/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
@@ -43,22 +43,16 @@ const MyPageScreen = () => {
 
         <Spacing size={12} />
 
+        {/* 핵심 기능 */}
         <SettingNavigationSection>
           <SettingNavigationItem label="AI 리포트" onPress={() => router.push('/reports')} />
           <SettingNavigationItem label="친구 관리" onPress={() => router.push('/friends')} />
-          <SettingNavigationItem
-            label="구독 관리"
-            onPress={() => router.push('/settings/subscription')}
-          />
         </SettingNavigationSection>
 
         <Spacing size={12} />
 
+        {/* 환경설정 */}
         <SettingNavigationSection>
-          <SettingNavigationItem
-            label="연결된 계정"
-            onPress={() => router.push('/settings/linked-accounts')}
-          />
           <SettingNavigationItem
             label="알림 설정"
             onPress={() => router.push('/settings/notifications')}
@@ -71,6 +65,21 @@ const MyPageScreen = () => {
 
         <Spacing size={12} />
 
+        {/* 계정 관리 */}
+        <SettingNavigationSection>
+          <SettingNavigationItem
+            label="구독 관리"
+            onPress={() => router.push('/settings/subscription')}
+          />
+          <SettingNavigationItem
+            label="연결된 계정"
+            onPress={() => router.push('/settings/linked-accounts')}
+          />
+        </SettingNavigationSection>
+
+        <Spacing size={12} />
+
+        {/* 정보 */}
         <SettingNavigationSection>
           <SettingNavigationItem
             label="약관 및 정책"

--- a/apps/mobile/app/(app)/settings/linked-accounts.tsx
+++ b/apps/mobile/app/(app)/settings/linked-accounts.tsx
@@ -122,33 +122,26 @@ function LinkedAccountsList() {
 
 LinkedAccountsList.Loading = function Loading() {
   return (
-    <>
-      <View className="px-2 pb-2">
-        <SkeletonGroup isLoading isSkeletonOnly>
-          <Skeleton className="h-4 w-64 rounded" />
-        </SkeletonGroup>
-      </View>
-      <VStack className="bg-white rounded-2xl overflow-hidden border border-gray-2">
-        <SkeletonGroup isLoading isSkeletonOnly>
-          {times(4, (index) => (
-            <Fragment key={`linked-account-skeleton-${index}`}>
-              <SkeletonRow />
-              {index < 3 && <Separator className="mx-4 bg-gray-2" />}
-            </Fragment>
-          ))}
-        </SkeletonGroup>
-      </VStack>
-    </>
+    <VStack className="bg-white rounded-2xl overflow-hidden border border-gray-2">
+      <SkeletonGroup isLoading isSkeletonOnly>
+        {times(4, (index) => (
+          <Fragment key={`linked-account-skeleton-${index}`}>
+            <SkeletonRow />
+            {index < 3 && <Separator className="mx-4 bg-gray-2" />}
+          </Fragment>
+        ))}
+      </SkeletonGroup>
+    </VStack>
   );
 };
 
 function SkeletonRow() {
   return (
-    <HStack align="center" gap={12} className="px-4 py-3.5">
-      <Skeleton className="w-9 h-9 rounded-full" />
+    <HStack align="center" gap={12} className="px-4 py-4">
+      <Skeleton className="size-10 rounded-full" />
       <VStack flex={1} gap={2}>
-        <Skeleton className="h-4 w-16 rounded" />
-        <Skeleton className="h-3 w-12 rounded" />
+        <Skeleton className="h-5 w-16 rounded" />
+        <Skeleton className="h-4 w-12 rounded" />
       </VStack>
       <Skeleton className="h-8 w-16 rounded-lg" />
     </HStack>

--- a/apps/mobile/app/(app)/settings/notifications.tsx
+++ b/apps/mobile/app/(app)/settings/notifications.tsx
@@ -60,7 +60,7 @@ function NotificationSettingsForm() {
 
 NotificationSettingsForm.Loading = function Loading() {
   return (
-    <VStack gap={12}>
+    <VStack gap={24}>
       <VStack p={16} gap={12} className="bg-white rounded-2xl">
         <SkeletonGroup isLoading isSkeletonOnly>
           <HStack justify="between" align="center" className="py-2">
@@ -85,25 +85,27 @@ NotificationSettingsForm.Loading = function Loading() {
         </SkeletonGroup>
       </VStack>
 
-      <VStack p={16} gap={12} className="bg-white rounded-2xl">
-        <SkeletonGroup isLoading isSkeletonOnly>
-          <VStack gap={2}>
-            <Skeleton className="h-5 w-28 rounded" />
-            <Skeleton className="h-4 w-52 rounded" />
-          </VStack>
+      <VStack gap={8}>
+        <VStack gap={2} className="px-2">
+          <Skeleton className="h-5 w-28 rounded" />
+          <Skeleton className="h-4 w-52 rounded" />
+        </VStack>
 
-          <HStack justify="between" align="center" className="py-2">
-            <Skeleton className="h-5 w-24 rounded" />
-            <Skeleton className="h-5 w-20 rounded" />
-          </HStack>
+        <VStack p={16} gap={12} className="bg-white rounded-2xl">
+          <SkeletonGroup isLoading isSkeletonOnly>
+            <HStack justify="between" align="center" className="py-2">
+              <Skeleton className="h-5 w-24 rounded" />
+              <Skeleton className="h-5 w-20 rounded" />
+            </HStack>
 
-          <Separator className="bg-gray-2" />
+            <Separator className="bg-gray-2" />
 
-          <HStack justify="between" align="center" className="py-2">
-            <Skeleton className="h-5 w-24 rounded" />
-            <Skeleton className="h-5 w-20 rounded" />
-          </HStack>
-        </SkeletonGroup>
+            <HStack justify="between" align="center" className="py-2">
+              <Skeleton className="h-5 w-24 rounded" />
+              <Skeleton className="h-5 w-20 rounded" />
+            </HStack>
+          </SkeletonGroup>
+        </VStack>
       </VStack>
     </VStack>
   );
@@ -132,7 +134,9 @@ function PushSettingsSection() {
       <ControlField
         isSelected={preference.nightPushEnabled}
         onSelectedChange={(enabled) => {
-          if (!preference.pushEnabled) return;
+          if (!preference.pushEnabled) {
+            return;
+          }
           updateMutation.mutate({ nightPushEnabled: enabled });
         }}
         isDisabled={updateMutation.isPending || !preference.pushEnabled}

--- a/apps/mobile/app/(app)/settings/terms.tsx
+++ b/apps/mobile/app/(app)/settings/terms.tsx
@@ -66,10 +66,12 @@ function TermsSettingsForm() {
               <Text size="b2" weight="medium">
                 서비스 이용약관
               </Text>
+
               <VStack gap={2}>
                 <Text size="b4" shade={6}>
                   동의일: {formatDate(consent.termsAgreedAt)}
                 </Text>
+
                 {consent.agreedTermsVersion && (
                   <Text size="b4" shade={6}>
                     버전: {consent.agreedTermsVersion}
@@ -89,10 +91,12 @@ function TermsSettingsForm() {
               <Text size="b2" weight="medium">
                 개인정보처리방침
               </Text>
+
               <VStack gap={2}>
                 <Text size="b4" shade={6}>
                   동의일: {formatDate(consent.privacyAgreedAt)}
                 </Text>
+
                 {consent.agreedTermsVersion && (
                   <Text size="b4" shade={6}>
                     버전: {consent.agreedTermsVersion}
@@ -127,7 +131,7 @@ function TermsSettingsForm() {
 TermsSettingsForm.Loading = function Loading() {
   return (
     <>
-      <VStack p={8} gap={8} className="bg-white rounded-2xl">
+      <VStack p={16} gap={8} className="bg-white rounded-2xl">
         <SkeletonGroup isLoading isSkeletonOnly>
           <VStack gap={4} className="py-2">
             <Skeleton className="h-5 w-28 rounded" />
@@ -151,7 +155,7 @@ TermsSettingsForm.Loading = function Loading() {
 
       <Spacing size={12} />
 
-      <VStack p={8} className="bg-white rounded-2xl">
+      <VStack p={16} className="bg-white rounded-2xl">
         <SkeletonGroup isLoading isSkeletonOnly>
           <HStack justify="between" align="center" className="py-2">
             <VStack flex={1} gap={2}>

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -37,7 +37,7 @@ const LoginScreen = () => {
         if (code) {
           // exchangeCode 성공 시 AuthProvider가 status를 'authenticated'로 변경하고
           // Stack.Protected가 자동으로 (app) 그룹으로 라우팅 처리
-          exchangeCodeMutation.mutate({ code });
+          exchangeCodeMutation.mutate({ code, provider: 'kakao' });
         }
       },
     });
@@ -48,7 +48,7 @@ const LoginScreen = () => {
     naverLoginMutation.mutate(undefined, {
       onSuccess: (code) => {
         if (code) {
-          exchangeCodeMutation.mutate({ code });
+          exchangeCodeMutation.mutate({ code, provider: 'naver' });
         }
       },
     });
@@ -59,7 +59,7 @@ const LoginScreen = () => {
     googleLoginMutation.mutate(undefined, {
       onSuccess: (code) => {
         if (code) {
-          exchangeCodeMutation.mutate({ code });
+          exchangeCodeMutation.mutate({ code, provider: 'google' });
         }
       },
     });

--- a/apps/mobile/src/core/ports/analytics.ts
+++ b/apps/mobile/src/core/ports/analytics.ts
@@ -5,4 +5,5 @@ export interface Analytics {
   trackScreenView(screenName: string, params?: AnalyticsEventParams): void;
   setUserId(userId: string | null): void;
   setUserProperties(properties: Record<string, string | number | boolean>): void;
+  resetData(): void;
 }

--- a/apps/mobile/src/features/ai/presentations/components/ReportStatusBanner.tsx
+++ b/apps/mobile/src/features/ai/presentations/components/ReportStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { HStack, Spacing, Text, VStack } from '@src/shared/ui';
+import { HStack, Text, VStack } from '@src/shared/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Card, Separator, SkeletonGroup } from 'heroui-native';
 import { useGetReportStatusQueryOptions } from '../queries/use-get-report-status-query-options';
@@ -41,7 +41,6 @@ ReportStatusBanner.Loading = function Loading() {
         <HStack className="items-stretch">
           <VStack gap={4} align="center" className="flex-1 py-2">
             <SkeletonGroup.Item className="h-4 w-24 rounded-md" />
-            <Spacing size={2} />
             <SkeletonGroup.Item className="h-7 w-12 rounded-md" />
           </VStack>
 
@@ -49,7 +48,6 @@ ReportStatusBanner.Loading = function Loading() {
 
           <VStack gap={4} align="center" className="flex-1 py-2">
             <SkeletonGroup.Item className="h-4 w-24 rounded-md" />
-            <Spacing size={2} />
             <SkeletonGroup.Item className="h-7 w-12 rounded-md" />
           </VStack>
         </HStack>

--- a/apps/mobile/src/features/auth/presentations/queries/use-delete-account-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/use-delete-account-mutation-options.ts
@@ -2,10 +2,12 @@ import { ErrorCode } from '@aido/errors';
 import type { DeleteAccountInput } from '@aido/validators';
 import { useAuth } from '@src/bootstrap/providers/auth-provider';
 import {
+  useAnalytics,
   useAuthService,
   useLogger,
   useNotificationService,
 } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -15,6 +17,7 @@ import * as Haptics from 'expo-haptics';
 
 export const useDeleteAccountMutationOptions = () => {
   const authService = useAuthService();
+  const analytics = useAnalytics();
   const notificationService = useNotificationService();
   const queryClient = useQueryClient();
   const toast = useAppToast();
@@ -40,6 +43,7 @@ export const useDeleteAccountMutationOptions = () => {
     onSuccess: () => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       toast.success('계정이 탈퇴 처리되었어요');
+      track(analytics, 'auth_account_deleted');
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/auth/presentations/queries/use-email-login-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/use-email-login-mutation-options.ts
@@ -1,6 +1,7 @@
 import { ErrorCode } from '@aido/errors';
 import { useAuth } from '@src/bootstrap/providers/auth-provider';
-import { useAuthService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useAuthService } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -10,6 +11,7 @@ import { router } from 'expo-router';
 
 export const useEmailLoginMutationOptions = () => {
   const authService = useAuthService();
+  const analytics = useAnalytics();
   const { setStatus } = useAuth();
   const toast = useAppToast();
 
@@ -23,6 +25,7 @@ export const useEmailLoginMutationOptions = () => {
       if (data.accountRestored) {
         toast.success('탈퇴한 계정이 복구되었어요');
       }
+      track(analytics, 'auth_login', { method: 'email' });
     },
     onError: (error, variables) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/auth/presentations/queries/use-exchange-code-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/use-exchange-code-mutation-options.ts
@@ -1,27 +1,33 @@
 import { useAuth } from '@src/bootstrap/providers/auth-provider';
 import {
+  useAnalytics,
   useAuthService,
   useLogger,
   useNotificationService,
 } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
 import { mutationOptions } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
+import type { OAuthProviderSlug } from '../../models/oauth.model';
 
 export const useExchangeCodeMutationOptions = () => {
   const authService = useAuthService();
+  const analytics = useAnalytics();
   const notificationService = useNotificationService();
   const logger = useLogger();
   const { setStatus } = useAuth();
   const toast = useAppToast();
 
   return mutationOptions({
-    mutationFn: async (request: Parameters<typeof authService.exchangeCode>[0]) => {
+    mutationFn: async (
+      request: Parameters<typeof authService.exchangeCode>[0] & { provider: OAuthProviderSlug },
+    ) => {
       const result = await authService.exchangeCode(request);
       return unwrap(result);
     },
-    onSuccess: async (data) => {
+    onSuccess: async (data, variables) => {
       setStatus('authenticated');
       if (data.accountRestored) {
         toast.success('탈퇴한 계정이 복구되었어요');
@@ -36,6 +42,8 @@ export const useExchangeCodeMutationOptions = () => {
         // Silently fail - push notification is optional
         logger.warn('[PushNotification] Setup error', { error });
       }
+
+      track(analytics, 'auth_login', { method: variables.provider });
     },
     onError: () => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/auth/presentations/queries/use-link-account-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/use-link-account-mutation-options.ts
@@ -1,4 +1,5 @@
-import { useAuthService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useAuthService } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -11,6 +12,7 @@ import { AUTH_QUERY_KEYS } from '../constants/auth-query-keys.constant';
 
 export const useLinkAccountMutationOptions = () => {
   const authService = useAuthService();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const toast = useAppToast();
 
@@ -24,6 +26,7 @@ export const useLinkAccountMutationOptions = () => {
       toast.success(
         `${OAUTH_PROVIDER_LABELS[provider.toUpperCase() as OAuthProvider]} 계정이 연결되었습니다`,
       );
+      track(analytics, 'auth_social_linked', { provider });
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/auth/presentations/queries/use-logout-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/use-logout-mutation-options.ts
@@ -1,16 +1,19 @@
 import { useAuth } from '@src/bootstrap/providers/auth-provider';
 import {
+  useAnalytics,
   useAuthService,
   useLogger,
   useNotificationService,
   useRevenueCatSdkManager,
 } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { resetAuthClient } from '@src/shared/infra/http/auth-client';
 import { mutationOptions, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 
 export const useLogoutMutationOptions = () => {
   const authService = useAuthService();
+  const analytics = useAnalytics();
   const notificationService = useNotificationService();
   const sdkManager = useRevenueCatSdkManager();
   const queryClient = useQueryClient();
@@ -48,6 +51,8 @@ export const useLogoutMutationOptions = () => {
     },
     // API 성공/실패 관계없이 항상 로그아웃 처리
     onSettled: () => {
+      track(analytics, 'auth_logout');
+      analytics.setUserId(null);
       setStatus('unauthenticated');
       queryClient.clear();
       resetAuthClient();

--- a/apps/mobile/src/features/auth/presentations/queries/use-register-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/use-register-mutation-options.ts
@@ -1,6 +1,7 @@
 import { ErrorCode } from '@aido/errors';
 import type { RegisterInput } from '@aido/validators';
-import { useAuthService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useAuthService } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -10,12 +11,16 @@ import { router } from 'expo-router';
 
 export const useRegisterMutationOptions = () => {
   const authService = useAuthService();
+  const analytics = useAnalytics();
   const toast = useAppToast();
 
   return mutationOptions({
     mutationFn: async (input: RegisterInput) => {
       const result = await authService.register(input);
       return unwrap(result);
+    },
+    onSuccess: () => {
+      track(analytics, 'auth_signup', { method: 'email' });
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/auth/presentations/queries/use-unlink-account-mutation-options.ts
+++ b/apps/mobile/src/features/auth/presentations/queries/use-unlink-account-mutation-options.ts
@@ -1,15 +1,17 @@
-import { useAuthService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useAuthService } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
 import { mutationOptions, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
-import type { OAuthProvider } from '../../models/oauth.model';
+import type { OAuthProvider, OAuthProviderSlug } from '../../models/oauth.model';
 import { OAUTH_PROVIDER_LABELS } from '../constants/auth-provider-labels.constant';
 import { AUTH_QUERY_KEYS } from '../constants/auth-query-keys.constant';
 
 export const useUnlinkAccountMutationOptions = () => {
   const authService = useAuthService();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const toast = useAppToast();
 
@@ -21,6 +23,9 @@ export const useUnlinkAccountMutationOptions = () => {
     onSuccess: (_data, provider) => {
       queryClient.invalidateQueries({ queryKey: AUTH_QUERY_KEYS.linkedAccounts() });
       toast.success(`${OAUTH_PROVIDER_LABELS[provider]} 계정 연결이 해제되었습니다`);
+      track(analytics, 'auth_social_unlinked', {
+        provider: provider.toLowerCase() as OAuthProviderSlug,
+      });
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/notification/presentations/components/notification-list.tsx
+++ b/apps/mobile/src/features/notification/presentations/components/notification-list.tsx
@@ -1,6 +1,6 @@
 import { FlashList } from '@shopify/flash-list';
 import { useRefresh } from '@src/shared/hooks/useRefresh';
-import { Box, Flex, NotiIcon, Result, Text, VStack } from '@src/shared/ui';
+import { Box, Flex, HStack, NotiIcon, Result, Text, VStack } from '@src/shared/ui';
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import times from 'es-toolkit/compat/times';
 import { Separator, Skeleton, Spinner } from 'heroui-native';
@@ -90,17 +90,19 @@ export function NotificationList({ category, unreadOnly, limit }: NotificationLi
 NotificationList.Loading = function Loading() {
   return (
     <ScrollView className="flex-1">
-      <Box px={16} py={12}>
-        <Skeleton className="w-32 h-4" />
+      <Box px={16} py={8}>
+        <Skeleton className="w-32 h-5" />
       </Box>
       <VStack>
         {times(5, (i) => (
-          <Box key={i} px={16} py={14}>
-            <VStack gap={6}>
-              <Skeleton className="w-10 h-3" />
-              <Skeleton className="w-3/4 h-4" />
-              <Skeleton className="w-full h-3" />
-              <Skeleton className="w-16 h-3" />
+          <Box key={i} px={16} py={16}>
+            <VStack gap={4}>
+              <HStack justify="between">
+                <Skeleton className="w-10 h-4" />
+                <Skeleton className="w-12 h-4" />
+              </HStack>
+              <Skeleton className="w-3/4 h-5" />
+              <Skeleton className="w-full h-4" />
             </VStack>
           </Box>
         ))}

--- a/apps/mobile/src/features/todo/presentations/components/PokeBanner.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/PokeBanner.tsx
@@ -73,7 +73,7 @@ PokeBanner.Loading = function Loading() {
   return (
     <HStack mx={16} px={12} className="rounded-xl bg-gray-1" align="center" gap={12}>
       <Skeleton className="size-[72px] rounded-full" />
-      <VStack flex={1} gap={4}>
+      <VStack flex={1} gap={2}>
         <Skeleton className="h-5 w-3/4 rounded" />
         <Skeleton className="h-4 w-full rounded" />
       </VStack>

--- a/apps/mobile/src/features/todo/presentations/queries/use-create-todo-mutation-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-create-todo-mutation-options.ts
@@ -1,7 +1,8 @@
 import { ErrorCode } from '@aido/errors';
 import type { CreateTodoInput } from '@aido/validators';
-import { useTodoService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useTodoService } from '@src/bootstrap/providers/di-provider';
 import { TODO_CATEGORY_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-category-query-keys.constant';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -13,6 +14,7 @@ import { TODO_QUERY_KEYS } from '../constants/todo-query-keys.constant';
 
 export const useCreateTodoMutationOptions = () => {
   const todoService = useTodoService();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const toast = useAppToast();
 
@@ -21,10 +23,15 @@ export const useCreateTodoMutationOptions = () => {
       const result = await todoService.createTodo(params);
       return unwrap(result);
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.all });
       queryClient.invalidateQueries({ queryKey: TODO_CATEGORY_QUERY_KEYS.all });
       toast.success('할 일을 추가했어요!');
+      track(analytics, 'todo_created', {
+        category_id: variables.categoryId,
+        has_due_date: !!variables.startDate,
+        source: 'manual',
+      });
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/todo/presentations/queries/use-delete-todo-mutation-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-delete-todo-mutation-options.ts
@@ -1,5 +1,6 @@
-import { useTodoService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useTodoService } from '@src/bootstrap/providers/di-provider';
 import { TODO_CATEGORY_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-category-query-keys.constant';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -16,6 +17,7 @@ interface DeleteTodoMutationParams {
 
 export const useDeleteTodoMutationOptions = () => {
   const todoService = useTodoService();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const toast = useAppToast();
 
@@ -24,12 +26,13 @@ export const useDeleteTodoMutationOptions = () => {
       const result = await todoService.deleteTodo(todoId);
       return unwrap(result);
     },
-    onSuccess: (_, { startDate }) => {
+    onSuccess: (_, { startDate, todoId }) => {
       queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.listByDate(startDate) });
       queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.completions() });
       queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.ranges() });
       queryClient.invalidateQueries({ queryKey: TODO_CATEGORY_QUERY_KEYS.all });
       toast.success('할 일을 삭제했어요');
+      track(analytics, 'todo_deleted', { todo_id: todoId });
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/todo/presentations/queries/use-parse-todo-mutation-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-parse-todo-mutation-options.ts
@@ -1,5 +1,6 @@
 import { ErrorCode } from '@aido/errors';
-import { useTodoService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useTodoService } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -9,6 +10,7 @@ import * as Haptics from 'expo-haptics';
 
 export const useParseTodoMutationOptions = () => {
   const todoService = useTodoService();
+  const analytics = useAnalytics();
   const premiumDialog = usePremiumDialog();
   const toast = useAppToast();
 
@@ -17,7 +19,11 @@ export const useParseTodoMutationOptions = () => {
       const result = await todoService.parseTodo(params.text, params.categoryId);
       return unwrap(result);
     },
+    onSuccess: () => {
+      track(analytics, 'ai_parse_used', { success: true });
+    },
     onError: (error) => {
+      track(analytics, 'ai_parse_used', { success: false });
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
 
       if (isApiError(error) && error.hasCode(ErrorCode.AI_1303)) {

--- a/apps/mobile/src/features/todo/presentations/queries/use-send-todo-nudge-mutation-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-send-todo-nudge-mutation-options.ts
@@ -1,4 +1,5 @@
-import { useTodoNudgeService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useTodoNudgeService } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -10,6 +11,7 @@ import { TODO_QUERY_KEYS } from '../constants/todo-query-keys.constant';
 
 export const useSendTodoNudgeMutationOptions = () => {
   const todoNudgeService = useTodoNudgeService();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const toast = useAppToast();
 
@@ -24,6 +26,7 @@ export const useSendTodoNudgeMutationOptions = () => {
         queryKey: TODO_QUERY_KEYS.nudgeCooldown(variables.receiverId),
       });
       toast.success('콕 찔렀어요!');
+      track(analytics, 'nudge_sent');
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/todo/presentations/queries/use-toggle-todo-mutation-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-toggle-todo-mutation-options.ts
@@ -1,5 +1,6 @@
 import type { ToggleTodoCompleteInput } from '@aido/validators';
-import { useTodoService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useTodoService } from '@src/bootstrap/providers/di-provider';
+import { track } from '@src/shared/analytics';
 import { unwrap } from '@src/shared/errors/result';
 import { mutationOptions, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
@@ -13,6 +14,7 @@ interface ToggleTodoMutationParams {
 
 export const useToggleTodoMutationOptions = () => {
   const todoService = useTodoService();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
 
   return mutationOptions({
@@ -20,8 +22,12 @@ export const useToggleTodoMutationOptions = () => {
       const result = await todoService.toggleTodoComplete(todoId, body);
       return unwrap(result);
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.all });
+      track(analytics, 'todo_completed', {
+        todo_id: variables.todoId,
+        is_completed: variables.body.completed,
+      });
     },
     onError: () => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/todo/presentations/queries/use-update-todo-mutation-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-update-todo-mutation-options.ts
@@ -1,6 +1,7 @@
 import type { UpdateTodoInput } from '@aido/validators';
-import { useTodoService } from '@src/bootstrap/providers/di-provider';
+import { useAnalytics, useTodoService } from '@src/bootstrap/providers/di-provider';
 import { TODO_CATEGORY_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-category-query-keys.constant';
+import { track } from '@src/shared/analytics';
 import { isApiError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
@@ -17,6 +18,7 @@ interface UpdateTodoMutationParams {
 
 export const useUpdateTodoMutationOptions = () => {
   const todoService = useTodoService();
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const toast = useAppToast();
 
@@ -25,10 +27,11 @@ export const useUpdateTodoMutationOptions = () => {
       const result = await todoService.updateTodo(todoId, input);
       return unwrap(result);
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.all });
       queryClient.invalidateQueries({ queryKey: TODO_CATEGORY_QUERY_KEYS.all });
       toast.success('할 일을 수정했어요');
+      track(analytics, 'todo_edited', { todo_id: variables.todoId, field: 'general' });
     },
     onError: (error) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);

--- a/apps/mobile/src/features/user/presentations/components/ProfileCard.tsx
+++ b/apps/mobile/src/features/user/presentations/components/ProfileCard.tsx
@@ -4,7 +4,7 @@ import { useClipboard } from '@src/shared/hooks/useClipboard';
 import { ArrowRightIcon, CopyIcon, H4, HStack, Text, VStack } from '@src/shared/ui';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
-import { Avatar, PressableFeedback, SkeletonGroup } from 'heroui-native';
+import { Avatar, Chip, PressableFeedback, SkeletonGroup } from 'heroui-native';
 import { Pressable } from 'react-native';
 import { useGetMeQueryOptions } from '../queries/use-get-me-query-options';
 
@@ -33,7 +33,12 @@ export function ProfileCard() {
         </Avatar>
 
         <VStack className="flex-1">
-          <H4>{user.name}</H4>
+          <HStack align="center" gap={6}>
+            <H4 numberOfLines={1} className="shrink">
+              {user.name}
+            </H4>
+            <UserTierChip tier={user.tier} />
+          </HStack>
 
           <HStack align="center" gap={2}>
             <Text size="b4" shade={6}>
@@ -59,14 +64,30 @@ export function ProfileCard() {
   );
 }
 
+const USER_TIER_CONFIG = {
+  ADMIN: { label: '어드민', color: 'warning', className: 'shrink-0' },
+  PREMIUM: { label: '프리미엄', color: 'accent', className: 'shrink-0' },
+  BASIC: { label: '베이직', color: 'default', className: 'shrink-0 bg-gray-3' },
+} as const;
+
+function UserTierChip({ tier }: { tier: 'ADMIN' | 'PREMIUM' | 'BASIC' }) {
+  const { label, color, className } = USER_TIER_CONFIG[tier];
+
+  return (
+    <Chip size="sm" variant="soft" color={color} className={className}>
+      <Chip.Label>{label}</Chip.Label>
+    </Chip>
+  );
+}
+
 ProfileCard.Loading = function Loading() {
   return (
     <SkeletonGroup isLoading isSkeletonOnly>
       <HStack gap={12} align="center" className="rounded-2xl px-4 py-3">
         <SkeletonGroup.Item className="size-12 rounded-full" />
         <VStack className="flex-1">
-          <SkeletonGroup.Item className="h-5 w-24 rounded-md" />
-          <SkeletonGroup.Item className="h-4 w-20 rounded-md" />
+          <SkeletonGroup.Item className="h-6 w-24 rounded-md" />
+          <SkeletonGroup.Item className="h-5 w-20 rounded-md" />
         </VStack>
       </HStack>
     </SkeletonGroup>

--- a/apps/mobile/src/features/user/presentations/components/ProfileInfoCard.tsx
+++ b/apps/mobile/src/features/user/presentations/components/ProfileInfoCard.tsx
@@ -71,14 +71,18 @@ export function ProfileInfoCard({
 
 ProfileInfoCard.Loading = function Loading() {
   return (
-    <SkeletonGroup isLoading isSkeletonOnly>
-      <VStack align="center" py={32}>
-        <SkeletonGroup.Item className="size-24 rounded-full" />
-      </VStack>
+    <VStack gap={24}>
+      <SkeletonGroup isLoading isSkeletonOnly>
+        <VStack align="center" py={32}>
+          <SkeletonGroup.Item className="size-24 rounded-full" />
+        </VStack>
+      </SkeletonGroup>
 
       <VStack p={8} className="bg-white rounded-2xl">
-        <SkeletonGroup.Item className="h-14 w-full rounded-lg" />
+        <SkeletonGroup isLoading isSkeletonOnly>
+          <SkeletonGroup.Item className="h-14 w-full rounded-lg" />
+        </SkeletonGroup>
       </VStack>
-    </SkeletonGroup>
+    </VStack>
   );
 };

--- a/apps/mobile/src/features/user/presentations/queries/use-get-me-query-options.ts
+++ b/apps/mobile/src/features/user/presentations/queries/use-get-me-query-options.ts
@@ -1,7 +1,20 @@
 import { useUserService } from '@src/bootstrap/providers/di-provider';
+import type { User } from '@src/features/user/models/user.model';
 import { unwrap } from '@src/shared/errors/result';
 import { queryOptions } from '@tanstack/react-query';
 import { USER_QUERY_KEYS } from '../constants/user-query-keys.constant';
+
+type UserTier = 'ADMIN' | 'PREMIUM' | 'BASIC';
+
+const getUserTier = (user: User): UserTier => {
+  if (user.role === 'ADMIN') {
+    return 'ADMIN';
+  }
+  if (user.subscriptionStatus === 'ACTIVE') {
+    return 'PREMIUM';
+  }
+  return 'BASIC';
+};
 
 export const useGetMeQueryOptions = () => {
   const userService = useUserService();
@@ -15,6 +28,7 @@ export const useGetMeQueryOptions = () => {
     select: (user) => ({
       ...user,
       name: user.name ?? '열정적인 사용자',
+      tier: getUserTier(user),
     }),
   });
 };

--- a/apps/mobile/src/shared/__tests__/create-mock-analytics.ts
+++ b/apps/mobile/src/shared/__tests__/create-mock-analytics.ts
@@ -1,0 +1,9 @@
+import type { Analytics } from '@src/core/ports/analytics';
+
+export const createMockAnalytics = (): jest.Mocked<Analytics> => ({
+  trackEvent: jest.fn(),
+  trackScreenView: jest.fn(),
+  setUserId: jest.fn(),
+  setUserProperties: jest.fn(),
+  resetData: jest.fn(),
+});

--- a/apps/mobile/src/shared/__tests__/index.ts
+++ b/apps/mobile/src/shared/__tests__/index.ts
@@ -1,2 +1,3 @@
+export { createMockAnalytics } from './create-mock-analytics';
 export { createMockHttpClient } from './create-mock-http-client';
 export { createMockStorage } from './create-mock-storage';

--- a/apps/mobile/src/shared/analytics/__tests__/track.test.ts
+++ b/apps/mobile/src/shared/analytics/__tests__/track.test.ts
@@ -1,0 +1,42 @@
+import { createMockAnalytics } from '@src/shared/__tests__';
+import { track } from '../track';
+
+describe('track', () => {
+  let analytics: ReturnType<typeof createMockAnalytics>;
+
+  beforeEach(() => {
+    analytics = createMockAnalytics();
+  });
+
+  test('이벤트명과 파라미터를 analytics.trackEvent에 전달한다', () => {
+    // Given
+    const params = { method: 'google' as const };
+
+    // When
+    track(analytics, 'auth_login', params);
+
+    // Then
+    expect(analytics.trackEvent).toHaveBeenCalledWith('auth_login', params);
+    expect(analytics.trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('파라미터가 없는 이벤트는 params 없이 호출한다', () => {
+    // Given & When
+    track(analytics, 'auth_logout');
+
+    // Then
+    expect(analytics.trackEvent).toHaveBeenCalledWith('auth_logout', undefined);
+    expect(analytics.trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('복합 파라미터를 가진 이벤트를 올바르게 전달한다', () => {
+    // Given
+    const params = { category_id: 1, has_due_date: true, source: 'manual' as const };
+
+    // When
+    track(analytics, 'todo_created', params);
+
+    // Then
+    expect(analytics.trackEvent).toHaveBeenCalledWith('todo_created', params);
+  });
+});

--- a/apps/mobile/src/shared/analytics/events/ai.events.ts
+++ b/apps/mobile/src/shared/analytics/events/ai.events.ts
@@ -1,0 +1,3 @@
+export interface AiEventMap {
+  ai_parse_used: { success: boolean };
+}

--- a/apps/mobile/src/shared/analytics/events/auth.events.ts
+++ b/apps/mobile/src/shared/analytics/events/auth.events.ts
@@ -1,0 +1,11 @@
+export type AuthMethod = 'email' | 'google' | 'apple' | 'kakao' | 'naver';
+export type SocialProvider = 'google' | 'apple' | 'kakao' | 'naver';
+
+export interface AuthEventMap {
+  auth_login: { method: AuthMethod };
+  auth_signup: { method: AuthMethod };
+  auth_logout: undefined;
+  auth_social_linked: { provider: SocialProvider };
+  auth_social_unlinked: { provider: SocialProvider };
+  auth_account_deleted: undefined;
+}

--- a/apps/mobile/src/shared/analytics/events/friend.events.ts
+++ b/apps/mobile/src/shared/analytics/events/friend.events.ts
@@ -1,0 +1,5 @@
+export interface FriendEventMap {
+  friend_request_sent: undefined;
+  friend_removed: undefined;
+  nudge_sent: undefined;
+}

--- a/apps/mobile/src/shared/analytics/events/index.ts
+++ b/apps/mobile/src/shared/analytics/events/index.ts
@@ -1,0 +1,22 @@
+import type { AiEventMap } from './ai.events';
+import type { AuthEventMap } from './auth.events';
+import type { FriendEventMap } from './friend.events';
+import type { SubscriptionEventMap } from './subscription.events';
+import type { TodoEventMap } from './todo.events';
+import type { UserEventMap } from './user.events';
+
+export type {
+  AiEventMap,
+  AuthEventMap,
+  FriendEventMap,
+  SubscriptionEventMap,
+  TodoEventMap,
+  UserEventMap,
+};
+
+export type AppEventMap = AuthEventMap &
+  TodoEventMap &
+  FriendEventMap &
+  SubscriptionEventMap &
+  AiEventMap &
+  UserEventMap;

--- a/apps/mobile/src/shared/analytics/events/subscription.events.ts
+++ b/apps/mobile/src/shared/analytics/events/subscription.events.ts
@@ -1,0 +1,5 @@
+export interface SubscriptionEventMap {
+  subscription_started: { product_id: string };
+  subscription_restored: undefined;
+  premium_gate_shown: { feature: string };
+}

--- a/apps/mobile/src/shared/analytics/events/todo.events.ts
+++ b/apps/mobile/src/shared/analytics/events/todo.events.ts
@@ -1,0 +1,8 @@
+export interface TodoEventMap {
+  todo_created: { category_id?: number; has_due_date: boolean; source: 'manual' | 'ai' | 'voice' };
+  todo_completed: { todo_id: number; is_completed: boolean };
+  todo_deleted: { todo_id: number };
+  todo_edited: { todo_id: number; field: string };
+  category_created: undefined;
+  category_deleted: undefined;
+}

--- a/apps/mobile/src/shared/analytics/events/user.events.ts
+++ b/apps/mobile/src/shared/analytics/events/user.events.ts
@@ -1,0 +1,4 @@
+export interface UserEventMap {
+  profile_edited: { field: string };
+  settings_changed: { setting: string; value: string };
+}

--- a/apps/mobile/src/shared/analytics/index.ts
+++ b/apps/mobile/src/shared/analytics/index.ts
@@ -1,0 +1,3 @@
+export type { AppEventMap } from './events';
+export { track } from './track';
+export { useTrack } from './use-track';

--- a/apps/mobile/src/shared/analytics/track.ts
+++ b/apps/mobile/src/shared/analytics/track.ts
@@ -1,0 +1,10 @@
+import type { Analytics } from '@src/core/ports/analytics';
+import type { AppEventMap } from './events';
+
+export const track = <E extends keyof AppEventMap>(
+  analytics: Analytics,
+  eventName: E,
+  ...args: AppEventMap[E] extends undefined ? [] : [params: AppEventMap[E]]
+): void => {
+  analytics.trackEvent(eventName as string, args[0] as Record<string, unknown> | undefined);
+};

--- a/apps/mobile/src/shared/analytics/use-track.ts
+++ b/apps/mobile/src/shared/analytics/use-track.ts
@@ -1,0 +1,19 @@
+import { useAnalytics } from '@src/bootstrap/providers/di-provider';
+import { useCallback } from 'react';
+import type { AppEventMap } from './events';
+
+export const useTrack = () => {
+  const analytics = useAnalytics();
+
+  const trackEvent = useCallback(
+    <E extends keyof AppEventMap>(
+      eventName: E,
+      ...args: AppEventMap[E] extends undefined ? [] : [params: AppEventMap[E]]
+    ) => {
+      analytics.trackEvent(eventName as string, args[0] as Record<string, unknown> | undefined);
+    },
+    [analytics],
+  );
+
+  return { trackEvent } as const;
+};

--- a/apps/mobile/src/shared/infra/analytics/console-analytics.ts
+++ b/apps/mobile/src/shared/infra/analytics/console-analytics.ts
@@ -17,4 +17,7 @@ export const createConsoleAnalytics = (): Analytics => ({
   setUserProperties(properties: Record<string, string | number | boolean>): void {
     console.info('[Analytics] setUserProperties:', properties);
   },
+  resetData(): void {
+    console.info('[Analytics] resetData');
+  },
 });

--- a/apps/mobile/src/shared/infra/analytics/firebase-analytics.ts
+++ b/apps/mobile/src/shared/infra/analytics/firebase-analytics.ts
@@ -33,5 +33,10 @@ export const createFirebaseAnalytics = (): Analytics => {
         });
       }
     },
+    async resetData(): Promise<void> {
+      await firebaseAnalytics.resetAnalyticsData().catch((e) => {
+        if (__DEV__) console.warn('[FirebaseAnalytics] resetData failed:', e);
+      });
+    },
   };
 };


### PR DESCRIPTION
## 📋 개요

Firebase Analytics 인프라(Ports & Adapters)는 구축되어 있으나 `trackEvent()`가 어디서도 호출되지 않던 상태를 해결. DI 기반 타입 안전한 이벤트 트래킹 레이어를 구축하고, 13개 mutation에 트래킹 호출을 통합.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

### 트래킹 레이어 (핵심)
- **Analytics Port 확장**: `resetData()` 추가 (Firebase GDPR 공식 권장)
- **이벤트 카탈로그**: 21개 이벤트, 6개 도메인 (auth/todo/friend/subscription/ai/user)
- **`track()` 순수 함수**: Analytics를 DI로 받는 타입 안전 함수 — 이벤트명 오타, 잘못된 파라미터 → 컴파일 에러
- **`useTrack()` 훅**: React 컴포넌트용 편의 훅 (DI Context 자동 바인딩)
- **Mutation 통합**: 13개 mutation의 `onSuccess`/`onSettled`에 트래킹 호출 추가

### 트래킹 대상 Mutation (13개)
| 도메인 | 이벤트 | 위치 |
|--------|--------|------|
| Auth | `auth_login`, `auth_signup`, `auth_logout` | email-login, exchange-code, register, logout |
| Auth | `auth_account_deleted`, `auth_social_linked/unlinked` | delete-account, link/unlink-account |
| Todo | `todo_created/completed/deleted/edited` | create/toggle/delete/update-todo |
| Friend | `nudge_sent` | send-todo-nudge |
| AI | `ai_parse_used` (성공/실패 구분) | parse-todo |

### UI 개선 (부수적)
- 유저 티어 칩 (ADMIN/PREMIUM/BASIC) 추가
- iOS LiquidGlass 탭에 다크모드 ThemeProvider 적용
- 설정 화면 일관성 개선

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck  # 타입 안전성 검증
pnpm lint       # Biome 린트
pnpm test       # 단위 테스트
```

### 테스트 결과

- [x] 타입 체크 통과 (8/8 packages)
- [x] 린트 통과 (446 files, 0 issues)
- [x] 단위 테스트 통과 (track 함수 3건)
- [x] 빌드 통과 (iOS + Android bundle)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] Firebase 예약어 회피 확인 (`notification_*`, `app_*`, `ad_*` 등 미사용)
- [x] 이벤트명 `object_action` snake_case 네이밍 준수

## 🔗 관련 이슈

Closes #308

## 📸 스크린샷 (UI 변경 시)

<img width="305" height="610" alt="스크린샷 2026-03-07 오전 3 29 53" src="https://github.com/user-attachments/assets/c168a4bf-e33e-46e0-ab4c-e93264f21644" />
<img width="354" height="622" alt="스크린샷 2026-03-07 오전 3 30 27" src="https://github.com/user-attachments/assets/610e5e5f-acd9-4993-96c9-93874cc04022" />

어드민인지, 일반 유저인지, 프리미엄 유저인지 구분하는 뱃지와, 스켈레톤 관련된 로직도 추가했습니다!