### PR TITLE
fix(mobile): 시간 피커 spinner 레이아웃 개선

### DIFF
--- a/apps/mobile/src/features/todo/presentations/components/TodoTimePickerContent.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoTimePickerContent.tsx
@@ -108,7 +108,7 @@ export const TodoTimePickerContent = ({
           disabled={localIsAllDay}
         />
         {!localIsAllDay && isIOS && (
-          <View className="h-[216px] items-center">
+          <View className="items-center">
             <DateTimePicker
               value={getDateWithTime(draftDate, localTime, DEFAULT_TIME)}
               mode="time"


### PR DESCRIPTION
## 📋 개요

iOS `DateTimePicker`의 `display="compact"` 모드가 바깥 탭 시 닫히는 문제로 `display="spinner"`로 변경하고, spinner를 별도 영역으로 분리하여 레이아웃 개선

## 🏷️ 변경 유형


- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위


- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- iOS 시간 피커를 `compact` → `spinner`로 변경하여 바깥 탭 시 닫히는 문제 해결
- spinner를 "시간" ListRow의 `right` 슬롯에서 분리하여 아래 별도 영역에 배치
- "시간" ListRow의 `right`에는 `formatTimeDisplay`로 현재 시간 텍스트만 표시
- `overflow-hidden`으로 spinner 하이라이트 바가 둥근 컨테이너 밖으로 넘어가지 않도록 처리

## 🧪 테스트

### 테스트 결과

- [x] 수동 테스트 완료

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [ ] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

## 📸 스크린샷 (UI 변경 시)
<img width="200" height="600" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-03-27 at 13 50 02" src="https://github.com/user-attachments/assets/0b5f7058-1f02-48b3-a291-0cee883bc1f0" />
<img width="200" height="600" alt="Screenshot_1774587010" src="https://github.com/user-attachments/assets/2ddc5602-b530-4083-822b-7c642c7895bf" />

안드 많이 못생겨서 다른 라이브러리 찾을까 고민이지만 일단 이전꺼가 불편해서 수정 

## 💬 추가 정보

- 알림 설정의 오전/오후 리마인드 시간 피커와 동일한 패턴(View + height 216 + alignItems center) 적용
- Android 동작은 기존과 동일 (탭 시 모달 spinner)