### PR TITLE
fix(mobile): 알림 라우팅 + Android Apple 계정 + 친구 실시간 갱신 + 프리미엄 리포트 빈 상태 UX 수정 (#352)

### DIFF
--- a/apps/mobile/app/(app)/reports/index.tsx
+++ b/apps/mobile/app/(app)/reports/index.tsx
@@ -3,16 +3,14 @@ import { ReportStatusBanner } from '@src/features/ai/presentations/components/Re
 import { ScallopedContainer } from '@src/features/ai/presentations/components/ScallopedContainer';
 import { AI_QUERY_KEYS } from '@src/features/ai/presentations/constants/ai-query-keys.constant';
 import { getSampleReport } from '@src/features/ai/presentations/constants/sample-reports.constant';
+import { useGetReportStatusQueryOptions } from '@src/features/ai/presentations/queries/use-get-report-status-query-options';
 import { useGetReportsQueryOptions } from '@src/features/ai/presentations/queries/use-get-reports-query-options';
 import { UserPolicy } from '@src/features/user/models/user.model';
 import { useGetMeQueryOptions } from '@src/features/user/presentations/queries/use-get-me-query-options';
 import {
-  Box,
   Button,
-  DocsIcon,
   H4,
   QueryErrorBoundary,
-  Result,
   Spacing,
   StyledSafeAreaView,
   Text,
@@ -157,15 +155,7 @@ function ReportList({ type }: { type: ReportType }) {
   const { data: reports } = useSuspenseQuery(useGetReportsQueryOptions({ type }));
 
   if (reports.length === 0) {
-    return (
-      <Box my={32}>
-        <Result
-          icon={<DocsIcon width={48} height={48} />}
-          title="아직 리포트가 없어요"
-          description="할 일을 완료하면 AI가 리포트를 생성해줘요"
-        />
-      </Box>
-    );
+    return <PremiumPendingPreview type={type} />;
   }
 
   return (
@@ -173,6 +163,28 @@ function ReportList({ type }: { type: ReportType }) {
       {reports.map((report, index) => (
         <ReportCard key={report.id} report={report} isLast={index === reports.length - 1} />
       ))}
+    </VStack>
+  );
+}
+
+function PremiumPendingPreview({ type }: { type: ReportType }) {
+  const { data: status } = useSuspenseQuery(useGetReportStatusQueryOptions());
+  const sampleReport = getSampleReport(`sample-${type.toLowerCase()}`);
+
+  const daysUntil = type === 'WEEKLY' ? status.daysUntilWeekly : status.daysUntilMonthly;
+  const reportLabel = type === 'WEEKLY' ? '주간' : '월간';
+
+  return (
+    <VStack gap={12}>
+      <View className="opacity-60">
+        <ReportCard report={sampleReport} isSample isLast />
+      </View>
+
+      <Text size="b3" shade={7} align="center">
+        {daysUntil === 0
+          ? `오늘 첫 번째 ${reportLabel} 리포트가 도착해요!`
+          : `${daysUntil}일 후에 첫 번째 ${reportLabel} 리포트가 도착해요`}
+      </Text>
     </VStack>
   );
 }

--- a/apps/mobile/app/(app)/settings/linked-accounts.tsx
+++ b/apps/mobile/app/(app)/settings/linked-accounts.tsx
@@ -17,7 +17,7 @@ import times from 'es-toolkit/compat/times';
 import { Chip, Separator, Skeleton, SkeletonGroup, Spinner } from 'heroui-native';
 import type { ReactNode } from 'react';
 import { Fragment, memo, Suspense, useCallback, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { Platform, ScrollView, View } from 'react-native';
 
 const LinkedAccountsScreen = () => {
   return (
@@ -40,6 +40,9 @@ const LinkedAccountsScreen = () => {
 };
 
 export default LinkedAccountsScreen;
+
+const visibleConfigs =
+  Platform.OS === 'ios' ? PROVIDER_CONFIGS : PROVIDER_CONFIGS.filter((c) => c.provider !== 'APPLE');
 
 function LinkedAccountsList() {
   const { canUnlink, getProviderState, link, unlink } = useLinkedAccounts();
@@ -70,7 +73,7 @@ function LinkedAccountsList() {
   return (
     <>
       <VStack className="bg-white rounded-2xl overflow-hidden border border-gray-2">
-        {PROVIDER_CONFIGS.map((config, index) => {
+        {visibleConfigs.map((config, index) => {
           const { isLinked, isPending } = getProviderState(config.provider, config.slug);
 
           return (
@@ -124,10 +127,10 @@ LinkedAccountsList.Loading = function Loading() {
   return (
     <VStack className="bg-white rounded-2xl overflow-hidden border border-gray-2">
       <SkeletonGroup isLoading isSkeletonOnly>
-        {times(4, (index) => (
+        {times(visibleConfigs.length, (index) => (
           <Fragment key={`linked-account-skeleton-${index}`}>
             <SkeletonRow />
-            {index < 3 && <Separator className="mx-4 bg-gray-2" />}
+            {index < visibleConfigs.length - 1 && <Separator className="mx-4 bg-gray-2" />}
           </Fragment>
         ))}
       </SkeletonGroup>

--- a/apps/mobile/src/bootstrap/providers/notification-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/notification-provider.tsx
@@ -78,7 +78,7 @@ const NativeNotificationProvider = ({ children }: PropsWithChildren) => {
       logger.info('[Notification] Received in foreground', {
         title: notification.request.content.title,
       });
-      handleForegroundNotification();
+      handleForegroundNotification(notification);
     });
 
     responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {

--- a/apps/mobile/src/features/notification/models/notification.model.ts
+++ b/apps/mobile/src/features/notification/models/notification.model.ts
@@ -146,10 +146,8 @@ const getCategoryLabel = (type: NotificationType): string =>
 /** 알림 타입 + context → 앱 내부 라우트 */
 const getInternalRoute = (type: NotificationType, context?: NotificationContext): string | null =>
   match(type)
-    .with('FOLLOW_NEW', () => '/friends')
-    .with('FOLLOW_ACCEPTED', () =>
-      context?.friendId ? `/feed/friend/${context.friendId}` : '/feed',
-    )
+    .with('FOLLOW_NEW', () => '/friends?view=receiver')
+    .with('FOLLOW_ACCEPTED', () => '/friends?view=receiver')
     .with('CHEER_RECEIVED', 'FRIEND_COMPLETED', () =>
       context?.friendId ? `/feed/friend/${context.friendId}` : null,
     )

--- a/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
+++ b/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
@@ -1,6 +1,7 @@
 import type { NotificationType } from '@aido/validators';
 import { pushNotificationDataSchema } from '@aido/validators';
 import { useLogger, useNotificationService } from '@src/bootstrap/providers/di-provider';
+import { FRIEND_QUERY_KEYS } from '@src/features/friend/presentations/constants/friend-query-keys.constant';
 import { NOTIFICATION_QUERY_KEYS } from '@src/features/notification/presentations/constants/notification-query-keys.constant';
 import { useTrack } from '@src/shared/analytics';
 import { useQueryClient } from '@tanstack/react-query';
@@ -93,22 +94,32 @@ export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandl
     [trackEvent, logger, notificationService, queryClient],
   );
 
-  const handleForegroundNotification = useCallback(() => {
-    if (!isAuthenticated) return;
+  const handleForegroundNotification = useCallback(
+    (notification?: Notifications.Notification) => {
+      if (!isAuthenticated) return;
 
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
 
-    debounceTimerRef.current = setTimeout(() => {
-      Promise.all([
-        queryClient.invalidateQueries({ queryKey: NOTIFICATION_QUERY_KEYS.all }),
-        notificationService.syncBadgeCount(),
-      ]).catch((e) =>
-        logger.error('[Notification] Handler failed', e instanceof Error ? e : undefined),
-      );
-    }, 1000);
-  }, [isAuthenticated, logger, notificationService, queryClient]);
+      debounceTimerRef.current = setTimeout(() => {
+        const invalidations: Promise<void>[] = [
+          queryClient.invalidateQueries({ queryKey: NOTIFICATION_QUERY_KEYS.all }),
+          notificationService.syncBadgeCount(),
+        ];
+
+        const notificationType = notification?.request.content.data?.type as string | undefined;
+        if (notificationType === 'FOLLOW_NEW' || notificationType === 'FOLLOW_ACCEPTED') {
+          invalidations.push(queryClient.invalidateQueries({ queryKey: FRIEND_QUERY_KEYS.all }));
+        }
+
+        Promise.all(invalidations).catch((e) =>
+          logger.error('[Notification] Handler failed', e instanceof Error ? e : undefined),
+        );
+      }, 1000);
+    },
+    [isAuthenticated, logger, notificationService, queryClient],
+  );
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## 📋 개요

서비스 전반의 4가지 UX 이슈를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

### 1. 친구 알림 라우팅 수정
- `FOLLOW_NEW` / `FOLLOW_ACCEPTED` 푸시 탭 시 → `/friends?view=receiver` (받은 요청 탭)으로 이동
- 기존: `FOLLOW_NEW` → `/friends` (기본 탭), `FOLLOW_ACCEPTED` → `/feed/friend/:id`

### 2. Android Apple 연결 계정 숨기기
- `Platform.OS !== 'ios'`일 때 Apple 계정 옵션 숨김 (로그인 화면과 동일 패턴)
- 스켈레톤 로딩도 플랫폼에 맞게 동적 조정

### 3. 친구 승인 시 실시간 갱신
- 포그라운드 알림 핸들러에 `notification` 파라미터 전달
- `FOLLOW_NEW` / `FOLLOW_ACCEPTED` 수신 시 `FRIEND_QUERY_KEYS.all` 선택적 invalidation
- TkDodo 패턴 기반 이벤트 드리븐 선택적 갱신

### 4. 프리미엄 리포트 빈 상태 개선
- 리포트 미생성 시 샘플 데이터(opacity 60%) + 카운트다운 문구 표시
- `ReportStatusBanner`에서 이미 캐시된 status 데이터 활용 (추가 네트워크 요청 없음)

## 🧪 테스트

### 테스트 방법

```bash
pnpm lint
pnpm typecheck
```

### 테스트 결과

- [x] Biome lint 통과
- [x] TypeScript 타입 체크 통과
- [x] Metro 번들 빌드 통과 (iOS + Android)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #352

## 📸 스크린샷 (UI 변경 시)

|          Before           |           After           |
| :-----------------------: | :-----------------------: |
| <!-- 변경 전 스크린샷 --> | <!-- 변경 후 스크린샷 --> |