### PR TITLE
fix(mobile): 카테고리 색상 변경 시 캘린더 투두 쿼리 무효화 

### DIFF
--- a/apps/mobile/src/features/todo/presentations/queries/use-update-todo-category-mutation-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-update-todo-category-mutation-options.ts
@@ -9,6 +9,7 @@ import { useAppToast } from '@src/shared/hooks/useAppToast';
 import { mutationOptions, useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { TODO_CATEGORY_QUERY_KEYS } from '../constants/todo-category-query-keys.constant';
+import { TODO_QUERY_KEYS } from '../constants/todo-query-keys.constant';
 
 interface UpdateTodoCategoryParams {
   id: number;
@@ -47,6 +48,9 @@ export const useUpdateTodoCategoryMutationOptions = () => {
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: TODO_CATEGORY_QUERY_KEYS.all });
+      queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.ranges() });
+      queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.lists() });
+      queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.completions() });
       toast.success('카테고리를 수정했어요');
       trackEvent('category_updated', {
         field: variables.input.color ? 'color' : 'name',


### PR DESCRIPTION
## 📋 개요

카테고리 색상 변경 시 캘린더 뷰의 투두 표시 색상이 반영되지 않는 버그를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `useUpdateTodoCategoryMutationOptions`의 `onSuccess`에서 투두 관련 쿼리 무효화 추가
  - `TODO_QUERY_KEYS.ranges()` — 캘린더 뷰 범위 데이터 (카테고리 색상 포함)
  - `TODO_QUERY_KEYS.lists()` — 날짜별 투두 리스트 (카테고리 색상 포함)
  - `TODO_QUERY_KEYS.completions()` — 캘린더 달성 표시 (`categoryColors` 포함)

## 🧪 테스트

### 테스트 결과

- [x] 수동 테스트 완료
  - 카테고리 색상 변경 → 캘린더 뷰로 이동 → 변경된 색상 즉시 반영 확인

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

### 리뷰어 확인

- [ ] 코드 로직이 올바릅니다
- [ ] 에러 처리가 적절합니다
- [ ] 보안 취약점이 없습니다
- [ ] 성능 이슈가 없습니다

## 🔗 관련 이슈

Closes #450

## 📸 스크린샷 (UI 변경 시)

UI 변경 없음 (쿼리 무효화 로직 추가)

## 💬 추가 정보

기존에는 `TODO_CATEGORY_QUERY_KEYS.all`만 무효화하여 카테고리 목록은 갱신되었으나, 투두 데이터에 포함된 카테고리 색상은 캐시된 상태로 남아있었음. nudge, AI usage 등 색상과 무관한 쿼리는 무효화하지 않음.