### PR TITLE
fix(mobile): iOS NativeTabs에서 useBottomTabBarHeight crash 수정 (#417)

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/feed/(feed)/friend/[friendId].tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/(feed)/friend/[friendId].tsx
@@ -1,4 +1,3 @@
-import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useGetFriendsQueryOptions } from '@src/features/friend/presentations/queries/use-get-friends-query-options';
 import { Calendar } from '@src/features/todo/presentations/components/Calendar/Calendar';
 import { FriendTodoList } from '@src/features/todo/presentations/components/FriendTodoList';
@@ -6,6 +5,7 @@ import { PokeBanner } from '@src/features/todo/presentations/components/PokeBann
 import { TODO_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-query-keys.constant';
 import { useFeedCalendar } from '@src/features/todo/presentations/providers/feed-calendar-provider';
 import { useRefresh } from '@src/shared/hooks/useRefresh';
+import { useTabBarHeight } from '@src/shared/hooks/useTabBarHeight';
 import { QueryErrorBoundary, Spacing } from '@src/shared/ui';
 import { useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { Redirect, useLocalSearchParams } from 'expo-router';
@@ -13,7 +13,7 @@ import { Suspense, useCallback, useMemo } from 'react';
 import { RefreshControl, ScrollView } from 'react-native';
 
 const FriendFeedScreen = () => {
-  const tabBarHeight = useBottomTabBarHeight();
+  const tabBarHeight = useTabBarHeight();
   const { friendId } = useLocalSearchParams<{ friendId: string }>();
   const { selectedDate } = useFeedCalendar();
   const queryClient = useQueryClient();

--- a/apps/mobile/app/(app)/(tabs)/feed/(feed)/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/(feed)/index.tsx
@@ -1,5 +1,4 @@
 import MagicIcon from '@assets/icons/ic_magic.svg';
-import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useGetSuggestionsQueryOptions } from '@src/features/ai/presentations/queries/use-get-suggestions-query-options';
 import { Calendar } from '@src/features/todo/presentations/components/Calendar/Calendar';
 import { TodoList } from '@src/features/todo/presentations/components/TodoList/TodoList';
@@ -8,6 +7,7 @@ import { useFeedCalendar } from '@src/features/todo/presentations/providers/feed
 import { UserPolicy } from '@src/features/user/models/user.model';
 import { useGetMeQueryOptions } from '@src/features/user/presentations/queries/use-get-me-query-options';
 import { useRefresh } from '@src/shared/hooks/useRefresh';
+import { useTabBarHeight } from '@src/shared/hooks/useTabBarHeight';
 import { Box, ListRow, QueryErrorBoundary, Spacing } from '@src/shared/ui';
 import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
@@ -17,7 +17,7 @@ import { RefreshControl } from 'react-native';
 import { NestableScrollContainer } from 'react-native-draggable-flatlist';
 
 const MyFeedScreen = () => {
-  const tabBarHeight = useBottomTabBarHeight();
+  const tabBarHeight = useTabBarHeight();
   const { selectedDate } = useFeedCalendar();
   const queryClient = useQueryClient();
   const invalidateTodos = useCallback(

--- a/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
@@ -1,9 +1,9 @@
-import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useDeleteAccountMutationOptions } from '@src/features/auth/presentations/queries/use-delete-account-mutation-options';
 import { useLogoutMutationOptions } from '@src/features/auth/presentations/queries/use-logout-mutation-options';
 import { UserPolicy } from '@src/features/user/models/user.model';
 import { ProfileCard } from '@src/features/user/presentations/components/ProfileCard';
 import { useGetMeQueryOptions } from '@src/features/user/presentations/queries/use-get-me-query-options';
+import { useTabBarHeight } from '@src/shared/hooks/useTabBarHeight';
 import {
   ConfirmDialog,
   H3,
@@ -22,7 +22,7 @@ import { Suspense } from 'react';
 import { ScrollView } from 'react-native';
 
 const MyPageScreen = () => {
-  const tabBarHeight = useBottomTabBarHeight();
+  const tabBarHeight = useTabBarHeight();
   const router = useRouter();
 
   return (

--- a/apps/mobile/src/shared/hooks/useTabBarHeight.ts
+++ b/apps/mobile/src/shared/hooks/useTabBarHeight.ts
@@ -1,0 +1,21 @@
+import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
+import { useContext } from 'react';
+
+/**
+ * Bottom Tab Bar 높이를 안전하게 반환하는 훅.
+ *
+ * `@react-navigation/bottom-tabs`의 `useBottomTabBarHeight()`는
+ * `BottomTabBarHeightContext`가 없으면 throw하지만, iOS Liquid Glass 환경에서
+ * 사용하는 `NativeTabs`(expo-router/unstable-native-tabs)는 이 context를 제공하지 않는다.
+ *
+ * - **Android** (`Tabs`): context가 존재하므로 실제 탭바 높이를 반환한다.
+ * - **iOS** (`NativeTabs`): context가 없으므로 `0`을 반환한다.
+ *   iOS는 네이티브에서 ScrollView content inset을 자동 처리하므로 수동 padding이 불필요하다.
+ *
+ * @see https://github.com/react-navigation/react-navigation/issues/12958 — NativeTabs에서 useBottomTabBarHeight 미지원
+ * @see https://docs.expo.dev/router/advanced/native-tabs/ — NativeTabs 자동 content inset 처리
+ */
+export function useTabBarHeight(): number {
+  const height = useContext(BottomTabBarHeightContext);
+  return height ?? 0;
+}


### PR DESCRIPTION
## 📋 개요

iOS Liquid Glass 환경에서 `NativeTabs` 사용 시 `useBottomTabBarHeight()` 훅이 `BottomTabBarHeightContext`를 찾지 못해 발생하는 Render Error를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `useTabBarHeight()` 커스텀 훅 생성 (`apps/mobile/src/shared/hooks/useTabBarHeight.ts`)
  - `BottomTabBarHeightContext`를 직접 `useContext`로 읽어, context가 없으면 `0` 반환
  - Android: `Tabs`가 context를 제공하므로 실제 탭바 높이 반환
  - iOS: `NativeTabs`는 context 미제공 → `0` 반환 (네이티브에서 content inset 자동 처리)
- 기존 3개 화면의 `useBottomTabBarHeight()` → `useTabBarHeight()`로 교체
  - `feed/(feed)/index.tsx` (MyFeedScreen)
  - `feed/(feed)/friend/[friendId].tsx` (FriendFeedScreen)
  - `mypage/index.tsx` (MyPageScreen)

## 🔍 근본 원인

| 플랫폼 | 탭 컴포넌트 | `BottomTabBarHeightContext` 제공 | 수동 padding 필요 |
|--------|------------|-------------------------------|------------------|
| Android | `Tabs` (expo-router) | ✅ | ✅ |
| iOS (Liquid Glass) | `NativeTabs` | ❌ → **crash** | ❌ (네이티브 자동 처리) |

- [react-navigation#12958](https://github.com/react-navigation/react-navigation/issues/12958) — NativeTabs에서 useBottomTabBarHeight 미지원
- [Expo Docs: Native Tabs](https://docs.expo.dev/router/advanced/native-tabs/) — NativeTabs 자동 content inset 처리

## 🧪 테스트

### 테스트 방법

1. iOS (Liquid Glass 지원 기기/시뮬레이터): feed/mypage 탭 진입 시 crash 없이 정상 렌더링 확인
2. Android: feed/mypage 탭에서 `paddingBottom`이 정상 적용되어 컨텐츠가 탭바에 가려지지 않는지 확인

### 테스트 결과

- [x] `pnpm lint` 통과
- [x] `pnpm typecheck` 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #417

## 📸 스크린샷 (UI 변경 시)

|          Before           |           After           |
| :-----------------------: | :-----------------------: |
| <!-- 변경 전 스크린샷 --> | <!-- 변경 후 스크린샷 --> |