### PR TITLE
fix(mobile): AI 제안 카테고리 바텀시트 자동 열림 수정 

### DIFF
--- a/apps/mobile/src/features/ai/presentations/components/SuggestionsList.tsx
+++ b/apps/mobile/src/features/ai/presentations/components/SuggestionsList.tsx
@@ -155,10 +155,7 @@ function SuggestionCard({
           onOpenChange={(open) => {
             if (!open) closeSheet();
           }}
-          onAccepted={() => {
-            closeSheet();
-            onAccepted();
-          }}
+          onAccepted={onAccepted}
         />
       );
     });


### PR DESCRIPTION
## 📋 개요

구독 유저가 AI 제안 화면 진입 시 카테고리 선택 바텀시트가 자동으로 열리는 버그 수정. `SuggestionCategoryBottomSheet`를 인라인 렌더링에서 `useOverlay` 기반으로 전환.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `SuggestionCategoryBottomSheet`를 인라인 렌더링에서 `useOverlay` 기반으로 전환
- 수락 버튼 클릭 시에만 오버레이로 바텀시트 마운트되도록 변경
- `categorySheetSuggestionId` state 제거, `openCategorySheet`를 `SuggestionCard`로 이동

## 🧪 테스트

### 테스트 결과

- [x] 수동 테스트 완료

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

### 리뷰어 확인

- [ ] 코드 로직이 올바릅니다
- [ ] 에러 처리가 적절합니다
- [ ] 보안 취약점이 없습니다
- [ ] 성능 이슈가 없습니다

## 🔗 관련 이슈

Closes #465

## 📸 스크린샷 (UI 변경 시)

<img width="200" height="600" alt="Screenshot_1774567931" src="https://github.com/user-attachments/assets/5e3fac73-1447-4194-8677-799696079032" />
<img width="200" height="600" alt="Screenshot_1774567929" src="https://github.com/user-attachments/assets/6d5e14e6-bab4-4415-bdde-dea11e5d9bb5" />
<img width="200" height="600" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-03-27 at 08 26 03" src="https://github.com/user-attachments/assets/8db8211a-a62f-4742-8b30-008f32306c0c" />
<img width="200" height="600" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-03-27 at 08 25 58" src="https://github.com/user-attachments/assets/c1674c42-3209-49be-8035-8e99b1572b0f" />


## 💬 추가 정보

gorhom bottom-sheet의 `enableDynamicSizing` + `index={-1}` 조합에서 초기 마운트 시 레이아웃 계산 중 시트가 잠깐 열리는 플래시 현상이 원인. 오버레이 패턴으로 필요 시에만 마운트하여 해결.