### PR TITLE
feat(api,validators): 관리자 알림에 action 필드 추가 (#422)

### DIFF
--- a/apps/api/src/modules/admin/admin.service.spec.ts
+++ b/apps/api/src/modules/admin/admin.service.spec.ts
@@ -8,7 +8,10 @@
  *
  * @see https://docs.nestjs.com/recipes/suites
  */
-import { BROADCAST_TARGET_FILTER } from "@aido/validators";
+import {
+	BROADCAST_TARGET_FILTER,
+	NOTIFICATION_ACTION_TYPE,
+} from "@aido/validators";
 import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
 import { UserBuilder } from "@test/builders";
@@ -199,6 +202,88 @@ describe("AdminService", () => {
 			);
 		});
 
+		it("action에 URL이 있으면 metadata.externalUrl을 포함해야 한다", async () => {
+			// Given
+			const dto = {
+				title: "v1.0.4 업데이트",
+				body: "새로운 기능이 추가되었어요!",
+				targetFilter: BROADCAST_TARGET_FILTER.ALL,
+				action: {
+					type: NOTIFICATION_ACTION_TYPE.BROWSER,
+					url: "https://www.aido.kr/ko/patch-notes",
+				},
+			};
+
+			const userIds: UserIdOnly[] = [{ id: "user-1" }, { id: "user-2" }];
+			database.user.findMany.mockResolvedValue(userIds as never);
+			notificationService.createAndSendBatch.mockResolvedValue({
+				count: 2,
+			});
+
+			// When
+			await service.broadcastNotification(dto);
+
+			// Then
+			expect(notificationService.createAndSendBatch).toHaveBeenCalledWith([
+				{
+					userId: "user-1",
+					type: "ADMIN_BROADCAST",
+					title: "v1.0.4 업데이트",
+					body: "새로운 기능이 추가되었어요!",
+					action: {
+						type: NOTIFICATION_ACTION_TYPE.BROWSER,
+						url: "https://www.aido.kr/ko/patch-notes",
+					},
+					metadata: { externalUrl: "https://www.aido.kr/ko/patch-notes" },
+				},
+				{
+					userId: "user-2",
+					type: "ADMIN_BROADCAST",
+					title: "v1.0.4 업데이트",
+					body: "새로운 기능이 추가되었어요!",
+					action: {
+						type: NOTIFICATION_ACTION_TYPE.BROWSER,
+						url: "https://www.aido.kr/ko/patch-notes",
+					},
+					metadata: { externalUrl: "https://www.aido.kr/ko/patch-notes" },
+				},
+			]);
+		});
+
+		it("action에 URL이 없으면 metadata를 포함하지 않아야 한다", async () => {
+			// Given
+			const dto = {
+				title: "공지사항",
+				body: "안내 메시지",
+				targetFilter: BROADCAST_TARGET_FILTER.ALL,
+				action: {
+					type: NOTIFICATION_ACTION_TYPE.NONE,
+				},
+			};
+
+			const userIds: UserIdOnly[] = [{ id: "user-1" }];
+			database.user.findMany.mockResolvedValue(userIds as never);
+			notificationService.createAndSendBatch.mockResolvedValue({
+				count: 1,
+			});
+
+			// When
+			await service.broadcastNotification(dto);
+
+			// Then
+			expect(notificationService.createAndSendBatch).toHaveBeenCalledWith([
+				{
+					userId: "user-1",
+					type: "ADMIN_BROADCAST",
+					title: "공지사항",
+					body: "안내 메시지",
+					action: {
+						type: NOTIFICATION_ACTION_TYPE.NONE,
+					},
+				},
+			]);
+		});
+
 		it("구독자에게만 알림을 발송해야 한다", async () => {
 			// Given
 			const dto = {
@@ -325,6 +410,43 @@ describe("AdminService", () => {
 					type: "ADMIN_TARGETED",
 					title: "알림",
 					body: "메시지",
+				},
+			]);
+		});
+
+		it("action에 URL이 있으면 metadata.externalUrl을 포함해야 한다", async () => {
+			// Given
+			const dto = {
+				title: "개인 알림",
+				body: "확인해주세요",
+				userIds: ["user-1"],
+				action: {
+					type: NOTIFICATION_ACTION_TYPE.BROWSER,
+					url: "https://www.aido.kr/ko/patch-notes",
+				},
+			};
+
+			const userIds: UserIdOnly[] = [{ id: "user-1" }];
+			database.user.findMany.mockResolvedValue(userIds as never);
+			notificationService.createAndSendBatch.mockResolvedValue({
+				count: 1,
+			});
+
+			// When
+			await service.sendTargetedNotification(dto);
+
+			// Then
+			expect(notificationService.createAndSendBatch).toHaveBeenCalledWith([
+				{
+					userId: "user-1",
+					type: "ADMIN_TARGETED",
+					title: "개인 알림",
+					body: "확인해주세요",
+					action: {
+						type: NOTIFICATION_ACTION_TYPE.BROWSER,
+						url: "https://www.aido.kr/ko/patch-notes",
+					},
+					metadata: { externalUrl: "https://www.aido.kr/ko/patch-notes" },
 				},
 			]);
 		});

--- a/apps/api/src/modules/admin/admin.service.ts
+++ b/apps/api/src/modules/admin/admin.service.ts
@@ -33,7 +33,7 @@ export class AdminService {
 	async broadcastNotification(
 		dto: BroadcastNotificationDto,
 	): Promise<BroadcastResult> {
-		const { title, body, targetFilter } = dto;
+		const { title, body, targetFilter, action } = dto;
 		const whereClause = this.#buildTargetWhere(targetFilter);
 
 		let totalTargets = 0;
@@ -59,6 +59,7 @@ export class AdminService {
 					type: "ADMIN_BROADCAST" as const,
 					title,
 					body,
+					action,
 				}));
 
 				const result =
@@ -88,7 +89,7 @@ export class AdminService {
 	async sendTargetedNotification(
 		dto: TargetedNotificationDto,
 	): Promise<BroadcastResult> {
-		const { title, body, userIds } = dto;
+		const { title, body, userIds, action } = dto;
 
 		// 존재하는 사용자만 필터링
 		const existingUsers = await this.database.user.findMany({
@@ -115,6 +116,7 @@ export class AdminService {
 			type: "ADMIN_TARGETED" as const,
 			title,
 			body,
+			action,
 		}));
 
 		// 배치로 알림 생성 및 발송

--- a/apps/api/src/modules/admin/admin.service.ts
+++ b/apps/api/src/modules/admin/admin.service.ts
@@ -35,6 +35,7 @@ export class AdminService {
 	): Promise<BroadcastResult> {
 		const { title, body, targetFilter, action } = dto;
 		const whereClause = this.#buildTargetWhere(targetFilter);
+		const metadata = action?.url ? { externalUrl: action.url } : undefined;
 
 		let totalTargets = 0;
 		let successCount = 0;
@@ -60,6 +61,7 @@ export class AdminService {
 					title,
 					body,
 					action,
+					metadata,
 				}));
 
 				const result =
@@ -90,6 +92,7 @@ export class AdminService {
 		dto: TargetedNotificationDto,
 	): Promise<BroadcastResult> {
 		const { title, body, userIds, action } = dto;
+		const metadata = action?.url ? { externalUrl: action.url } : undefined;
 
 		// 존재하는 사용자만 필터링
 		const existingUsers = await this.database.user.findMany({
@@ -117,6 +120,7 @@ export class AdminService {
 			title,
 			body,
 			action,
+			metadata,
 		}));
 
 		// 배치로 알림 생성 및 발송

--- a/packages/validators/src/domains/admin/admin.request.ts
+++ b/packages/validators/src/domains/admin/admin.request.ts
@@ -27,7 +27,7 @@ export const broadcastNotificationSchema = z
     action: notificationActionSchema
       .optional()
       .describe(
-        '알림 클릭 시 액션 (BROWSER: 외부 브라우저, WEBVIEW: 인앱, DEEP_LINK: 내부 라우팅)',
+        '알림 클릭 시 액션 (BROWSER: 외부 브라우저, WEBVIEW: 인앱, DEEP_LINK: 내부 라우팅, NONE: 액션 없음)',
       ),
   })
   .describe('전체/조건부 알림 브로드캐스트 요청')
@@ -64,7 +64,7 @@ export const targetedNotificationSchema = z
     action: notificationActionSchema
       .optional()
       .describe(
-        '알림 클릭 시 액션 (BROWSER: 외부 브라우저, WEBVIEW: 인앱, DEEP_LINK: 내부 라우팅)',
+        '알림 클릭 시 액션 (BROWSER: 외부 브라우저, WEBVIEW: 인앱, DEEP_LINK: 내부 라우팅, NONE: 액션 없음)',
       ),
   })
   .describe('특정 사용자 대상 알림 요청')

--- a/packages/validators/src/domains/admin/admin.request.ts
+++ b/packages/validators/src/domains/admin/admin.request.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { notificationActionSchema } from '../notification/notification.payload';
 import { BROADCAST_TARGET_FILTER, BROADCAST_TARGET_FILTERS } from './admin.constants';
 
 /**
@@ -22,6 +23,11 @@ export const broadcastNotificationSchema = z
       .default(BROADCAST_TARGET_FILTER.ALL)
       .describe(
         '알림 대상 필터 (ALL: 전체, WITH_PUSH_TOKEN: 푸시 토큰 보유, ACTIVE_LAST_7_DAYS: 7일 내 활동, ACTIVE_LAST_30_DAYS: 30일 내 활동, SUBSCRIBERS: 유료 구독)',
+      ),
+    action: notificationActionSchema
+      .optional()
+      .describe(
+        '알림 클릭 시 액션 (BROWSER: 외부 브라우저, WEBVIEW: 인앱, DEEP_LINK: 내부 라우팅)',
       ),
   })
   .describe('전체/조건부 알림 브로드캐스트 요청')
@@ -55,6 +61,11 @@ export const targetedNotificationSchema = z
       .min(1, '최소 1명의 사용자를 선택해주세요')
       .max(1000, '최대 1000명까지 선택할 수 있습니다')
       .describe('알림 대상 사용자 ID 목록'),
+    action: notificationActionSchema
+      .optional()
+      .describe(
+        '알림 클릭 시 액션 (BROWSER: 외부 브라우저, WEBVIEW: 인앱, DEEP_LINK: 내부 라우팅)',
+      ),
   })
   .describe('특정 사용자 대상 알림 요청')
   .meta({


### PR DESCRIPTION
## 📋 개요

관리자 알림(브로드캐스트/타겟) 발송 시 알림 클릭 액션을 지정할 수 있도록 `action` 필드를 추가합니다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [x] `packages/validators` - Zod 스키마

## 📝 변경 내용

- `broadcastNotificationSchema`에 optional `action` 필드 추가 (`notificationActionSchema` 재사용)
- `targetedNotificationSchema`에 optional `action` 필드 추가
- `AdminService.broadcastNotification()`에서 알림 생성 시 `action` 데이터 포함
- `AdminService.sendTargetedNotification()`에서 알림 생성 시 `action` 데이터 포함

## 🧪 테스트

### 테스트 방법

```bash
pnpm lint
pnpm typecheck
```

### 테스트 결과

- [x] lint 통과
- [x] typecheck 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #422