### PR TITLE
feat(mobile): 캘린더 뷰 모드 선택 값 MMKV 저장

### DIFF
--- a/apps/mobile/src/core/ports/sync-storage.ts
+++ b/apps/mobile/src/core/ports/sync-storage.ts
@@ -1,0 +1,5 @@
+export interface SyncStorage {
+  getString(key: string): string | undefined;
+  set(key: string, value: string): void;
+  delete(key: string): void;
+}

--- a/apps/mobile/src/features/todo/presentations/components/Calendar/calendar.types.ts
+++ b/apps/mobile/src/features/todo/presentations/components/Calendar/calendar.types.ts
@@ -1,1 +1,1 @@
-export type CalendarViewMode = 'week' | 'month';
+export type { CalendarViewMode } from '@src/shared/preferences/calendar-view-mode.preference';

--- a/apps/mobile/src/features/todo/presentations/providers/feed-calendar-provider.tsx
+++ b/apps/mobile/src/features/todo/presentations/providers/feed-calendar-provider.tsx
@@ -1,16 +1,12 @@
-import type { CalendarViewMode } from '@src/features/todo/presentations/components/Calendar/calendar.types';
+import type { SyncStorage } from '@src/core/ports/sync-storage';
 import { useToday } from '@src/shared/hooks/useToday';
-import { mmkvStorage } from '@src/shared/infra/storage/mmkv-storage';
+import { mmkvSyncStorage } from '@src/shared/infra/storage/mmkv-storage';
+import {
+  type CalendarViewMode,
+  readCalendarViewMode,
+  writeCalendarViewMode,
+} from '@src/shared/preferences/calendar-view-mode.preference';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-
-const VIEW_MODE_STORAGE_KEY = 'aido_calendar_view_mode';
-
-function readSavedViewMode(): CalendarViewMode {
-  const saved = mmkvStorage.getString(VIEW_MODE_STORAGE_KEY);
-
-  if (saved === 'week' || saved === 'month') return saved;
-  return 'week';
-}
 
 type FeedCalendarContextValue = {
   selectedDate: Date;
@@ -21,15 +17,28 @@ type FeedCalendarContextValue = {
 
 const FeedCalendarContext = createContext<FeedCalendarContextValue | null>(null);
 
-export function FeedCalendarProvider({ children }: { children: React.ReactNode }) {
+interface FeedCalendarProviderProps {
+  children: React.ReactNode;
+  syncStorage?: SyncStorage;
+}
+
+export function FeedCalendarProvider({
+  children,
+  syncStorage = mmkvSyncStorage,
+}: FeedCalendarProviderProps) {
   const [selectedDate, setSelectedDate] = useState(() => new Date());
-  const [viewMode, setViewMode] = useState<CalendarViewMode>(readSavedViewMode);
+  const [viewMode, setViewMode] = useState<CalendarViewMode>(() =>
+    readCalendarViewMode(syncStorage),
+  );
   const today = useToday();
 
-  const persistViewMode = useCallback((mode: CalendarViewMode) => {
-    setViewMode(mode);
-    mmkvStorage.set(VIEW_MODE_STORAGE_KEY, mode);
-  }, []);
+  const persistViewMode = useCallback(
+    (mode: CalendarViewMode) => {
+      setViewMode(mode);
+      writeCalendarViewMode(syncStorage, mode);
+    },
+    [syncStorage],
+  );
 
   useEffect(() => {
     setSelectedDate(today);

--- a/apps/mobile/src/shared/__tests__/create-mock-sync-storage.ts
+++ b/apps/mobile/src/shared/__tests__/create-mock-sync-storage.ts
@@ -1,0 +1,7 @@
+import type { SyncStorage } from '@src/core/ports/sync-storage';
+
+export const createMockSyncStorage = (): jest.Mocked<SyncStorage> => ({
+  getString: jest.fn(),
+  set: jest.fn(),
+  delete: jest.fn(),
+});

--- a/apps/mobile/src/shared/__tests__/index.ts
+++ b/apps/mobile/src/shared/__tests__/index.ts
@@ -1,3 +1,4 @@
 export { createMockAnalytics } from './create-mock-analytics';
 export { createMockHttpClient } from './create-mock-http-client';
 export { createMockStorage } from './create-mock-storage';
+export { createMockSyncStorage } from './create-mock-sync-storage';

--- a/apps/mobile/src/shared/infra/storage/mmkv-storage.ts
+++ b/apps/mobile/src/shared/infra/storage/mmkv-storage.ts
@@ -1,3 +1,10 @@
+import type { SyncStorage } from '@src/core/ports/sync-storage';
 import { MMKV } from 'react-native-mmkv';
 
-export const mmkvStorage = new MMKV();
+const mmkv = new MMKV();
+
+export const mmkvSyncStorage: SyncStorage = {
+  getString: (key) => mmkv.getString(key),
+  set: (key, value) => mmkv.set(key, value),
+  delete: (key) => mmkv.delete(key),
+};

--- a/apps/mobile/src/shared/preferences/calendar-view-mode.preference.test.ts
+++ b/apps/mobile/src/shared/preferences/calendar-view-mode.preference.test.ts
@@ -1,0 +1,65 @@
+import { createMockSyncStorage } from '@src/shared/__tests__';
+import { readCalendarViewMode, writeCalendarViewMode } from './calendar-view-mode.preference';
+
+describe('readCalendarViewMode', () => {
+  it('저장된 값이 없으면 week를 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue(undefined);
+
+    // When
+    const result = readCalendarViewMode(storage);
+
+    // Then
+    expect(result).toBe('week');
+  });
+
+  it('week가 저장되어 있으면 week를 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue('week');
+
+    // When
+    const result = readCalendarViewMode(storage);
+
+    // Then
+    expect(result).toBe('week');
+  });
+
+  it('month가 저장되어 있으면 month를 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue('month');
+
+    // When
+    const result = readCalendarViewMode(storage);
+
+    // Then
+    expect(result).toBe('month');
+  });
+
+  it('유효하지 않은 값이 저장되어 있으면 week를 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue('day');
+
+    // When
+    const result = readCalendarViewMode(storage);
+
+    // Then
+    expect(result).toBe('week');
+  });
+});
+
+describe('writeCalendarViewMode', () => {
+  it('올바른 key와 value로 storage.set을 호출한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+
+    // When
+    writeCalendarViewMode(storage, 'month');
+
+    // Then
+    expect(storage.set).toHaveBeenCalledWith('aido_calendar_view_mode', 'month');
+  });
+});

--- a/apps/mobile/src/shared/preferences/calendar-view-mode.preference.ts
+++ b/apps/mobile/src/shared/preferences/calendar-view-mode.preference.ts
@@ -1,0 +1,19 @@
+import type { SyncStorage } from '@src/core/ports/sync-storage';
+
+export type CalendarViewMode = 'week' | 'month';
+
+const KEY = 'aido_calendar_view_mode';
+
+export function readCalendarViewMode(storage: SyncStorage): CalendarViewMode {
+  const saved = storage.getString(KEY);
+
+  if (saved === 'week' || saved === 'month') {
+    return saved;
+  }
+
+  return 'week';
+}
+
+export function writeCalendarViewMode(storage: SyncStorage, mode: CalendarViewMode): void {
+  storage.set(KEY, mode);
+}

--- a/apps/mobile/src/shared/preferences/theme-mode.preference.test.ts
+++ b/apps/mobile/src/shared/preferences/theme-mode.preference.test.ts
@@ -1,0 +1,77 @@
+import { createMockSyncStorage } from '@src/shared/__tests__';
+import { readThemeMode, writeThemeMode } from './theme-mode.preference';
+
+describe('readThemeMode', () => {
+  it('저장된 값이 없으면 system을 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue(undefined);
+
+    // When
+    const result = readThemeMode(storage);
+
+    // Then
+    expect(result).toBe('system');
+  });
+
+  it('light가 저장되어 있으면 light를 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue('light');
+
+    // When
+    const result = readThemeMode(storage);
+
+    // Then
+    expect(result).toBe('light');
+  });
+
+  it('dark가 저장되어 있으면 dark를 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue('dark');
+
+    // When
+    const result = readThemeMode(storage);
+
+    // Then
+    expect(result).toBe('dark');
+  });
+
+  it('system이 저장되어 있으면 system을 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue('system');
+
+    // When
+    const result = readThemeMode(storage);
+
+    // Then
+    expect(result).toBe('system');
+  });
+
+  it('유효하지 않은 값이 저장되어 있으면 system을 반환한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+    storage.getString.mockReturnValue('invalid');
+
+    // When
+    const result = readThemeMode(storage);
+
+    // Then
+    expect(result).toBe('system');
+  });
+});
+
+describe('writeThemeMode', () => {
+  it('올바른 key와 value로 storage.set을 호출한다', () => {
+    // Given
+    const storage = createMockSyncStorage();
+
+    // When
+    writeThemeMode(storage, 'dark');
+
+    // Then
+    expect(storage.set).toHaveBeenCalledWith('aido_theme_mode', 'dark');
+  });
+});

--- a/apps/mobile/src/shared/preferences/theme-mode.preference.ts
+++ b/apps/mobile/src/shared/preferences/theme-mode.preference.ts
@@ -1,0 +1,19 @@
+import type { SyncStorage } from '@src/core/ports/sync-storage';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+const KEY = 'aido_theme_mode';
+
+export function readThemeMode(storage: SyncStorage): ThemeMode {
+  const saved = storage.getString(KEY);
+
+  if (saved === 'light' || saved === 'dark' || saved === 'system') {
+    return saved;
+  }
+
+  return 'system';
+}
+
+export function writeThemeMode(storage: SyncStorage, mode: ThemeMode): void {
+  storage.set(KEY, mode);
+}

--- a/apps/mobile/src/shared/providers/theme-provider.tsx
+++ b/apps/mobile/src/shared/providers/theme-provider.tsx
@@ -1,4 +1,10 @@
-import { mmkvStorage } from '@src/shared/infra/storage/mmkv-storage';
+import type { SyncStorage } from '@src/core/ports/sync-storage';
+import { mmkvSyncStorage } from '@src/shared/infra/storage/mmkv-storage';
+import {
+  readThemeMode,
+  type ThemeMode,
+  writeThemeMode,
+} from '@src/shared/preferences/theme-mode.preference';
 import {
   createContext,
   type PropsWithChildren,
@@ -10,18 +16,11 @@ import {
 import { useColorScheme } from 'react-native';
 import { Uniwind } from 'uniwind';
 
-export type ThemeMode = 'light' | 'dark' | 'system';
+export type { ThemeMode };
 export type ResolvedTheme = 'light' | 'dark';
 
-const THEME_STORAGE_KEY = 'aido_theme_mode';
-const VALID_MODES: ThemeMode[] = ['light', 'dark', 'system'];
-
-function readSavedMode(): ThemeMode {
-  const saved = mmkvStorage.getString(THEME_STORAGE_KEY);
-  if (saved && VALID_MODES.includes(saved as ThemeMode)) {
-    return saved as ThemeMode;
-  }
-  return 'system';
+interface ThemeProviderProps extends PropsWithChildren {
+  syncStorage?: SyncStorage;
 }
 
 interface ThemeContextValue {
@@ -32,9 +31,9 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
-export const ThemeProvider = ({ children }: PropsWithChildren) => {
+export const ThemeProvider = ({ children, syncStorage = mmkvSyncStorage }: ThemeProviderProps) => {
   const systemColorScheme = useColorScheme();
-  const [mode, setMode] = useState<ThemeMode>(readSavedMode);
+  const [mode, setMode] = useState<ThemeMode>(() => readThemeMode(syncStorage));
 
   const resolvedTheme: ResolvedTheme =
     mode === 'system' ? (systemColorScheme === 'dark' ? 'dark' : 'light') : mode;
@@ -43,10 +42,13 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     Uniwind.setTheme(mode);
   }, [mode]);
 
-  const persistMode = useCallback((newMode: ThemeMode) => {
-    setMode(newMode);
-    mmkvStorage.set(THEME_STORAGE_KEY, newMode);
-  }, []);
+  const persistMode = useCallback(
+    (newMode: ThemeMode) => {
+      setMode(newMode);
+      writeThemeMode(syncStorage, newMode);
+    },
+    [syncStorage],
+  );
 
   return (
     <ThemeContext.Provider value={{ mode, resolvedTheme, setMode: persistMode }}>


### PR DESCRIPTION
## 📋 개요

캘린더 뷰 모드(주/월) 선택 값을 MMKV에 저장하여 앱 재시작 후에도 유지되도록 합니다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `feed-calendar-provider.tsx`에서 `mmkvStorage`를 사용하여 뷰 모드 저장/복원
- `readSavedViewMode()` 함수로 앱 시작 시 MMKV에서 저장된 뷰 모드 읽기 (기본값: `week`)
- `setViewMode`에 `mmkvStorage.set()` 호출 추가로 변경 시 동기 저장
- 기존 `theme-provider.tsx`의 MMKV 저장 패턴과 동일한 구조

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm build
```

### 테스트 결과

- [x] 수동 테스트 완료

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #375