### PR TITLE
fix(api): AI 리포트 BullMQ jobId 타임존 불일치 수정

### DIFF
--- a/apps/api/src/common/date/utils/format.spec.ts
+++ b/apps/api/src/common/date/utils/format.spec.ts
@@ -3,6 +3,7 @@ import {
 	toDateStringOrNull,
 	toISOString,
 	toISOStringOrNull,
+	toIsoMonthId,
 	toIsoWeekId,
 } from "./format";
 
@@ -76,6 +77,31 @@ describe("format", () => {
 			// 2026-01-05(월) = ISO 2026-W02
 			const week2 = new Date("2026-01-05T00:00:00.000Z");
 			expect(toIsoWeekId(week2)).toBe("2026-W02");
+		});
+
+		it("tz 전달 시 해당 타임존 기준으로 주차를 계산한다", () => {
+			// UTC 일요일 16:00 = KST 월요일 01:00 → 주차가 달라야 함
+			const utcSunday = new Date("2026-03-15T16:00:00.000Z");
+			expect(toIsoWeekId(utcSunday)).toBe("2026-W11"); // UTC 일요일 = W11
+			expect(toIsoWeekId(utcSunday, "Asia/Seoul")).toBe("2026-W12"); // KST 월요일 = W12
+		});
+
+		it("tz 없이 호출하면 기존처럼 UTC 기준이다", () => {
+			const utcSunday = new Date("2026-03-15T16:00:00.000Z");
+			expect(toIsoWeekId(utcSunday)).toBe("2026-W11");
+		});
+	});
+
+	describe("toIsoMonthId", () => {
+		it("ISO 월 식별자를 반환한다", () => {
+			expect(toIsoMonthId(FROZEN_TIME)).toBe("2026-M03");
+		});
+
+		it("tz 전달 시 해당 타임존 기준으로 월을 계산한다", () => {
+			// UTC 3/31 16:00 = KST 4/1 01:00 → 월이 달라야 함
+			const utcMar31 = new Date("2026-03-31T16:00:00.000Z");
+			expect(toIsoMonthId(utcMar31)).toBe("2026-M03"); // UTC 3월
+			expect(toIsoMonthId(utcMar31, "Asia/Seoul")).toBe("2026-M04"); // KST 4월
 		});
 	});
 });

--- a/apps/api/src/common/date/utils/format.ts
+++ b/apps/api/src/common/date/utils/format.ts
@@ -39,10 +39,13 @@ export function toDateStringOrNull(date: Date | null): string | null {
  * ISO 주번호 식별자 (예: "2026-W10")
  *
  * BullMQ jobId 중복 방지용으로 사용합니다.
- * @example toIsoWeekId(new Date("2026-03-04")) // "2026-W10"
+ * tz를 전달하면 해당 타임존 기준으로 주차를 계산합니다.
+ *
+ * @example toIsoWeekId(new Date("2026-03-04"))                    // "2026-W10" (UTC)
+ * @example toIsoWeekId(new Date("2026-03-15T16:00:00Z"), "Asia/Seoul") // "2026-W12" (KST 3/16 월)
  */
-export function toIsoWeekId(date: Date = new Date()): string {
-	const d = dayjs.utc(date);
+export function toIsoWeekId(date: Date = new Date(), tz?: string): string {
+	const d = tz ? dayjs(date).tz(tz) : dayjs.utc(date);
 	return `${d.isoWeekYear()}-W${String(d.isoWeek()).padStart(2, "0")}`;
 }
 
@@ -50,9 +53,12 @@ export function toIsoWeekId(date: Date = new Date()): string {
  * ISO 월 식별자 (예: "2026-M03")
  *
  * 월간 리포트 BullMQ jobId 중복 방지용으로 사용합니다.
- * @example toIsoMonthId(new Date("2026-03-08")) // "2026-M03"
+ * tz를 전달하면 해당 타임존 기준으로 월을 계산합니다.
+ *
+ * @example toIsoMonthId(new Date("2026-03-08"))                    // "2026-M03" (UTC)
+ * @example toIsoMonthId(new Date("2026-03-31T16:00:00Z"), "Asia/Seoul") // "2026-M04" (KST 4/1)
  */
-export function toIsoMonthId(date: Date = new Date()): string {
-	const d = dayjs.utc(date);
+export function toIsoMonthId(date: Date = new Date(), tz?: string): string {
+	const d = tz ? dayjs(date).tz(tz) : dayjs.utc(date);
 	return `${d.year()}-M${String(d.month() + 1).padStart(2, "0")}`;
 }

--- a/apps/api/src/modules/ai-report/jobs/report-generation.job.ts
+++ b/apps/api/src/modules/ai-report/jobs/report-generation.job.ts
@@ -17,6 +17,9 @@ import {
 /** 잡 enqueue용 배치 크기 (API 호출 없이 큐 적재만 하므로 크게 설정) */
 const ENQUEUE_BATCH_SIZE = 50;
 
+/** 크론 스케줄 + jobId 계산에 사용하는 기준 타임존 */
+const CRON_TZ = "Asia/Seoul";
+
 /**
  * AI 리포트 생성 스케줄러 (Dispatcher)
  *
@@ -43,7 +46,7 @@ export class ReportGenerationJob implements OnModuleInit {
 
 		await this.queue.upsertJobScheduler(
 			"weekly-report-scheduler",
-			{ pattern: "0 1 * * 1", tz: "Asia/Seoul" },
+			{ pattern: "0 1 * * 1", tz: CRON_TZ },
 			{
 				name: AiReportJobName.DISPATCH,
 				data: { reportType: "WEEKLY" } satisfies AiReportJobData,
@@ -51,7 +54,7 @@ export class ReportGenerationJob implements OnModuleInit {
 		);
 		await this.queue.upsertJobScheduler(
 			"monthly-report-scheduler",
-			{ pattern: "0 1 1 * *", tz: "Asia/Seoul" },
+			{ pattern: "0 1 1 * *", tz: CRON_TZ },
 			{
 				name: AiReportJobName.DISPATCH,
 				data: { reportType: "MONTHLY" } satisfies AiReportJobData,
@@ -122,42 +125,44 @@ export class ReportGenerationJob implements OnModuleInit {
 	 * 멱등성이 보장되므로 (BullMQ jobId + DB exists) 중복 실행 위험 없음.
 	 */
 	async #catchUpIfNeeded(): Promise<void> {
-		const kstNow = dayjs().tz("Asia/Seoul");
+		const kstNow = dayjs().tz(CRON_TZ);
 		const dayOfWeek = kstNow.day(); // 0=일, 1=월, ...
 		const dayOfMonth = kstNow.date();
 		const hour = kstNow.hour();
-
-		const periodId = toIsoWeekId();
+		const now = new Date();
 
 		// 주간: 월요일 01:00 이후
 		if (dayOfWeek === 1 && hour >= 1) {
+			const weekId = toIsoWeekId(now, CRON_TZ);
 			this.#logger.log("Catch-up: WEEKLY report dispatch");
 			await this.queue.add(
 				AiReportJobName.DISPATCH,
 				{ reportType: "WEEKLY" } satisfies AiReportJobData,
-				{ jobId: `dispatch_WEEKLY_${periodId}` },
+				{ jobId: `dispatch_WEEKLY_${weekId}` },
 			);
 		}
 
 		// 월간: 1일 01:00 이후
 		if (dayOfMonth === 1 && hour >= 1) {
+			const monthId = toIsoMonthId(now, CRON_TZ);
 			this.#logger.log("Catch-up: MONTHLY report dispatch");
 			await this.queue.add(
 				AiReportJobName.DISPATCH,
 				{ reportType: "MONTHLY" } satisfies AiReportJobData,
-				{ jobId: `dispatch_MONTHLY_${periodId}` },
+				{ jobId: `dispatch_MONTHLY_${monthId}` },
 			);
 		}
 	}
 
 	/**
-	 * jobId 중복 방지용 기간 식별자 생성
+	 * jobId 중복 방지용 기간 식별자 생성 (KST 기준)
 	 *
-	 * 같은 주/월에 동일 사용자에 대해 중복 잡 등록을 방지합니다.
-	 * - WEEKLY: ISO 주번호 기반 "2026-W10"
-	 * - MONTHLY: 월 기반 "2026-M03"
+	 * 크론 스케줄과 동일한 타임존으로 주차/월을 계산하여
+	 * UTC ↔ KST 날짜 경계 불일치로 인한 jobId 충돌을 방지합니다.
 	 */
 	#getJobDeduplicationId(type: "WEEKLY" | "MONTHLY"): string {
-		return type === "WEEKLY" ? toIsoWeekId() : toIsoMonthId();
+		return type === "WEEKLY"
+			? toIsoWeekId(new Date(), CRON_TZ)
+			: toIsoMonthId(new Date(), CRON_TZ);
 	}
 }


### PR DESCRIPTION
## Summary
- `toIsoWeekId`/`toIsoMonthId`가 UTC 기준으로 주차를 계산하여, KST 월요일 01:00 크론(= UTC 일요일 16:00) 실행 시 jobId 주차가 어긋나는 버그 수정
- 서버 재시작 catchUp에서 잘못된 주차의 jobId가 소진되어 정규 dispatch가 BullMQ dedup에 의해 skip되는 문제 해결
- Admin 유저 3명의 W11 주간 리포트가 누락된 원인

## Changes
- `toIsoWeekId(date, tz?)` / `toIsoMonthId(date, tz?)` — tz 파라미터 추가 (하위호환)
- `report-generation.job.ts` — `CRON_TZ` 상수 도입, 모든 dedup ID 계산에 KST 기준 적용
- 타임존 경계 테스트 케이스 추가 (UTC 일요일 = KST 월요일 주차 차이 검증)

## Test plan
- [x] `format.spec.ts` 15개 테스트 전체 통과
- [x] typecheck 통과
- [x] build 통과
- [x] 프로덕션에서 Admin W11 리포트 수동 생성 완료 확인