### PR TITLE
feat(api): AI 제안 패턴 유형 확장 - 순차/발전 패턴 감지 추가 (#405)

### DIFF
--- a/apps/api/src/modules/ai-suggestion/ai-suggestion.controller.ts
+++ b/apps/api/src/modules/ai-suggestion/ai-suggestion.controller.ts
@@ -31,14 +31,19 @@ import {
 } from "./dtos";
 
 /**
- * AI 반복 제안 API 컨트롤러
+ * AI 제안 API 컨트롤러
  *
- * AI가 분석한 반복 패턴 제안을 조회하고 수락/거절하는 API입니다.
+ * AI가 분석한 패턴 제안을 조회하고 수락/거절하는 API입니다.
  * 프리미엄 유저만 이용 가능합니다.
  *
  * ### 주요 기능
  * - 대기 중인 제안 목록 조회
  * - 제안 수락 (반복 할 일 생성) 또는 거절
+ *
+ * ### 패턴 유형 (3가지)
+ * - **반복**: 동일/유사 제목 3회+ 반복 → 반복 할 일 제안
+ * - **순차**: 번호/단계 진행 (1주차→2주차) → 다음 단계 예측 (2회부터 감지)
+ * - **발전**: 수치/목표 증가 (3km→5km) → 다음 목표 예측 (2회부터 감지)
  *
  * ### 분석 스케줄
  * - 매일 KST 11:00에 자동 분석
@@ -63,16 +68,16 @@ export class AiSuggestionController {
 	 */
 	@Get()
 	@ApiDoc({
-		summary: "AI 반복 제안 목록 조회",
+		summary: "AI 제안 목록 조회",
 		operationId: "getAiSuggestions",
-		description: `대기 중인(PENDING) AI 반복 제안 목록을 조회합니다.
+		description: `대기 중인(PENDING) AI 제안 목록을 조회합니다.
 만료되지 않은 PENDING 상태의 제안만 반환됩니다.
 
 ## 📊 제안 필드
 | 필드 | 타입 | 설명 |
 |------|------|------|
 | \`id\` | number | 제안 ID |
-| \`title\` | string | 제안된 반복 할 일 제목 |
+| \`title\` | string | 예측된 다음 할 일 제목 |
 | \`daysOfWeek\` | string[] | 반복 요일 (\`MON\`~\`SUN\`) |
 | \`scheduledTime\` | string \\| null | 추천 시간 (HH:mm, null이면 종일) |
 | \`confidence\` | number | AI 확신도 (0.0~1.0) |
@@ -82,14 +87,24 @@ export class AiSuggestionController {
 | \`createdAt\` | string | 제안 생성 시각 (ISO 8601) |
 | \`suggestedCategoryId\` | number \\| null | 추천 카테고리 ID (매칭된 투두의 최빈 카테고리, 없으면 null) |
 
+## 🧠 AI 패턴 분석 유형
+
+AI는 최근 2주간의 할 일에서 **3가지 패턴**을 감지합니다:
+
+| 유형 | 설명 | 최소 횟수 | confidence 범위 | 예시 |
+|------|------|----------|----------------|------|
+| **반복** | 같은/유사 제목 반복 | 3회 | 0.7~0.95 | "팀 미팅" × 5 → "팀 미팅" 반복 제안 |
+| **순차** | 번호/단계 진행 | 2회 | 0.5~0.9 | "1주차 워크북", "2주차 워크북" → **"3주차 워크북"** 예측 |
+| **발전** | 수치/목표 증가 | 2회 | 0.5~0.9 | "달리기 3km", "달리기 5km" → **"달리기 7km"** 예측 |
+
 ## ⏰ 제안 생성 스케줄 및 조건
 
 **분석 크론**: **매일 KST 11:00**
 
 **생성 조건** (모두 충족해야 제안이 생김):
 1. \`subscriptionStatus = ACTIVE\` 또는 \`role = ADMIN\`
-2. 최근 2주 내 비반복(\`recurrenceGroupId = null\`) 할 일이 존재
-3. AI가 동일 패턴을 **3회 이상** 감지
+2. 최근 2주 내 비반복(\`recurrenceGroupId = null\`) 할 일이 **3개 이상** 존재
+3. AI가 위 3가지 패턴 중 하나 이상을 감지
 
 **제안 수량**: 매 분석 시 기존 PENDING 제안을 **교체**하여 최대 **5개** 유지 (누적되지 않음)
 
@@ -106,9 +121,9 @@ export class AiSuggestionController {
 \`\`\`
 
 ### 예시 데이터 (최근 2주 비반복 할 일)
-- **팀 미팅** 10:00 → 02-23, 02-25, 02-27, 03-02, 03-04 (5회, 월/수/금 패턴)
-- **헬스장 가기** 19:30 → 02-17, 02-19, 02-24, 02-26 (4회, 화/목 패턴)
-- **영어공부** → 03-01, 03-03 (2회뿐 → **최소 3회 미달, 제안 안 됨**)
+- **팀 미팅** 10:00 → 02-23, 02-25, 02-27, 03-02, 03-04 (5회, 월/수/금 패턴) → **반복 패턴**
+- **1주차 워크북**, **2주차 워크북**, **3주차 워크북** → 매주 월요일 → **순차 패턴 (4주차 예측)**
+- **달리기 3km** 07:00, **달리기 5km** 07:00 → 매주 수요일 → **발전 패턴 (7km 예측)**
 
 ### 예시 응답
 \`\`\`json
@@ -128,11 +143,23 @@ export class AiSuggestionController {
     },
     {
       "id": 102,
-      "title": "헬스장 가기",
-      "daysOfWeek": ["TUE", "THU"],
-      "scheduledTime": "19:30",
-      "confidence": 0.81,
-      "reason": "최근 2주간 화/목 저녁 시간대에 반복 수행 패턴이 있습니다.",
+      "title": "4주차 워크북",
+      "daysOfWeek": ["MON"],
+      "scheduledTime": null,
+      "confidence": 0.85,
+      "reason": "매주 월요일 워크북이 순차 진행중 (1→2→3주차)",
+      "status": "PENDING",
+      "expiresAt": "2026-03-18T02:00:00.000Z",
+      "createdAt": "2026-03-04T02:00:00.000Z",
+      "suggestedCategoryId": 2
+    },
+    {
+      "id": 103,
+      "title": "달리기 7km",
+      "daysOfWeek": ["WED"],
+      "scheduledTime": "07:00",
+      "confidence": 0.6,
+      "reason": "수요일 아침 달리기 거리가 2km씩 증가하는 발전 패턴",
       "status": "PENDING",
       "expiresAt": "2026-03-18T02:00:00.000Z",
       "createdAt": "2026-03-04T02:00:00.000Z",
@@ -141,7 +168,6 @@ export class AiSuggestionController {
   ]
 }
 \`\`\`
-> "영어공부"는 2회뿐이라 최소 3회 조건 미달 → 제안 생성 안 됨
 
 ## 🔒 안전성 보장
 
@@ -189,9 +215,9 @@ export class AiSuggestionController {
 	@Patch(":id")
 	@HttpCode(HttpStatus.OK)
 	@ApiDoc({
-		summary: "AI 반복 제안 수락/거절",
+		summary: "AI 제안 수락/거절",
 		operationId: "handleAiSuggestion",
-		description: `AI 반복 제안을 수락하거나 거절합니다.
+		description: `AI 제안을 수락하거나 거절합니다.
 
 ## 📝 요청 본문
 | 필드 | 타입 | 필수 | 기본값 | 설명 |

--- a/apps/api/src/modules/ai-suggestion/ai-suggestion.repository.spec.ts
+++ b/apps/api/src/modules/ai-suggestion/ai-suggestion.repository.spec.ts
@@ -301,12 +301,16 @@ describe("AiSuggestionRepository", () => {
 					startDate: new Date("2026-02-10T00:00:00.000Z"),
 					scheduledTime: new Date("2026-02-10T01:00:00.000Z"), // UTC 01:00 → KST 10:00
 					categoryId: 3,
+					completed: true,
+					category: { name: "업무" },
 				},
 				{
 					title: "운동",
 					startDate: new Date("2026-02-11T00:00:00.000Z"),
 					scheduledTime: null,
 					categoryId: 5,
+					completed: false,
+					category: { name: "운동" },
 				},
 			];
 			(db.todo.findMany as jest.Mock).mockResolvedValue(mockTodos);
@@ -331,6 +335,8 @@ describe("AiSuggestionRepository", () => {
 					startDate: true,
 					scheduledTime: true,
 					categoryId: true,
+					completed: true,
+					category: { select: { name: true } },
 				},
 				orderBy: { startDate: "asc" },
 			});
@@ -338,8 +344,12 @@ describe("AiSuggestionRepository", () => {
 			expect(result[0]?.title).toBe("팀 미팅");
 			expect(result[0]?.scheduledTime).toBe("10:00");
 			expect(result[0]?.categoryId).toBe(3);
+			expect(result[0]?.completed).toBe(true);
+			expect(result[0]?.categoryName).toBe("업무");
 			expect(result[1]?.scheduledTime).toBeNull();
 			expect(result[1]?.categoryId).toBe(5);
+			expect(result[1]?.completed).toBe(false);
+			expect(result[1]?.categoryName).toBe("운동");
 		});
 	});
 });

--- a/apps/api/src/modules/ai-suggestion/ai-suggestion.repository.ts
+++ b/apps/api/src/modules/ai-suggestion/ai-suggestion.repository.ts
@@ -147,6 +147,8 @@ export class AiSuggestionRepository {
 				startDate: true,
 				scheduledTime: true,
 				categoryId: true,
+				completed: true,
+				category: { select: { name: true } },
 			},
 			orderBy: { startDate: "asc" },
 		});
@@ -158,6 +160,8 @@ export class AiSuggestionRepository {
 				? dayjs(t.scheduledTime).tz(timezone).format("HH:mm")
 				: null,
 			categoryId: t.categoryId,
+			completed: t.completed,
+			categoryName: t.category.name,
 		}));
 	}
 }

--- a/apps/api/src/modules/ai-suggestion/ai-suggestion.service.spec.ts
+++ b/apps/api/src/modules/ai-suggestion/ai-suggestion.service.spec.ts
@@ -357,12 +357,16 @@ describe("AiSuggestionService", () => {
 					startDate: "2026-03-01",
 					scheduledTime: null,
 					categoryId: 1,
+					completed: false,
+					categoryName: "기본",
 				},
 				{
 					title: "할일2",
 					startDate: "2026-03-02",
 					scheduledTime: null,
 					categoryId: 1,
+					completed: false,
+					categoryName: "기본",
 				},
 			]);
 
@@ -384,6 +388,8 @@ describe("AiSuggestionService", () => {
 				startDate: `2026-02-${String(10 + i).padStart(2, "0")}`,
 				scheduledTime: "10:00",
 				categoryId: 3,
+				completed: true,
+				categoryName: "업무",
 			}));
 			mockRepository.findRecentTodos.mockResolvedValue(todos);
 
@@ -396,7 +402,7 @@ describe("AiSuggestionService", () => {
 							scheduledTime: "10:00",
 							confidence: 0.85,
 							reason: "반복 패턴",
-							matchedTitles: ["팀 미팅"],
+							matchedTitles: ["팀 미팅", "팀 미팅", "팀 미팅"],
 						},
 					],
 				},
@@ -428,6 +434,8 @@ describe("AiSuggestionService", () => {
 				startDate: `2026-02-${String(10 + i).padStart(2, "0")}`,
 				scheduledTime: null,
 				categoryId: 5,
+				completed: true,
+				categoryName: "운동",
 			}));
 			mockRepository.findRecentTodos.mockResolvedValue(todos);
 
@@ -440,7 +448,7 @@ describe("AiSuggestionService", () => {
 							scheduledTime: null,
 							confidence: 0.8,
 							reason: "이유",
-							matchedTitles: ["운동"],
+							matchedTitles: ["운동", "운동", "운동"],
 						},
 					],
 				},
@@ -470,6 +478,8 @@ describe("AiSuggestionService", () => {
 				startDate: `2026-02-${String(10 + i).padStart(2, "0")}`,
 				scheduledTime: null,
 				categoryId: 2,
+				completed: true,
+				categoryName: "자기계발",
 			}));
 			mockRepository.findRecentTodos.mockResolvedValue(todos);
 
@@ -482,7 +492,7 @@ describe("AiSuggestionService", () => {
 							scheduledTime: null,
 							confidence: 0.8,
 							reason: "이유",
-							matchedTitles: ["독서"],
+							matchedTitles: ["독서", "독서", "독서"],
 						},
 					],
 				},
@@ -508,6 +518,8 @@ describe("AiSuggestionService", () => {
 				startDate: `2026-02-${String(10 + i).padStart(2, "0")}`,
 				scheduledTime: null,
 				categoryId: 5,
+				completed: true,
+				categoryName: "운동",
 			}));
 			mockRepository.findRecentTodos.mockResolvedValue(todos);
 
@@ -520,7 +532,7 @@ describe("AiSuggestionService", () => {
 							scheduledTime: null,
 							confidence: 0.8,
 							reason: "이유",
-							matchedTitles: ["운동"],
+							matchedTitles: ["운동", "운동", "운동"],
 						},
 					],
 				},
@@ -550,6 +562,8 @@ describe("AiSuggestionService", () => {
 				startDate: `2026-02-${String(10 + i).padStart(2, "0")}`,
 				scheduledTime: null,
 				categoryId: 1,
+				completed: false,
+				categoryName: "기본",
 			}));
 			mockRepository.findRecentTodos.mockResolvedValue(todos);
 
@@ -559,7 +573,7 @@ describe("AiSuggestionService", () => {
 				scheduledTime: null,
 				confidence: 0.8,
 				reason: "이유",
-				matchedTitles: [`할일${i}`],
+				matchedTitles: [`할일${i}a`, `할일${i}b`],
 			}));
 
 			mockAiProvider.generateStructured.mockResolvedValue({
@@ -593,30 +607,40 @@ describe("AiSuggestionService", () => {
 					startDate: "2026-02-10",
 					scheduledTime: "10:00",
 					categoryId: 3,
+					completed: true,
+					categoryName: "업무",
 				},
 				{
 					title: "팀 미팅",
 					startDate: "2026-02-12",
 					scheduledTime: "10:00",
 					categoryId: 3,
+					completed: true,
+					categoryName: "업무",
 				},
 				{
 					title: "팀 미팅",
 					startDate: "2026-02-14",
 					scheduledTime: "10:00",
 					categoryId: 5,
+					completed: true,
+					categoryName: "일반",
 				},
 				{
 					title: "팀 미팅",
 					startDate: "2026-02-17",
 					scheduledTime: "10:00",
 					categoryId: 3,
+					completed: true,
+					categoryName: "업무",
 				},
 				{
 					title: "팀 미팅",
 					startDate: "2026-02-19",
 					scheduledTime: "10:00",
 					categoryId: 5,
+					completed: false,
+					categoryName: "일반",
 				},
 			];
 			mockRepository.findRecentTodos.mockResolvedValue(todos);
@@ -630,7 +654,7 @@ describe("AiSuggestionService", () => {
 							scheduledTime: "10:00",
 							confidence: 0.85,
 							reason: "반복 패턴",
-							matchedTitles: ["팀 미팅"],
+							matchedTitles: ["팀 미팅", "팀 미팅", "팀 미팅"],
 						},
 					],
 				},
@@ -658,6 +682,8 @@ describe("AiSuggestionService", () => {
 				startDate: `2026-02-${String(10 + i).padStart(2, "0")}`,
 				scheduledTime: null,
 				categoryId: 5,
+				completed: true,
+				categoryName: "운동",
 			}));
 			mockRepository.findRecentTodos.mockResolvedValue(todos);
 
@@ -670,7 +696,7 @@ describe("AiSuggestionService", () => {
 							scheduledTime: null,
 							confidence: 0.8,
 							reason: "이유",
-							matchedTitles: ["존재하지않는제목"],
+							matchedTitles: ["존재하지않는제목1", "존재하지않는제목2"],
 						},
 					],
 				},

--- a/apps/api/src/modules/ai-suggestion/ai-suggestion.service.ts
+++ b/apps/api/src/modules/ai-suggestion/ai-suggestion.service.ts
@@ -18,6 +18,7 @@ import { AiSuggestionRepository } from "./ai-suggestion.repository";
 import type { SuggestionActionDto } from "./dtos";
 import {
 	buildDetectPatternsPrompt,
+	type DetectedPatternsResponse,
 	detectedPatternsSchema,
 } from "./prompts/detect-patterns.prompt";
 import type { TodoSummaryForAnalysis } from "./types";
@@ -210,7 +211,7 @@ export class AiSuggestionService {
 			temperature: 0.3,
 		});
 
-		const { patterns } = aiResult.output;
+		const patterns = this.#filterWeakPatterns(aiResult.output.patterns);
 
 		if (patterns.length === 0) {
 			this.#logger.debug(`패턴 미감지: userId=${userId}`);
@@ -257,6 +258,26 @@ export class AiSuggestionService {
 		);
 
 		return createdCount;
+	}
+
+	/**
+	 * AI가 반환한 패턴 중 약한 패턴을 필터링
+	 *
+	 * - 반복 패턴(같은 제목 반복): matchedTitles가 minOccurrences 미만이면 제거
+	 * - 순차/발전 패턴(서로 다른 제목): 2개 이상이면 허용
+	 */
+	#filterWeakPatterns(
+		patterns: DetectedPatternsResponse["patterns"],
+	): DetectedPatternsResponse["patterns"] {
+		return patterns.filter((p) => {
+			const uniqueTitles = new Set(p.matchedTitles);
+			const isRepetition = uniqueTitles.size === 1;
+
+			if (isRepetition) {
+				return p.matchedTitles.length >= AI_SUGGESTION_LIMITS.MIN_OCCURRENCES;
+			}
+			return p.matchedTitles.length >= 2;
+		});
 	}
 
 	/**

--- a/apps/api/src/modules/ai-suggestion/prompts/detect-patterns.prompt.ts
+++ b/apps/api/src/modules/ai-suggestion/prompts/detect-patterns.prompt.ts
@@ -30,7 +30,9 @@ export type DetectedPatternsResponse = z.infer<typeof detectedPatternsSchema>;
 /**
  * 패턴 감지 프롬프트 생성
  *
- * 최근 할 일 목록에서 반복 패턴을 감지하도록 AI에 요청합니다.
+ * 최근 할 일 목록에서 3가지 패턴(반복/순차/발전)을 감지하도록 AI에 요청합니다.
+ *
+ * 토큰 최적화: 압축 표기법 + 파이프 구분 입력 포맷
  */
 export function buildDetectPatternsPrompt(
 	todos: TodoSummaryForAnalysis[],
@@ -38,26 +40,57 @@ export function buildDetectPatternsPrompt(
 ): string {
 	const todoLines = todos
 		.map((t) => {
-			const time = t.scheduledTime ? ` (${t.scheduledTime})` : "";
-			return `- ${t.startDate}: ${sanitizeForPrompt(t.title)}${time}`;
+			const time = t.scheduledTime ?? "null";
+			const done = t.completed ? "O" : "X";
+			return `${t.startDate}|${sanitizeForPrompt(t.title)}|${time}|${done}|${t.categoryName}`;
 		})
 		.join("\n");
 
-	return `너는 사용자의 할 일 패턴을 분석하는 AI야.
-아래는 최근 2주간의 할 일 기록이야. 같은 할 일이 ${minOccurrences}회 이상 비슷한 스케줄로 반복된 패턴을 찾아줘.
+	return `할일 패턴 분석기. 최근 2주간 할일에서 3가지 패턴을 찾아 다음 할일을 예측해.
 
-## 할 일 기록
-${todoLines}
+## 패턴 유형
+1. 반복: 같은/유사 제목 ${minOccurrences}회+ 반복 → title=반복제목, daysOfWeek=반복요일
+2. 순차: 번호/단계 진행 (1주차→2주차, 1장→2장, step1→step2) → title=다음단계 예측 (2회면 충분)
+3. 발전: 수치/목표 증가 (3km→5km, 30분→45분, 절반→전부) → title=다음목표 예측 (2회면 충분)
 
 ## 규칙
-1. 동일하거나 매우 유사한 제목의 할 일이 ${minOccurrences}회 이상 나타난 경우에만 패턴으로 인식해.
-2. 요일 패턴을 분석해서 어떤 요일에 반복되는지 파악해.
-3. 시간 정보가 있으면 scheduledTime에 HH:mm 형식으로 넣어줘.
-4. confidence는 패턴의 확신도야 (0.7 이상이면 강한 패턴).
-5. reason은 한국어로 왜 이 패턴을 감지했는지 간단히 설명해.
-6. matchedTitles에는 이 패턴과 매칭된 원본 할 일 제목들을 넣어.
-7. 최대 5개의 패턴만 반환해.
-8. 패턴이 없으면 빈 배열을 반환해.
+- 요일패턴 분석→daysOfWeek, 시간있으면→scheduledTime(HH:mm)
+- confidence: 반복(${minOccurrences}회+)=0.7~0.95, 순차/발전(2회)=0.5~0.7, (3회+)=0.7~0.9
+- reason: 한국어, 왜 이 패턴이고 왜 이 title을 예측했는지 1문장
+- matchedTitles: 매칭된 원본 제목들
+- 최대5개, 없으면 빈배열
+- title은 예측된 다음 할일 (반복=같은제목, 순차=다음단계, 발전=다음목표)
+- 완료(O)된 항목이 많을수록 confidence 높임
+- 같은 카테고리 내 항목끼리 우선 비교
+- ★중요: 반복 패턴은 같은 제목이 ${minOccurrences}회 이상이어야만 인정. 2회만 반복된 동일 제목은 패턴이 아님
+- ★중요: 순차/발전은 2회면 충분하지만, 단순 반복(같은 제목)은 절대 2회로 인정하지 마
+- 1회만 등장한 항목은 절대 패턴 아님. 단발성 할일만 있으면 반드시 빈배열 반환
+
+## 예시
+입력:
+2026-03-03|1주차 워크북|null|O|공부
+2026-03-10|2주차 워크북|null|O|공부
+2026-03-17|3주차 워크북|null|X|공부
+→ title:"4주차 워크북", daysOfWeek:["MON"], confidence:0.85, reason:"매주 월요일 워크북이 순차 진행중 (1→2→3주차)", matchedTitles:["1주차 워크북","2주차 워크북","3주차 워크북"]
+
+입력:
+2026-03-05|달리기 3km|07:00|O|운동
+2026-03-12|달리기 5km|07:00|O|운동
+→ title:"달리기 7km", daysOfWeek:["WED"], scheduledTime:"07:00", confidence:0.6, reason:"수요일 아침 달리기 거리가 2km씩 증가하는 발전 패턴", matchedTitles:["달리기 3km","달리기 5km"]
+
+입력:
+2026-03-03|이사 견적 알아보기|null|O|일상
+2026-03-07|치과 예약|14:00|O|건강
+2026-03-10|생일 선물 사기|null|X|일상
+→ [] (모두 1회씩만 등장 → 패턴 없음)
+
+입력:
+2026-03-03|장보기|null|O|일상
+2026-03-10|장보기|null|O|일상
+→ [] (같은 제목 2회뿐 → 반복 패턴 아님. 반복은 3회 이상 필요)
+
+## 할일 기록 (날짜|제목|시간|완료|카테고리)
+${todoLines}
 
 JSON 형식으로 응답해.`;
 }

--- a/apps/api/src/modules/ai-suggestion/types/ai-suggestion.types.ts
+++ b/apps/api/src/modules/ai-suggestion/types/ai-suggestion.types.ts
@@ -20,4 +20,6 @@ export interface TodoSummaryForAnalysis {
 	startDate: string;
 	scheduledTime: string | null;
 	categoryId: number;
+	completed: boolean;
+	categoryName: string;
 }


### PR DESCRIPTION
## 📋 개요

AI 제안 시스템에 3가지 패턴 유형(반복/순차/발전)을 지원하여, 기존 단순 반복 감지 외에 순차적 진행과 수치 증가 패턴도 예측할 수 있도록 개선합니다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드

## 📝 변경 내용

- 3가지 패턴 유형 추가: 반복(같은 제목 3회+), 순차(번호/단계 진행 2회+), 발전(수치/목표 증가 2회+)
- `#filterWeakPatterns` 메서드 추가로 약한 패턴 서버 측 필터링
- Repository에서 `completed`, `categoryName` 추가 조회하여 AI 분석 정확도 향상
- 프롬프트 토큰 최적화: 압축 표기법 + 파이프 구분 입력 포맷 + few-shot 예시 추가
- Controller API 문서 업데이트 (3가지 패턴 유형 설명 및 예시)
- 테스트 업데이트 (새 필드 반영 + matchedTitles 검증 강화)

## 💡 AI 제안 예시 시나리오 (Gemini API 실제 테스트 결과)

> 20개 시나리오를 Gemini 2.5 Flash Lite에 직접 호출하여 검증했습니다.

### 순차 패턴 (번호/단계 진행)

| # | 유저가 등록한 할 일 | AI 예측 제안 | confidence |
|---|---------------------|-------------|-----------|
| 1 | `1주차 워크북`, `2주차 워크북`, `3주차 워크북` | **4주차 워크북** (매주 월요일) | 0.85 |
| 2 | `클린코드 1장 읽기`, `클린코드 2장 읽기` | **클린코드 3장 읽기** (매주 수요일 21:00) | 0.60 |
| 3 | `알고리즘 1강 듣기`, `2강 듣기`, `3강 듣기` | **알고리즘 4강 듣기** (매주 화요일) | 0.85 |
| 4 | `프로젝트 step1 완료`, `step2 완료`, `step3 완료` | **프로젝트 step4 완료** | 0.75 |

### 발전 패턴 (수치/목표 증가)

| # | 유저가 등록한 할 일 | AI 예측 제안 | confidence |
|---|---------------------|-------------|-----------|
| 5 | `달리기 3km`, `달리기 5km` | **달리기 7km** (+2km씩, 매주 수요일 07:00) | 0.60 |
| 6 | `플랭크 30초`, `플랭크 45초`, `플랭크 1분` | **플랭크 1분 15초** (+15초씩, 매주 수요일 08:00) | 0.80 |
| 7 | `책 30페이지 읽기`, `책 50페이지 읽기` | **책 70페이지 읽기** (+20p씩, 매주 화요일 22:00) | 0.70 |
| 8 | `수영 500m`, `수영 700m` | **수영 900m** (+200m씩, 매주 금요일 06:30) | 0.70 |

### 반복 패턴 (동일 제목 3회+)

| # | 유저가 등록한 할 일 | AI 예측 제안 | confidence |
|---|---------------------|-------------|-----------|
| 9 | `팀 미팅` × 5회 (월/수/금) | **팀 미팅** (매주 월/수/금 10:00) | 0.95 |
| 10 | `약 먹기` × 5회 (매일) | **약 먹기** (매일 09:00) | 0.95 |

### 제안이 생성되지 않는 경우 (빈 배열)

| # | 유저가 등록한 할 일 | AI 결과 | 이유 |
|---|---------------------|---------|------|
| - | `이사 견적`, `치과 예약`, `생일 선물` | **빈 배열** | 모두 1회씩만 등장 (단발성) |
| - | `장보기` × 2회 | **빈 배열** | 반복은 최소 3회 필요 (코드 가드에서 필터링) |

### v1.0.3 앱 호환성

- API 응답 스키마 (`title`, `reason`, `confidence`, `daysOfWeek`, `scheduledTime`, `suggestedCategoryId`) 변경 없음
- 프롬프트 + 서비스 내부 로직만 변경 → **클라이언트 대응 불필요**

## 🧪 테스트

### 테스트 방법

```bash
pnpm test
```

### 테스트 결과

- [x] 단위 테스트 54개 전체 통과
- [x] Gemini API 실제 호출 테스트 20개 시나리오 검증 (18/20 LLM 통과 + 코드 가드로 20/20)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #405