### PR TITLE
fix(mobile): 비 Liquid Glass iOS 탭 전환 시 빈 화면 수정

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/_layout.tsx
@@ -90,7 +90,6 @@ function AndroidBottomTabs() {
           borderTopColor: tabBarBorder.borderColor as string,
         },
         headerShown: false,
-        animation: 'shift',
       }}
     >
       <Tabs.Screen


### PR DESCRIPTION
## 📋 개요

비 Liquid Glass iOS 기기(iPhone SE 등)에서 탭 반복 전환 시 간헐적으로 빈 화면이 발생하는 버그 수정

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `Tabs`의 `animation: 'shift'` 옵션 제거 (알려진 upstream 버그)

`shift` 애니메이션: 탭 전환 시 활성 탭의 아이콘이 위로 올라가면서 라벨이 나타나고, 비활성 탭은 라벨이 숨겨지며 아이콘만 표시되는 Android Material Design 스타일 전환 효과


## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #318

## 💬 추가 정보

### 원인
`animation: 'shift'` + `detachInactiveScreens: true`(기본값)일 때 빠른 탭 전환 시 `react-native-screens`가 화면 re-attach에 실패하는 알려진 버그

- [expo/expo#39514](https://github.com/expo/expo/issues/39514)
- [react-navigation#12755](https://github.com/react-navigation/react-navigation/issues/12755)
- [react-native-screens#3550](https://github.com/software-mansion/react-native-screens/issues/3550)

upstream fix가 머지되기 전까지는 `animation: 'shift'` 제거가 유일한 워크어라운드입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)