### PR TITLE
fix(mobile): 다크모드에서 Apple 아이콘 미표시 수정 (#388)

### DIFF
--- a/apps/mobile/src/features/auth/presentations/constants/provider-configs.constant.tsx
+++ b/apps/mobile/src/features/auth/presentations/constants/provider-configs.constant.tsx
@@ -1,13 +1,6 @@
-import { useTheme } from '@src/shared/providers/theme-provider';
 import { AppleIcon, GoogleIcon, KakaoIcon, NaverIcon } from '@src/shared/ui';
 import type { ReactNode } from 'react';
 import type { OAuthProvider, OAuthProviderSlug } from '../../models/oauth.model';
-
-function ThemedAppleIcon() {
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
-  return <AppleIcon width={18} height={18} colorClassName={isDark ? 'text-black' : 'text-white'} />;
-}
 
 interface ProviderConfig {
   provider: OAuthProvider;
@@ -36,7 +29,7 @@ export const PROVIDER_CONFIGS = [
     provider: 'APPLE',
     slug: 'apple',
     label: 'Apple',
-    icon: <ThemedAppleIcon />,
+    icon: <AppleIcon width={18} height={18} colorClassName="text-white dark:text-black" />,
     iconClassName: 'bg-apple-button dark:bg-apple-button-dark',
   },
   {


### PR DESCRIPTION
## 📋 개요

다크모드에서 연결된 계정 화면의 Apple 아이콘이 어두운 배경에 묻혀 보이지 않는 문제를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- Apple 아이콘 배경색을 시맨틱 토큰(`bg-gray-9 dark:bg-white`) 대신 고정 브랜드 컬러(`bg-apple-button dark:bg-apple-button-dark`)로 변경
- `--white`가 다크모드에서 어두운 색(`oklch(0.182)`)으로 매핑되어 배경이 오히려 어두워지는 문제 해결

| 모드 | 배경 | 아이콘 |
|------|------|--------|
| 라이트 | `#000000` (검정) | 흰색 |
| 다크 | `#ffffff` (흰색) | 검정 |

## 🧪 테스트

### 테스트 방법

- 시뮬레이터에서 라이트/다크 모드 전환 후 연결된 계정 화면의 Apple 아이콘 가시성 확인

### 테스트 결과

- [x] lint 통과
- [x] typecheck 통과
- [x] 빌드 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #388

## 📸 스크린샷 (UI 변경 시)

|          Before           |           After           |
| :-----------------------: | :-----------------------: |
| <!-- 변경 전 스크린샷 --> | <!-- 변경 후 스크린샷 --> |