### PR TITLE
fix(mobile): 디자인 스펙에 맞게 oklch 색상 값 교정

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -39,9 +39,9 @@
   }
 
   @variant dark {
-    --background: oklch(0.18 0.0056 29);
+    --background: oklch(0.182 0 0);
     --foreground: oklch(0.97 0 0);
-    --surface: oklch(0.2 0.005 285);
+    --surface: oklch(0.248 0 0);
     --muted: oklch(0.78 0 0);
     --default: oklch(0.32 0 0);
     --accent: oklch(0.65 0.2 30);


### PR DESCRIPTION
## 📋 개요

`global.css`의 oklch 색상 값이 디자인 스펙(hex)과 불일치하여 정확한 값으로 교정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- Gray 5~10 oklch L값 교정 (반올림으로 스펙보다 어둡게 렌더링되던 문제)
- gray-10 보라빛 틴트 제거 (`C=0.005 H=285` → `0`)
- main/secondary/error 브랜드 색상 스펙 hex 정밀 매칭
- dark white 따뜻한 틴트 제거 (`H=29` → 무채색)
- 다크 모드 gray 1~6도 동일하게 교정

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm build
```

### 테스트 결과

- [x] 수동 테스트 완료

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #357



