### PR TITLE
feat(api): AI 투두 파싱 프롬프트 개선 — 한국어 날짜/시간/기간 표현 전면 커버 (#350)

### DIFF
--- a/apps/api/src/modules/ai/prompts/parse-todo.prompt.spec.ts
+++ b/apps/api/src/modules/ai/prompts/parse-todo.prompt.spec.ts
@@ -72,82 +72,169 @@ describe("buildParseTodoPrompt", () => {
 
 	describe("프롬프트 구조", () => {
 		it("사용자 입력 텍스트가 프롬프트에 포함된다", () => {
-			// When
 			const prompt = buildParseTodoPrompt("내일 회의", "Asia/Seoul");
-
-			// Then
 			expect(prompt).toContain('Parse: "내일 회의"');
 		});
 
 		it("Korean Todo Parser 헤더가 포함된다", () => {
-			// When
 			const prompt = buildParseTodoPrompt("테스트", "Asia/Seoul");
-
-			// Then
 			expect(prompt).toContain("Korean Todo Parser");
 		});
 
-		it("시간 해석 규칙이 포함된다", () => {
-			// When
-			const prompt = buildParseTodoPrompt("테스트", "UTC");
-
-			// Then
-			expect(prompt).toContain("오전/아침→AM");
-			expect(prompt).toContain("오후/저녁/밤→PM");
-		});
-
-		it("날짜 해석 규칙이 포함된다", () => {
-			// When
-			const prompt = buildParseTodoPrompt("테스트", "UTC");
-
-			// Then
-			expect(prompt).toContain("내일→+1d");
-			expect(prompt).toContain("모레→+2d");
+		it("recurrence endDate에 4주 후 날짜가 포함된다", () => {
+			const now = new Date("2026-03-01T00:00:00.000Z");
+			const prompt = buildParseTodoPrompt("매주 운동", "UTC", now);
+			expect(prompt).toContain("2026-03-29");
 		});
 
 		it("JSON 출력 포맷이 포함된다", () => {
-			// When
 			const prompt = buildParseTodoPrompt("테스트", "UTC");
-
-			// Then
 			expect(prompt).toContain('"title":"str"');
 			expect(prompt).toContain('"startDate":"YYYY-MM-DD"');
 			expect(prompt).toContain('"isAllDay":bool');
 			expect(prompt).toContain('"isRecurring":bool');
 			expect(prompt).toContain('"recurrence"');
 		});
+	});
 
-		it("반복 해석 규칙이 포함된다", () => {
-			// When
+	describe("Default 규칙", () => {
+		it("날짜/시간 기본값 규칙이 포함된다", () => {
 			const prompt = buildParseTodoPrompt("테스트", "UTC");
-
-			// Then
-			expect(prompt).toContain("매주→isRecurring:true+요일");
-			expect(prompt).toContain("매일→MON~SUN");
-			expect(prompt).toContain("평일→MON~FRI");
+			expect(prompt).toContain("날짜없음→today");
+			expect(prompt).toContain("시간없음→isAllDay:true");
 		});
 
-		it("recurrence endDate에 4주 후 날짜가 포함된다", () => {
-			// Given
-			const now = new Date("2026-03-01T00:00:00.000Z");
+		it("긴급 표현 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("당장/지금/바로→today");
+		});
+	});
 
-			// When
-			const prompt = buildParseTodoPrompt("매주 운동", "UTC", now);
+	describe("Time 규칙", () => {
+		it("AM/PM 시간대 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("새벽/오전/아침→AM");
+			expect(prompt).toContain("낮/오후/저녁/밤→PM");
+		});
 
-			// Then - 4주 후 = 2026-03-29
-			expect(prompt).toContain("2026-03-29");
+		it("특수 시간 표현이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("점심/정오→12:00");
+			expect(prompt).toContain("자정→00:00");
+			expect(prompt).toContain("N시반→N:30");
+		});
+	});
+
+	describe("PastTime 규칙", () => {
+		it("지난 시간 처리 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("날짜없이시간만+이미지남→내일");
+			expect(prompt).toContain('날짜명시("오늘")→유지');
+		});
+	});
+
+	describe("Date 규칙", () => {
+		it("기본 날짜 표현이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("오늘→today");
+			expect(prompt).toContain("내일→+1d");
+			expect(prompt).toContain("모레/이틀후→+2d");
+			expect(prompt).toContain("글피/사흘후→+3d");
+			expect(prompt).toContain("나흘후→+4d");
+		});
+
+		it("상대 날짜 표현이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("N일후→+Nd");
+			expect(prompt).toContain("N주후→+Nw");
+			expect(prompt).toContain("N달후→+Nmo");
+			expect(prompt).toContain("다음달→+1mo");
+			expect(prompt).toContain("내년→next year");
+		});
+	});
+
+	describe("Week 규칙", () => {
+		it("요일 해석 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("요일만→이번주(미래면)/다음주(지났으면)");
+			expect(prompt).toContain("이번주X요일→this week");
+			expect(prompt).toContain("다음주X요일→next week");
+		});
+
+		it("주 단위 단독 사용 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("이번주→this week");
+			expect(prompt).toContain("다음주→+7d");
+			expect(prompt).toContain("다다음주→+14d");
+		});
+	});
+
+	describe("DateExpr 규칙", () => {
+		it("날짜 표현식 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("M월D일→해당날짜(지났으면내년)");
+			expect(prompt).toContain("이번달N일→해당일(지났으면다음달)");
+			expect(prompt).toContain("다음달N일→next month");
+		});
+
+		it("월초/월말/연초/연말 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("월초→1일(지났으면다음달)");
+			expect(prompt).toContain("월말→말일");
+			expect(prompt).toContain("연초→1/1");
+			expect(prompt).toContain("연말→12/31");
+		});
+	});
+
+	describe("Range 규칙", () => {
+		it("범위 표현이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("~까지→endDate(startDate=today)");
+			expect(prompt).toContain("~부터~까지→startDate+endDate");
+			expect(prompt).toContain("N일/주동안→endDate=start+N");
+		});
+	});
+
+	describe("NonRepeat 규칙", () => {
+		it("주말 비반복 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("이번/다음주말→토요일(isRecurring:false)");
+		});
+	});
+
+	describe("Repeat 규칙", () => {
+		it("반복 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("매주→isRecurring:true+요일");
+			expect(prompt).toContain("매일→MON~SUN");
+			expect(prompt).toContain("매주주말→SAT+SUN");
+			expect(prompt).toContain("매주평일→MON~FRI");
+		});
+
+		it("시스템 미지원 반복은 isRecurring:false로 처리된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("격주/격일/매달→isRecurring:false");
+		});
+	});
+
+	describe("Compound 규칙", () => {
+		it("반복+기간 복합 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("반복+기간→recurrence.endDate=시작+기간");
+		});
+	});
+
+	describe("Title 규칙", () => {
+		it("제목 추출 규칙이 포함된다", () => {
+			const prompt = buildParseTodoPrompt("테스트", "UTC");
+			expect(prompt).toContain("날짜/시간표현 제외, 핵심내용만");
 		});
 	});
 
 	describe("기본값", () => {
 		it("timezone 생략 시 UTC를 사용한다", () => {
-			// Given
 			const utcDate = new Date("2026-02-25T20:00:00.000Z");
-
-			// When
 			const prompt = buildParseTodoPrompt("테스트", undefined, utcDate);
-
-			// Then - UTC 시간 그대로
 			expect(prompt).toContain("2026-02-25 20:00");
 		});
 	});

--- a/apps/api/src/modules/ai/prompts/parse-todo.prompt.ts
+++ b/apps/api/src/modules/ai/prompts/parse-todo.prompt.ts
@@ -4,8 +4,8 @@ import { sanitizeForPrompt } from "./sanitize";
 /**
  * 최적화된 투두 파싱 프롬프트
  *
- * 토큰 최적화: ~200 토큰 (기존 ~800 토큰에서 75% 절감)
- * - 불필요한 예시 제거
+ * 토큰 최적화: ~320-350 토큰
+ * - 한국어 자연어의 다양한 날짜/기간/요일 표현 커버
  * - 핵심 규칙만 유지
  * - 간결한 포맷
  */
@@ -31,9 +31,17 @@ export function buildParseTodoPrompt(
 	const safeText = sanitizeForPrompt(text);
 
 	return `Korean Todo Parser. Now: ${datetime}
-Time: 오전/아침→AM, 오후/저녁/밤→PM, 숫자만→context기반(지난시간=PM)
-Date: 내일→+1d, 모레→+2d, 다음주→+7d, 이번주→this week
-Repeat: 매주→isRecurring:true+요일, 매일→MON~SUN, 주말→SAT+SUN, 평일→MON~FRI, 격주/매달→isRecurring:false
+Default: 날짜없음→today, 시간없음→isAllDay:true, 당장/지금/바로→today
+Time: 새벽/오전/아침→AM, 낮/오후/저녁/밤→PM, 점심/정오→12:00, 자정→00:00, N시반→N:30, 숫자만→context(지난시간→PM)
+PastTime: 날짜없이시간만+이미지남→내일, 날짜명시("오늘")→유지
+Date: 오늘→today, 내일→+1d, 모레/이틀후→+2d, 글피/사흘후→+3d, 나흘후→+4d, N일후→+Nd, N주후→+Nw, N달후→+Nmo, 다음달→+1mo, 내년→next year
+Week: 요일만→이번주(미래면)/다음주(지났으면), 이번주X요일→this week, 다음주X요일→next week, 이번주→this week, 다음주→+7d, 다다음주→+14d
+DateExpr: M월D일→해당날짜(지났으면내년), 이번달N일→해당일(지났으면다음달), 다음달N일→next month, 월초→1일(지났으면다음달), 월말→말일, 연초→1/1, 연말→12/31
+Range: ~까지→endDate(startDate=today), ~부터~까지→startDate+endDate, N일/주동안→endDate=start+N
+NonRepeat: 이번/다음주말→토요일(isRecurring:false)
+Repeat: 매주→isRecurring:true+요일, 매일→MON~SUN, 매주주말→SAT+SUN, 매주평일→MON~FRI, 격주/격일/매달→isRecurring:false
+Compound: 반복+기간→recurrence.endDate=시작+기간
+Title: 날짜/시간표현 제외, 핵심내용만
 JSON: {"title":"str","startDate":"YYYY-MM-DD","endDate":"YYYY-MM-DD|null","scheduledTime":"HH:mm|null","isAllDay":bool,"isRecurring":bool,"recurrence":{"daysOfWeek":["MON"],"endDate":"${fourWeeksLater}"}|null}
 Parse: "${safeText}"`;
 }


### PR DESCRIPTION
## 🎙️ 녹음 테스트 가이드

> 아래 문장들을 **음성 녹음으로 입력**하여 AI 파싱 결과를 확인해주세요.
> 기준 시점: 테스트 당시 현재 시각 기준으로 판단합니다.

### 1. 기본값 (날짜/시간 없는 입력)

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 1 | "밥먹기" | 날짜 규칙 없음 → 랜덤 날짜 | startDate: 오늘 |
| 2 | "운동하기" | 같은 문제 | startDate: 오늘, isAllDay: true |
| 3 | "당장 전화해" | 미지원 | startDate: 오늘 |
| 4 | "지금 메일 보내기" | 미지원 | startDate: 오늘 |

### 2. "오늘" 키워드

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 5 | "오늘 밥먹기" | "오늘" 규칙 없음 → LLM 추론 의존 | startDate: 오늘 |
| 6 | "오늘 저녁 7시 약속" | 불확실 | startDate: 오늘, scheduledTime: 19:00 |

### 3. 시간이 이미 지난 경우

> ⏰ **밤 11시 이후에 테스트** 해야 효과 확인 가능

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 7 | "저녁 7시 약속" (23시에 테스트) | 오늘 19:00 (이미 지남) | startDate: **내일**, scheduledTime: 19:00 |
| 8 | "오전 9시 회의" (14시에 테스트) | 오늘 09:00 (이미 지남) | startDate: **내일**, scheduledTime: 09:00 |
| 9 | "**오늘** 저녁 7시 약속" (23시에 테스트) | 불확실 | startDate: **오늘** (명시 → 의도 존중), scheduledTime: 19:00 |

### 4. 특수 시간 표현

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 10 | "3시 반 미팅" | "N시 반" 미지원 | scheduledTime: 15:30 (또는 03:30, 컨텍스트 따라) |
| 11 | "정오에 점심" | "정오" 미지원 | scheduledTime: 12:00 |
| 12 | "자정까지 제출" | "자정" 미지원 | scheduledTime: 00:00 |
| 13 | "새벽 2시 알람" | "새벽" 미지원 | scheduledTime: 02:00 |
| 14 | "점심에 밥먹기" | "점심" 미지원 | scheduledTime: 12:00 |
| 15 | "낮 1시 미팅" | "낮" 미지원 | scheduledTime: 13:00 |

### 5. 한국어 고유 날짜 표현

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 16 | "글피 미팅" | "글피" 미지원 | startDate: +3일 |
| 17 | "사흘 후 약속" | 전통 셈법 미지원 | startDate: +3일 |
| 18 | "나흘 후 미팅" | 전통 셈법 미지원 | startDate: +4일 |
| 19 | "이틀 후 병원" | "이틀후" 미지원 | startDate: +2일 (= 모레) |

### 6. 상대 날짜 (N일/주/달 후)

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 20 | "3일 후 약속" | N일 후 규칙 없음 | startDate: +3일 |
| 21 | "2주 후 검진" | 같은 문제 | startDate: +14일 |
| 22 | "1달 후 생일파티" | 같은 문제 | startDate: +1개월 |
| 23 | "다음 달에 여행" | 미지원 | startDate: +1개월 |
| 24 | "내년 계획 세우기" | 미지원 | startDate: 내년 1/1 |

### 7. 요일 표현

> 📅 아래 기대값은 오늘 요일에 따라 달라집니다

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 25 | "수요일에 미팅" | 요일→날짜 규칙 없음 | 이번 주 수(미래면) / 다음 주 수(지났으면) |
| 26 | "이번 주 금요일 회식" | "이번주" 규칙 모호 | 이번 주 금요일 |
| 27 | "다음 주 월요일 면접" | "다음주" 규칙 모호 | 다음 주 월요일 |
| 28 | "이번주 마감" | 단독 "이번주" 삭제됨 (회귀) | 이번 주 내 날짜 |
| 29 | "다음주 미팅" | 단독 "다음주" 삭제됨 (회귀) | +7일 |
| 30 | "다다음주 발표" | 미지원 | +14일 |

### 8. 주말 (비반복)

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 31 | "이번 주말에 쇼핑" | isRecurring: true 오설정 가능 | 이번 주 토요일, isRecurring: **false** |
| 32 | "다음 주말 캠핑" | 같은 문제 | 다음 주 토요일, isRecurring: **false** |

### 9. 특정 날짜 (M월 D일)

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 33 | "3월 15일에 발표" | LLM 추론 의존 | 올해 3/15 (지났으면 내년) |
| 34 | "1월 5일 신년회" (현재 3월) | 연도 판단 불확실 | **내년** 1/5 |
| 35 | "이번 달 20일 회의" | 미지원 | 이번 달 20일 (지났으면 다음 달) |
| 36 | "다음 달 15일 회의" | 미지원 | 다음 달 15일 |

### 10. 월초/월말/연초/연말

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 37 | "월말에 정산" | 미지원 | 이번 달 말일 |
| 38 | "월초에 보고" | 미지원 | 다음 달 1일 (이미 지났으므로) |
| 39 | "연말 정산" | 미지원 | 12/31 |
| 40 | "연초에 계획 세우기" | 미지원 | 내년 1/1 (지났으므로) |

### 11. 기간/범위 ("~동안", "~까지", "~부터 ~까지")

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 41 | "일주일 동안 밥먹기" | 기간 개념 없음 → 단일 날짜 | startDate: 오늘, endDate: +7일 |
| 42 | "3일 동안 프로젝트" | 같은 문제 | startDate: 오늘, endDate: +3일 |
| 43 | "2주간 다이어트" | 같은 문제 | startDate: 오늘, endDate: +14일 |
| 44 | "금요일까지 보고서 작성" | "까지" → startDate로 오해석 | startDate: 오늘, endDate: 금요일 |
| 45 | "3월 20일까지 과제" | 같은 문제 | startDate: 오늘, endDate: 3/20 |
| 46 | "월요일부터 금요일까지 출장" | 범위 미지원 | startDate: 월요일, endDate: 금요일 |
| 47 | "3월 15일부터 20일까지 여행" | 같은 문제 | startDate: 3/15, endDate: 3/20 |

### 12. 반복

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 48 | "매일 운동" | 기존 지원 | isRecurring: true, MON~SUN |
| 49 | "매주 수요일 영어" | 기존 지원 | isRecurring: true, WED |
| 50 | "매주 주말 등산" | "매주주말" 미지원 | isRecurring: true, SAT+SUN |
| 51 | "매주 평일 출근" | "평일" → "매주평일"로 변경 | isRecurring: true, MON~FRI |
| 52 | "격일로 운동" | "격일" 미지원 | isRecurring: **false** (시스템 미지원) |
| 53 | "격주 미팅" | 기존 지원 | isRecurring: **false** (시스템 미지원) |

### 13. 반복 + 기간 복합

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 54 | "2주 동안 매일 운동" | 기간·반복 모두 미지원 | isRecurring: true, MON~SUN, recurrence.endDate: +14일 |
| 55 | "한 달간 매주 수요일 영어" | 같은 문제 | isRecurring: true, WED, recurrence.endDate: +1개월 |

### 14. 제목 추출

| # | 녹음 문장 | 기존 문제 | 기대 결과 |
|---|----------|----------|----------|
| 56 | "다음 주 월요일 오후 3시에 팀 미팅" | title에 날짜/시간 포함 가능 | title: "팀 미팅" (날짜/시간 제외) |
| 57 | "내일 아침 9시 반 병원 가기" | 같은 문제 | title: "병원 가기" |

---

## 📋 개요

AI 투두 파싱 프롬프트를 ~200토큰에서 ~350토큰으로 확장하여 한국어 자연어의 다양한 날짜/시간/기간 표현을 전면 커버.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드

## 📝 변경 내용

### 프롬프트 규칙 추가 (parse-todo.prompt.ts)

- **Default**: `날짜없음→today`, `당장/지금/바로→today`
- **Time**: `점심/정오→12:00`, `자정→00:00`, `N시반→N:30`, `새벽→AM`
- **PastTime**: 날짜 없이 시간만 언급 + 이미 지남 → 내일
- **Date**: `글피/사흘후→+3d`, `나흘후→+4d`, `모레/이틀후→+2d`, `N일/주/달후`, `내년→next year`
- **Week**: `이번주→this week`, `다음주→+7d` (단독 사용 복원), `다다음주→+14d`
- **DateExpr**: `이번달N일(지났으면다음달)`, `다음달N일`, `월초(지났으면다음달)`, `연초→1/1`, `연말→12/31`
- **Range**: `~까지→endDate`, `~부터~까지`, `N일/주동안→endDate=start+N`
- **NonRepeat**: `이번/다음주말→토요일(isRecurring:false)`
- **Repeat**: `격일` 추가 (시스템 미지원 → isRecurring:false)
- **Compound**: 반복+기간 → recurrence.endDate
- **Title**: 날짜/시간표현 제외, 핵심내용만

### 테스트 (parse-todo.prompt.spec.ts)

- 기존 테스트 리팩토링 + 새 규칙별 describe 블록으로 재구성
- 22개 → 27개 테스트 케이스 (5개 추가)

## 🧪 테스트

### 테스트 방법

```bash
cd apps/api && npx jest "parse-todo.prompt.spec"
```

### 테스트 결과

- [x] 단위 테스트 27개 통과
- [x] `pnpm lint` 통과
- [x] `pnpm typecheck` 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #350