### PR TITLE
fix(mobile): 백그라운드 전환 시 키보드 바텀시트 위치 깨짐 수정 

### DIFF
--- a/apps/mobile/src/shared/ui/BottomSheet/KeyboardBottomSheet.tsx
+++ b/apps/mobile/src/shared/ui/BottomSheet/KeyboardBottomSheet.tsx
@@ -12,6 +12,8 @@ import {
   useRef,
 } from 'react';
 import {
+  AppState,
+  type AppStateStatus,
   Keyboard,
   type LayoutChangeEvent,
   Platform,
@@ -69,19 +71,29 @@ export const KeyboardBottomSheet = ({
   }, [isOpen, setEnabled]);
 
   useEffect(() => {
+    if (!isOpen) return;
+
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
     const hideSubscription = Keyboard.addListener(hideEvent, () => {
-      if (!isOpen || isClosingRef.current) {
-        return;
-      }
+      if (isClosingRef.current) return;
 
       requestAnimationFrame(() => {
         sheetRef.current?.snapToIndex(SHEET_INDEX.OPEN);
       });
     });
 
+    const appStateSubscription = AppState.addEventListener(
+      'change',
+      (nextState: AppStateStatus) => {
+        if (nextState === 'background' && !isClosingRef.current) {
+          Keyboard.dismiss();
+        }
+      },
+    );
+
     return () => {
       hideSubscription.remove();
+      appStateSubscription.remove();
     };
   }, [isOpen]);
 


### PR DESCRIPTION
## 📋 개요

키보드 바텀시트가 열린 상태에서 앱을 백그라운드로 보냈다가 복귀하면 시트 위치가 깨지는 버그를 수정합니다.

<img width="200" height="600" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-03-26 at 20 24 51" src="https://github.com/user-attachments/assets/fb1203a7-d6da-44eb-87c4-2dea706fa48d" />

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `KeyboardBottomSheet`에 `AppState` 리스너 추가
- 백그라운드 진입 시 `Keyboard.dismiss()`를 선제적으로 호출하여 가짜 키보드 이벤트로 인한 gorhom snap point 오염 방지
- `isOpen`이 false일 때 이벤트 리스너 등록 스킵하도록 early return 추가

## 🧪 테스트

### 테스트 방법

시뮬레이터에서 수동 테스트:
1. 할일 추가 바텀시트 열기 (키보드 올라온 상태)
2. 백그라운드 전환 → 복귀 반복 
3. 시트 위치가 정상인지 확인

### 테스트 결과

- [x] 수동 테스트 완료
- [x] 빌드 통과 (`pnpm build`)
- [x] 타입체크 통과 (`pnpm typecheck`)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [ ] 변경사항에 대한 테스트를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

## 🔗 관련 이슈

Closes #462

## 📸 스크린샷 (UI 변경 시)


아이폰 시뮬레이터 영상
https://github.com/user-attachments/assets/917c3e81-b7da-46dc-b65f-b7757811bb0a
안드 시뮬레이터 영상
https://github.com/user-attachments/assets/12fbf2df-1e14-4206-9606-4de3ab078aab

- 아이폰 ios26버전은 실기기에서 확인 

## 💬 추가 정보

### 근본 원인
iOS/Android가 백그라운드 전환 시 `keyboardWillShow(height:0)` 가짜 이벤트를 반복 발생시킵니다.
gorhom의 `useAnimatedKeyboard`가 이 이벤트를 처리하면서 내부 snap point 계산이 오염되어
`onAnimate: 0 → 426` 같은 잘못된 위치로 시트가 이동합니다.

### 해결 전략
포그라운드 복귀 시 `snapToIndex(OPEN)` 재동기화를 시도했으나, gorhom 내부 상태가 이미 오염된 후라 효과 없음.
대신 **백그라운드 진입 시점에 키보드를 선제적으로 dismiss**하여 가짜 이벤트가 gorhom 상태를 오염시키기 전에 정리하는 방식으로 해결.