### PR TITLE
fix(mobile): 문의하기 화면 키보드 UX 개선 (#393)

### DIFF
--- a/apps/mobile/app/(app)/settings/inquiry.tsx
+++ b/apps/mobile/app/(app)/settings/inquiry.tsx
@@ -37,6 +37,7 @@ const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView);
 
 const InquiryScreen = () => {
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>();
+  const contentHeight = useSharedValue(0);
   const hasScrolled = useSharedValue(false);
 
   const createInquiryMutation = useMutation(useCreateInquiryMutationOptions());
@@ -50,7 +51,7 @@ const InquiryScreen = () => {
       'worklet';
       if (e.height > 0 && !hasScrolled.value) {
         hasScrolled.value = true;
-        scrollTo(scrollViewRef, 0, 9999, true);
+        scrollTo(scrollViewRef, 0, contentHeight.value, true);
       }
     },
   });
@@ -73,6 +74,9 @@ const InquiryScreen = () => {
     <View className="flex-1 bg-gray-1">
       <AnimatedScrollView
         ref={scrollViewRef}
+        onContentSizeChange={(_w, h) => {
+          contentHeight.value = h;
+        }}
         contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 24, paddingBottom: 100 }}
         keyboardShouldPersistTaps="always"
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
## 📋 개요

문의하기 화면에서 TextArea 포커스 시 키보드가 올라올 때 jittering 없이 자연스럽게 스크롤되도록 키보드 UX를 개선합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `KeyboardAwareScrollView`를 제거하고 `ScrollView` + `automaticallyAdjustKeyboardInsets`로 대체
- `useKeyboardHandler`의 `onMove` 이벤트로 키보드 움직임 시작 즉시 `scrollToEnd` 트리거
- Reanimated `scrollTo`를 사용해 UI 스레드에서 직접 스크롤 (JS 브릿지 오버헤드 제거)
- `useSharedValue` 플래그로 `onMove` 매 프레임 호출 시 중복 스크롤 방지

### 왜 `KeyboardAwareScrollView`를 사용하지 않는가

현재 `react-native-keyboard-controller` 1.20.7에서 iOS의 `scrollRectToVisible`이 `KeyboardAwareScrollView`의 `contentInset` 조정과 충돌하여 jittering이 발생합니다 ([#856](https://github.com/kirillzyusko/react-native-keyboard-controller/issues/856)). 이 문제는 [PR #1336](https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1336)에서 수정되었으나 아직 릴리스되지 않았습니다.

## 🧪 테스트

### 테스트 방법

1. 설정 > 문의하기 화면 진입
2. 문의 내용 TextArea 터치 → jittering 없이 부드러운 스크롤 확인
3. 글자 수 카운터 보이는지 확인
4. 키보드 닫힌 상태에서 Radio 선택 정상 동작 확인
5. "문의 보내기" 버튼 클릭 정상 동작 확인

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #393

## 📸 스크린샷 (UI 변경 시)

|          Before           |           After           |
| :-----------------------: | :-----------------------: |
| https://github.com/user-attachments/assets/8d850655-50a9-437e-929b-2d891ad5cbae | https://github.com/user-attachments/assets/587e5fc7-da64-4a6d-94f0-494ba1af01b9 |







