### PR TITLE
fix(mobile): Android 마이페이지 하단 컨텐츠 탭 바 가림 수정 (#377)

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/feed/(feed)/friend/[friendId].tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/(feed)/friend/[friendId].tsx
@@ -4,6 +4,7 @@ import { FriendTodoList } from '@src/features/todo/presentations/components/Frie
 import { PokeBanner } from '@src/features/todo/presentations/components/PokeBanner';
 import { TODO_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-query-keys.constant';
 import { useFeedCalendar } from '@src/features/todo/presentations/providers/feed-calendar-provider';
+import { LAYOUT } from '@src/shared/constants/layout.constant';
 import { useRefresh } from '@src/shared/hooks/useRefresh';
 import { QueryErrorBoundary, Spacing } from '@src/shared/ui';
 import { useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
@@ -37,7 +38,7 @@ const FriendFeedScreen = () => {
   return (
     <ScrollView
       style={{ flex: 1 }}
-      contentContainerStyle={{ flexGrow: 1, paddingBottom: 120 }}
+      contentContainerStyle={{ flexGrow: 1, paddingBottom: LAYOUT.tabBarOverlayPadding }}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     >
       <Calendar showCompletions={false} />

--- a/apps/mobile/app/(app)/(tabs)/feed/(feed)/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/(feed)/index.tsx
@@ -6,6 +6,7 @@ import { TODO_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo
 import { useFeedCalendar } from '@src/features/todo/presentations/providers/feed-calendar-provider';
 import { UserPolicy } from '@src/features/user/models/user.model';
 import { useGetMeQueryOptions } from '@src/features/user/presentations/queries/use-get-me-query-options';
+import { LAYOUT } from '@src/shared/constants/layout.constant';
 import { useRefresh } from '@src/shared/hooks/useRefresh';
 import { Box, ListRow, QueryErrorBoundary, Spacing } from '@src/shared/ui';
 import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
@@ -31,7 +32,7 @@ const MyFeedScreen = () => {
   return (
     <NestableScrollContainer
       style={{ flex: 1 }}
-      contentContainerStyle={{ flexGrow: 1, paddingBottom: 120 }}
+      contentContainerStyle={{ flexGrow: 1, paddingBottom: LAYOUT.tabBarOverlayPadding }}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     >
       <Calendar />

--- a/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
@@ -3,6 +3,7 @@ import { useLogoutMutationOptions } from '@src/features/auth/presentations/queri
 import { UserPolicy } from '@src/features/user/models/user.model';
 import { ProfileCard } from '@src/features/user/presentations/components/ProfileCard';
 import { useGetMeQueryOptions } from '@src/features/user/presentations/queries/use-get-me-query-options';
+import { LAYOUT } from '@src/shared/constants/layout.constant';
 import {
   ArrowRightIcon,
   ConfirmDialog,
@@ -28,7 +29,10 @@ const MyPageScreen = () => {
 
   return (
     <StyledSafeAreaView className="flex-1 bg-gray-1" edges={['bottom']}>
-      <ScrollView className="px-4 flex-1" contentContainerStyle={{ paddingBottom: 120 }}>
+      <ScrollView
+        className="px-4 flex-1"
+        contentContainerStyle={{ paddingBottom: LAYOUT.tabBarOverlayPadding }}
+      >
         <H3>내 정보</H3>
 
         <Spacing size={20} />

--- a/apps/mobile/src/shared/constants/layout.constant.ts
+++ b/apps/mobile/src/shared/constants/layout.constant.ts
@@ -1,0 +1,9 @@
+/**
+ * 레이아웃 상수
+ * Android Tabs는 탭 바가 absolute position으로 콘텐츠 위에 오버레이되므로,
+ * ScrollView 하단에 탭 바 높이만큼의 여백이 필요하다.
+ */
+export const LAYOUT = {
+  /** Android 탭 바 오버레이를 회피하기 위한 ScrollView 하단 safe 패딩 */
+  tabBarOverlayPadding: 120,
+} as const;


### PR DESCRIPTION
## 📋 개요

Android에서 "내 정보" 화면 하단 컨텐츠가 탭 바에 가려지는 버그를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- MyPage `ScrollView`에 `contentContainerStyle={{ paddingBottom: 120 }}` 추가

### 원인

Android `Tabs`(React Navigation JS 기반)는 탭 바가 콘텐츠 위에 **absolute position**으로 오버레이됩니다. MyPage의 `ScrollView`에 하단 패딩이 없어서, 스크롤 끝까지 내려도 "로그아웃 | 탈퇴하기" 버튼이 탭 바 뒤에 가려졌습니다.

```
┌─────────────────────┐
│   ScrollView 영역    │  ← flex-1로 전체 화면 차지
│   ...컨텐츠...       │
│   로그아웃 | 탈퇴하기  │  ← 탭 바 뒤에 깔림
├─────────────────────┤
│   탭 바 (absolute)   │  ← 콘텐츠 위에 덮어씌워짐
└─────────────────────┘
```

iOS `NativeTabs`는 네이티브 레벨에서 content inset을 자동 조정하므로 문제 없었음.

### 해결

같은 탭 화면인 Feed(`feed/index.tsx`)에서 이미 사용 중인 `paddingBottom: 120` 패턴을 MyPage에도 적용:

```diff
- <ScrollView className="px-4 flex-1">
+ <ScrollView className="px-4 flex-1" contentContainerStyle={{ paddingBottom: 120 }}>
```

### 관련 이슈 (upstream)

- [react-native-screens #3627](https://github.com/software-mansion/react-native-screens/issues/3627) — 네이티브 탭 바 높이 JS 노출 미지원
- [react-navigation #12727](https://github.com/react-navigation/react-navigation/issues/12727) — Android 네비게이션 바/탭 바 겹침

## 🧪 테스트

### 테스트 방법

1. Android 기기/에뮬레이터에서 "마이" 탭 진입
2. 화면 최하단까지 스크롤
3. "로그아웃 | 탈퇴하기" 버튼이 탭 바에 가려지지 않는지 확인

### 테스트 결과

- [x] lint 통과
- [x] typecheck 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #377

## 📸 스크린샷 (UI 변경 시)

|          Before           |           After           |
| :-----------------------: | :-----------------------: |
| <img width="435" height="642" alt="스크린샷 2026-03-14 오후 6 29 20" src="https://github.com/user-attachments/assets/0609d33b-af7d-452f-a8f8-cfd03b011d20" /> | <img width="226" height="514" alt="스크린샷 2026-03-14 오후 6 29 44" src="https://github.com/user-attachments/assets/1b3e3009-0b42-4795-82b8-e8c8e93d961f" /> |


배포 이전, 실 기기에서 한 번 더 체크 필요할듯.

