### PR TITLE
refactor(api): 알림 DB 적재를 pushEnabled와 분리 및 야간 면제/스케줄 정비 (#478)

### DIFF
--- a/apps/api/src/modules/notification/push-delivery.service.spec.ts
+++ b/apps/api/src/modules/notification/push-delivery.service.spec.ts
@@ -285,8 +285,8 @@ describe("PushDeliveryService", () => {
 			expect(result).toBe(true);
 		});
 
-		it("야간이지만 NUDGE_RECEIVED는 nightPushEnabled=false여도 발송한다", async () => {
-			// Given
+		it("야간이지만 WEATHER_MORNING은 nightPushEnabled=false여도 발송한다", async () => {
+			// Given — 사용자가 직접 선택한 아침 시간이므로 야간 면제 필수
 			userPreferenceRepository.findByUserId.mockResolvedValue(
 				UserPreferenceBuilder.create("user-1")
 					.withTimezone("Asia/Seoul")
@@ -295,7 +295,7 @@ describe("PushDeliveryService", () => {
 			mockedIsNightTime.mockReturnValue(true);
 
 			// When
-			const result = await service.shouldSendPush("user-1", "NUDGE_RECEIVED");
+			const result = await service.shouldSendPush("user-1", "WEATHER_MORNING");
 
 			// Then
 			expect(result).toBe(true);

--- a/apps/api/src/modules/notification/push-delivery.service.ts
+++ b/apps/api/src/modules/notification/push-delivery.service.ts
@@ -40,11 +40,10 @@ const MARKETING_NOTIFICATION_TYPES: ReadonlySet<NotificationType> = new Set([
 /**
  * 야간 시간(21:00-08:00)에도 푸시를 발송하는 알림 타입
  *
- * 사용자가 직접 트리거한 액션의 결과 알림은 야간에도 발송한다:
- * - NUDGE_RECEIVED: 긴급성 있는 실시간 소셜 인터랙션
+ * - WEATHER_MORNING: 사용자가 직접 선택한 아침 시간, 못 받으면 무의미
  */
 const NIGHT_EXEMPT_NOTIFICATION_TYPES: ReadonlySet<NotificationType> = new Set([
-	"NUDGE_RECEIVED",
+	"WEATHER_MORNING",
 ]);
 
 @Injectable()

--- a/apps/api/src/modules/scheduler/constants/reminder.constants.ts
+++ b/apps/api/src/modules/scheduler/constants/reminder.constants.ts
@@ -48,5 +48,5 @@ export const NOTIFICATION_SCHEDULE = {
 	WINBACK: { hour: 12, minute: 0 },
 	NUDGE_SUGGEST: { hour: 14, minute: 0 },
 	LUNCH_NUDGE: { hour: 12, minute: 30 },
-	STREAK_AT_RISK: { hour: 21, minute: 0 },
+	STREAK_AT_RISK: { hour: 20, minute: 0 },
 } as const;

--- a/apps/api/src/modules/scheduler/jobs/strategies/evening-reminder.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/evening-reminder.strategy.ts
@@ -48,7 +48,6 @@ export class EveningReminderStrategy implements ITimezoneStrategy {
 				OR: [{ subscriptionStatus: "ACTIVE" }, { role: "ADMIN" }],
 				preference: {
 					timezone: tz,
-					pushEnabled: true,
 					eveningReminderHour: localHour,
 					eveningReminderMinute: localMinute,
 				},
@@ -71,7 +70,7 @@ export class EveningReminderStrategy implements ITimezoneStrategy {
 				where: {
 					subscriptionStatus: { not: "ACTIVE" },
 					role: { not: "ADMIN" },
-					preference: { timezone: tz, pushEnabled: true },
+					preference: { timezone: tz },
 					todos: {
 						some: { startDate: { gte: today, lt: tomorrow } },
 					},

--- a/apps/api/src/modules/scheduler/jobs/strategies/lunch-nudge.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/lunch-nudge.strategy.ts
@@ -34,7 +34,7 @@ export class LunchNudgeStrategy implements ITimezoneStrategy {
 		// 오늘 할일이 있지만 완료가 0개인 유저 조회
 		const users = await this.database.user.findMany({
 			where: {
-				preference: { timezone: tz, pushEnabled: true },
+				preference: { timezone: tz },
 				todos: {
 					some: { startDate: { gte: today, lt: tomorrow } },
 					none: {

--- a/apps/api/src/modules/scheduler/jobs/strategies/monthly-report.strategy.spec.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/monthly-report.strategy.spec.ts
@@ -61,7 +61,7 @@ describe("MonthlyReportStrategy", () => {
 	// 프리미엄 유저 대상 발송
 	// =========================================================================
 
-	it("프리미엄 pushEnabled 유저에게만 월간 리포트를 발송한다", async () => {
+	it("프리미엄 유저 전체에게 월간 리포트를 발송한다", async () => {
 		const ctx = makeCtx();
 
 		database.user.findMany.mockResolvedValueOnce([{ id: "user-1" }] as never);
@@ -70,12 +70,12 @@ describe("MonthlyReportStrategy", () => {
 
 		expect(result).toEqual({ sent: 1 });
 
-		// AI 리포트는 유료 기능 → 프리미엄 유저만 조회
+		// AI 리포트는 유료 기능 → 프리미엄 유저만 조회 (push 여부는 PushDeliveryService가 판단)
 		expect(database.user.findMany).toHaveBeenCalledTimes(1);
 		expect(database.user.findMany).toHaveBeenCalledWith(
 			expect.objectContaining({
 				where: expect.objectContaining({
-					preference: { timezone: TZ, pushEnabled: true },
+					preference: { timezone: TZ },
 					OR: [{ subscriptionStatus: "ACTIVE" }, { role: "ADMIN" }],
 				}),
 			}),

--- a/apps/api/src/modules/scheduler/jobs/strategies/monthly-report.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/monthly-report.strategy.ts
@@ -25,10 +25,10 @@ export class MonthlyReportStrategy implements ITimezoneStrategy {
 		const today = todayInTimezone(tz);
 		const monthAgo = subtractMonths(1, today);
 
-		// 오케스트레이터가 매월 1일 10:00에만 호출 → 프리미엄 pushEnabled 유저 대상
+		// 오케스트레이터가 매월 1일 10:00에만 호출 → 프리미엄 유저 대상
 		const users = await this.database.user.findMany({
 			where: {
-				preference: { timezone: tz, pushEnabled: true },
+				preference: { timezone: tz },
 				OR: [{ subscriptionStatus: "ACTIVE" }, { role: "ADMIN" }],
 				todos: { some: { startDate: { gte: monthAgo, lt: today } } },
 			},

--- a/apps/api/src/modules/scheduler/jobs/strategies/morning-reminder.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/morning-reminder.strategy.ts
@@ -44,7 +44,6 @@ export class MorningReminderStrategy implements ITimezoneStrategy {
 				OR: [{ subscriptionStatus: "ACTIVE" }, { role: "ADMIN" }],
 				preference: {
 					timezone: tz,
-					pushEnabled: true,
 					morningReminderHour: localHour,
 					morningReminderMinute: localMinute,
 				},
@@ -64,7 +63,7 @@ export class MorningReminderStrategy implements ITimezoneStrategy {
 				where: {
 					subscriptionStatus: { not: "ACTIVE" },
 					role: { not: "ADMIN" },
-					preference: { timezone: tz, pushEnabled: true },
+					preference: { timezone: tz },
 				},
 				select: selectClause,
 			});

--- a/apps/api/src/modules/scheduler/jobs/strategies/nudge-suggest.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/nudge-suggest.strategy.ts
@@ -36,11 +36,11 @@ export class NudgeSuggestStrategy implements ITimezoneStrategy {
 		const weekAgo = subtractDays(7, today);
 		const twoDaysAgo = subtractDays(2, today);
 
-		// 이 타임존에서 pushEnabled인 유저 목록
+		// 이 타임존의 활성 유저 목록
 		const activeUsers = await this.database.user.findMany({
 			where: {
 				deletedAt: null,
-				preference: { timezone: tz, pushEnabled: true },
+				preference: { timezone: tz },
 			},
 			select: { id: true },
 		});

--- a/apps/api/src/modules/scheduler/jobs/strategies/onboarding.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/onboarding.strategy.ts
@@ -33,11 +33,11 @@ export class OnboardingStrategy implements ITimezoneStrategy {
 		const today = todayInTimezone(tz);
 		const cutoffDate = subtractDays(ONBOARDING_MAX_DAY, today);
 
-		// 가입 0~7일 + pushEnabled + 해당 timezone 유저 조회
+		// 가입 0~7일 + 해당 timezone 유저 조회
 		const users = await this.database.user.findMany({
 			where: {
 				createdAt: { gte: cutoffDate },
-				preference: { timezone: tz, pushEnabled: true },
+				preference: { timezone: tz },
 			},
 			select: { id: true, createdAt: true },
 		});

--- a/apps/api/src/modules/scheduler/jobs/strategies/social-digest.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/social-digest.strategy.ts
@@ -26,10 +26,10 @@ export class SocialDigestStrategy implements ITimezoneStrategy {
 		const today = todayInTimezone(tz);
 		const tomorrow = addDays(1, today);
 
-		// pushEnabled + 해당 타임존 + 오늘 투두 미완료인 유저 조회
+		// 해당 타임존 + 오늘 투두 미완료인 유저 조회
 		const users = await this.database.user.findMany({
 			where: {
-				preference: { timezone: tz, pushEnabled: true },
+				preference: { timezone: tz },
 				todos: {
 					some: {
 						startDate: { gte: today, lt: tomorrow },

--- a/apps/api/src/modules/scheduler/jobs/strategies/streak-at-risk.strategy.spec.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/streak-at-risk.strategy.spec.ts
@@ -21,15 +21,15 @@ describe("StreakAtRiskStrategy", () => {
 
 	const TZ = "Asia/Seoul";
 
-	/** KST 2024-01-16 21:00 = UTC 2024-01-16T12:00:00Z */
-	const FAKE_NOW = new Date("2024-01-16T12:00:00Z");
+	/** KST 2024-01-16 20:00 = UTC 2024-01-16T11:00:00Z */
+	const FAKE_NOW = new Date("2024-01-16T11:00:00Z");
 
 	const TODAY = dayjs.utc("2024-01-16").startOf("day").toDate();
 	const YESTERDAY = dayjs.utc("2024-01-15").startOf("day").toDate();
 
 	const makeCtx = (overrides?: Partial<TimezoneContext>): TimezoneContext => ({
 		tz: TZ,
-		localHour: 21,
+		localHour: 20,
 		localMinute: 0,
 		dayOfWeek: 2,
 		today: TODAY,

--- a/apps/api/src/modules/scheduler/jobs/strategies/streak-at-risk.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/streak-at-risk.strategy.ts
@@ -13,11 +13,11 @@ import type {
 } from "./timezone-reminder-strategy.interface";
 
 /**
- * 스트릭 위기 Strategy (21:00)
+ * 스트릭 위기 Strategy (20:00)
  *
  * 스트릭 3일 이상인 유저 중 오늘 할일을 아직 다 완료하지 못한 유저에게
  * 스트릭 위기 알림을 발송합니다.
- * 고정 시간(21:00) 전용 — 프리미엄 커스텀 시간 미지원.
+ * 고정 시간(20:00) 전용 — 야간(21:00) 시작 전 마지막 넛지.
  */
 @Injectable()
 export class StreakAtRiskStrategy implements ITimezoneStrategy {
@@ -38,7 +38,6 @@ export class StreakAtRiskStrategy implements ITimezoneStrategy {
 			where: {
 				preference: {
 					timezone: tz,
-					pushEnabled: true,
 					currentStreak: { gte: 3 },
 				},
 				todos: {

--- a/apps/api/src/modules/scheduler/jobs/strategies/weather-evening.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/weather-evening.strategy.ts
@@ -50,7 +50,6 @@ export class WeatherEveningStrategy implements ITimezoneStrategy {
 				status: "ACTIVE",
 				deletedAt: null,
 				preference: {
-					pushEnabled: true,
 					weatherEveningEnabled: true,
 					timezone: tz,
 					weatherEveningHour: localHour,

--- a/apps/api/src/modules/scheduler/jobs/strategies/weather-morning.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/weather-morning.strategy.ts
@@ -50,7 +50,6 @@ export class WeatherMorningStrategy implements ITimezoneStrategy {
 				status: "ACTIVE",
 				deletedAt: null,
 				preference: {
-					pushEnabled: true,
 					weatherMorningEnabled: true,
 					timezone: tz,
 					weatherMorningHour: localHour,

--- a/apps/api/src/modules/scheduler/jobs/strategies/weekly-achievement.strategy.spec.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/weekly-achievement.strategy.spec.ts
@@ -50,7 +50,6 @@ describe("WeeklyAchievementStrategy", () => {
 
 		// 기본 mock 설정
 		(database.todo.groupBy as jest.Mock).mockResolvedValue([]);
-		database.user.findMany.mockResolvedValue([]);
 		notificationService.findAlreadyNotifiedUserIds.mockResolvedValue(new Set());
 		notificationService.createAndSendBatch.mockResolvedValue(
 			undefined as never,
@@ -164,9 +163,6 @@ describe("WeeklyAchievementStrategy", () => {
 				{ userId: "user-push-off", _count: { id: 2 } },
 			]);
 
-		// pushEnabled=true인 유저만 알림 대상
-		database.user.findMany.mockResolvedValue([{ id: "user-push-on" }] as never);
-
 		// When
 		await strategy.execute(ctx);
 
@@ -188,34 +184,34 @@ describe("WeeklyAchievementStrategy", () => {
 	});
 
 	// =========================================================================
-	// pushEnabled=false → 알림 미발송
+	// completedTodos > 0인 모든 유저에게 알림 발송
 	// =========================================================================
 
-	it("pushEnabled=false 유저는 알림을 발송하지 않는다", async () => {
+	it("completedTodos > 0인 모든 유저에게 알림을 발송한다", async () => {
 		// Given
 		const ctx = makeCtx();
 
 		(database.todo.groupBy as jest.Mock)
 			.mockResolvedValueOnce([
-				{ userId: "user-push-on", _count: { id: 5 } },
-				{ userId: "user-push-off", _count: { id: 3 } },
+				{ userId: "user-1", _count: { id: 5 } },
+				{ userId: "user-2", _count: { id: 3 } },
 			])
 			.mockResolvedValueOnce([
-				{ userId: "user-push-on", _count: { id: 4 } },
-				{ userId: "user-push-off", _count: { id: 2 } },
+				{ userId: "user-1", _count: { id: 4 } },
+				{ userId: "user-2", _count: { id: 2 } },
 			]);
-
-		database.user.findMany.mockResolvedValue([{ id: "user-push-on" }] as never);
 
 		// When
 		const result = await strategy.execute(ctx);
 
-		// Then — 알림은 pushEnabled=true인 유저만
-		expect(result).toEqual({ sent: 1 });
+		// Then — completedTodos > 0인 두 유저 모두 알림 발송
+		expect(result).toEqual({ sent: 2 });
 		const notifications =
 			notificationService.createAndSendBatch.mock.calls[0]?.[0];
-		expect(notifications).toHaveLength(1);
-		expect(notifications?.[0]?.userId).toBe("user-push-on");
+		expect(notifications).toHaveLength(2);
+		expect(notifications?.map((n: { userId: string }) => n.userId)).toEqual(
+			expect.arrayContaining(["user-1", "user-2"]),
+		);
 	});
 
 	// =========================================================================
@@ -261,11 +257,6 @@ describe("WeeklyAchievementStrategy", () => {
 				{ userId: "user-1", _count: { id: 2 } },
 				{ userId: "user-2", _count: { id: 3 } },
 			]);
-
-		database.user.findMany.mockResolvedValue([
-			{ id: "user-1" },
-			{ id: "user-2" },
-		] as never);
 
 		// user-1은 이미 알림 받음
 		notificationService.findAlreadyNotifiedUserIds.mockResolvedValue(

--- a/apps/api/src/modules/scheduler/jobs/strategies/weekly-achievement.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/weekly-achievement.strategy.ts
@@ -71,7 +71,7 @@ export class WeeklyAchievementStrategy implements ITimezoneStrategy {
 		// ─── B. 기록 저장 (모든 유저 — pushEnabled/dedup 무관) ─────
 		await this.weeklyAchievementService.upsertMany(records);
 
-		// ─── C. 알림 발송 (pushEnabled + completed > 0 + dedup) ────
+		// ─── C. 알림 발송 (completed > 0 + dedup) ────
 		const notifiableUserIds = records
 			.filter((r) => r.completedTodos > 0)
 			.map((r) => r.userId);
@@ -80,27 +80,15 @@ export class WeeklyAchievementStrategy implements ITimezoneStrategy {
 			return { sent: 0 };
 		}
 
-		const [pushEnabledUsers, alreadyNotified] = await Promise.all([
-			this.database.user.findMany({
-				where: {
-					id: { in: notifiableUserIds },
-					preference: { pushEnabled: true },
-				},
-				select: { id: true },
-			}),
-			this.notificationService.findAlreadyNotifiedUserIds({
+		const alreadyNotified =
+			await this.notificationService.findAlreadyNotifiedUserIds({
 				userIds: notifiableUserIds,
 				type: "WEEKLY_ACHIEVEMENT",
 				notificationDate: today,
-			}),
-		]);
+			});
 
-		const pushEnabledSet = new Set(pushEnabledUsers.map((u) => u.id));
 		const finalRecords = records.filter(
-			(r) =>
-				r.completedTodos > 0 &&
-				pushEnabledSet.has(r.userId) &&
-				!alreadyNotified.has(r.userId),
+			(r) => r.completedTodos > 0 && !alreadyNotified.has(r.userId),
 		);
 
 		if (finalRecords.length === 0) {

--- a/apps/api/src/modules/scheduler/jobs/strategies/weekly-report.strategy.spec.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/weekly-report.strategy.spec.ts
@@ -60,7 +60,7 @@ describe("WeeklyReportStrategy", () => {
 	// 프리미엄 유저 대상 발송
 	// =========================================================================
 
-	it("프리미엄 pushEnabled 유저에게만 주간 리포트를 발송한다", async () => {
+	it("프리미엄 유저 전체에게 주간 리포트를 발송한다", async () => {
 		const ctx = makeCtx();
 
 		database.user.findMany.mockResolvedValueOnce([{ id: "user-1" }] as never);
@@ -69,12 +69,12 @@ describe("WeeklyReportStrategy", () => {
 
 		expect(result).toEqual({ sent: 1 });
 
-		// AI 리포트는 유료 기능 → 프리미엄 유저만 조회
+		// AI 리포트는 유료 기능 → 프리미엄 유저만 조회 (pushEnabled 필터 없음, 푸시 전송은 PushDeliveryService가 담당)
 		expect(database.user.findMany).toHaveBeenCalledTimes(1);
 		expect(database.user.findMany).toHaveBeenCalledWith(
 			expect.objectContaining({
 				where: expect.objectContaining({
-					preference: { timezone: TZ, pushEnabled: true },
+					preference: { timezone: TZ },
 					OR: [{ subscriptionStatus: "ACTIVE" }, { role: "ADMIN" }],
 				}),
 			}),

--- a/apps/api/src/modules/scheduler/jobs/strategies/weekly-report.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/weekly-report.strategy.ts
@@ -25,10 +25,10 @@ export class WeeklyReportStrategy implements ITimezoneStrategy {
 		const today = todayInTimezone(tz);
 		const weekAgo = subtractDays(7, today);
 
-		// 오케스트레이터가 월요일 09:00에만 호출 → 프리미엄 pushEnabled 유저 대상
+		// 오케스트레이터가 월요일 09:00에만 호출 → 프리미엄 유저 대상
 		const users = await this.database.user.findMany({
 			where: {
-				preference: { timezone: tz, pushEnabled: true },
+				preference: { timezone: tz },
 				OR: [{ subscriptionStatus: "ACTIVE" }, { role: "ADMIN" }],
 				todos: { some: { startDate: { gte: weekAgo, lt: today } } },
 			},

--- a/apps/api/src/modules/scheduler/jobs/strategies/winback.strategy.ts
+++ b/apps/api/src/modules/scheduler/jobs/strategies/winback.strategy.ts
@@ -36,10 +36,10 @@ export class WinbackStrategy implements ITimezoneStrategy {
 		const cutoffStart = subtractDays(30, today);
 		const cutoffEnd = subtractDays(3, today);
 
-		// 3~30일 미접속 + pushEnabled 유저
+		// 3~30일 미접속 유저
 		const users = await this.database.user.findMany({
 			where: {
-				preference: { timezone: tz, pushEnabled: true },
+				preference: { timezone: tz },
 				lastActiveAt: { gte: cutoffStart, lte: cutoffEnd },
 			},
 			select: { id: true, lastActiveAt: true },

--- a/apps/api/src/modules/scheduler/jobs/timezone-aware-reminder.job.spec.ts
+++ b/apps/api/src/modules/scheduler/jobs/timezone-aware-reminder.job.spec.ts
@@ -50,7 +50,6 @@ describe("TimezoneAwareReminderJob", () => {
 
 		// 캐시 pass-through: factory를 그대로 실행
 		cacheService.wrapActiveTimezones.mockImplementation((factory) => factory());
-		cacheService.wrapAllTimezones.mockImplementation((factory) => factory());
 		morningReminder = unitRef.get(MorningReminderStrategy);
 		eveningReminder = unitRef.get(EveningReminderStrategy);
 		weeklyAchievement = unitRef.get(WeeklyAchievementStrategy);
@@ -80,7 +79,7 @@ describe("TimezoneAwareReminderJob", () => {
 	// =========================================================================
 
 	describe("handleMinuteSweep", () => {
-		it("pushEnabled=true 타임존 목록을 조회하고 각 타임존별 Strategy를 호출한다", async () => {
+		it("모든 타임존 목록을 조회하고 각 타임존별 Strategy를 호출한다", async () => {
 			const fakeNow = new Date("2024-01-16T23:00:00Z"); // KST 08:00 (화요일)
 			jest.setSystemTime(fakeNow);
 
@@ -92,7 +91,6 @@ describe("TimezoneAwareReminderJob", () => {
 
 			// 타임존 조회
 			expect(databaseService.userPreference.findMany).toHaveBeenCalledWith({
-				where: { pushEnabled: true },
 				select: { timezone: true },
 				distinct: ["timezone"],
 			});
@@ -126,7 +124,7 @@ describe("TimezoneAwareReminderJob", () => {
 			expect(eveningReminder.execute).toHaveBeenCalledTimes(2);
 		});
 
-		it("pushEnabled=false인 타임존만 있으면 조회 결과가 비어 Strategy 미호출", async () => {
+		it("조회 결과가 비어있으면 Strategy 미호출", async () => {
 			databaseService.userPreference.findMany.mockResolvedValue([] as never);
 
 			await job.handleMinuteSweep();
@@ -322,94 +320,6 @@ describe("TimezoneAwareReminderJob", () => {
 				await job.handleMinuteSweep();
 
 				expect(queueService.enqueueSocialDigest).not.toHaveBeenCalled();
-			});
-		});
-
-		describe("WeeklyAchievement catch-up (pushEnabled 유저 없는 TZ)", () => {
-			it("pushEnabled 유저가 없는 TZ에서도 월요일 07:00에 주간 배지를 집계한다", async () => {
-				// 2024-01-15 = 월요일, KST 07:00 = UTC 2024-01-14T22:00:00Z
-				const monday = new Date("2024-01-14T22:00:00Z");
-				jest.setSystemTime(monday);
-
-				// 1차 호출(pushEnabled TZ): Asia/Seoul만
-				// 2차 호출(allTz): Asia/Seoul + Pacific/Honolulu
-				databaseService.userPreference.findMany
-					.mockResolvedValueOnce([{ timezone: "Asia/Seoul" }] as never)
-					.mockResolvedValueOnce([
-						{ timezone: "Asia/Seoul" },
-						{ timezone: "Pacific/Honolulu" },
-					] as never);
-
-				await job.handleMinuteSweep();
-
-				// Asia/Seoul은 정상 스윕에서 호출 (1회) + catch-up에서는 이미 처리됨으로 스킵
-				expect(weeklyAchievement.execute).toHaveBeenCalledTimes(1);
-			});
-
-			it("pushEnabled TZ에 없는 TZ가 월요일 07:00이면 catch-up으로 배지를 집계한다", async () => {
-				// America/Anchorage: UTC-9, 월요일 07:00 = UTC 2024-01-15T16:00:00Z
-				const monday = new Date("2024-01-15T16:00:00Z");
-				jest.setSystemTime(monday);
-
-				// 1차(pushEnabled TZ): Asia/Seoul만
-				databaseService.userPreference.findMany
-					.mockResolvedValueOnce([{ timezone: "Asia/Seoul" }] as never)
-					// 2차(allTz): Asia/Seoul + America/Anchorage
-					.mockResolvedValueOnce([
-						{ timezone: "Asia/Seoul" },
-						{ timezone: "America/Anchorage" },
-					] as never);
-
-				await job.handleMinuteSweep();
-
-				// Asia/Seoul(정상 스윕) + America/Anchorage(catch-up)
-				// America/Anchorage는 이 시간에 월요일 07:00
-				const catchUpCalls = weeklyAchievement.execute.mock.calls.filter(
-					(call) => call[0]?.tz === "America/Anchorage",
-				);
-				expect(catchUpCalls).toHaveLength(1);
-			});
-
-			it("pushEnabled TZ가 비어있어도 catch-up으로 모든 TZ의 배지를 집계한다", async () => {
-				// America/Anchorage: UTC-9, 월요일 07:00 = UTC 2024-01-15T16:00:00Z
-				const monday = new Date("2024-01-15T16:00:00Z");
-				jest.setSystemTime(monday);
-
-				// 1차(pushEnabled TZ): 빈 배열
-				databaseService.userPreference.findMany
-					.mockResolvedValueOnce([] as never)
-					// 2차(allTz): America/Anchorage만 존재
-					.mockResolvedValueOnce([{ timezone: "America/Anchorage" }] as never);
-
-				await job.handleMinuteSweep();
-
-				// 정상 스윕 미호출 + catch-up에서 America/Anchorage 처리
-				expect(morningReminder.execute).not.toHaveBeenCalled();
-				expect(weeklyAchievement.execute).toHaveBeenCalledTimes(1);
-				expect(weeklyAchievement.execute).toHaveBeenCalledWith(
-					expect.objectContaining({ tz: "America/Anchorage" }),
-				);
-			});
-
-			it("missing TZ가 월요일 07:00이 아니면 catch-up을 건너뛴다", async () => {
-				// 2024-01-16 = 화요일, KST 08:00 = UTC 2024-01-16T23:00:00Z
-				const tuesday = new Date("2024-01-16T23:00:00Z");
-				jest.setSystemTime(tuesday);
-
-				databaseService.userPreference.findMany
-					.mockResolvedValueOnce([{ timezone: "Asia/Seoul" }] as never)
-					.mockResolvedValueOnce([
-						{ timezone: "Asia/Seoul" },
-						{ timezone: "America/Anchorage" },
-					] as never);
-
-				await job.handleMinuteSweep();
-
-				// 화요일이므로 catch-up 미발생
-				const catchUpCalls = weeklyAchievement.execute.mock.calls.filter(
-					(call) => call[0]?.tz === "America/Anchorage",
-				);
-				expect(catchUpCalls).toHaveLength(0);
 			});
 		});
 

--- a/apps/api/src/modules/scheduler/jobs/timezone-aware-reminder.job.ts
+++ b/apps/api/src/modules/scheduler/jobs/timezone-aware-reminder.job.ts
@@ -79,10 +79,9 @@ export class TimezoneAwareReminderJob implements OnModuleInit {
 		try {
 			const now = new Date();
 
-			// 1. 고유 타임존 목록 조회 (pushEnabled=true인 사용자만, 5분 캐시)
+			// 1. 고유 타임존 목록 조회 (모든 사용자 대상, 5분 캐시)
 			const tzList = await this.cacheService.wrapActiveTimezones(async () => {
 				const rows = await this.database.userPreference.findMany({
-					where: { pushEnabled: true },
 					select: { timezone: true },
 					distinct: ["timezone"],
 				});
@@ -108,8 +107,7 @@ export class TimezoneAwareReminderJob implements OnModuleInit {
 				}
 			});
 
-			// 3. WeeklyAchievement: pushEnabled 유저 없는 TZ도 뱃지 기록 생성
-			await this.#processWeeklyAchievementCatchUp(now, tzList);
+			// 3. 모든 TZ를 스윕하므로 WeeklyAchievement 보정 불필요
 
 			this.#logger.log("Every-minute sweep reminder job completed");
 		} catch (error) {
@@ -265,58 +263,6 @@ export class TimezoneAwareReminderJob implements OnModuleInit {
 		// 날씨 알림: 유저별 커스텀 시간 (내부에서 시:분 매칭)
 		await this.weatherMorning.execute(ctx);
 		await this.weatherEvening.execute(ctx);
-	}
-
-	/**
-	 * WeeklyAchievement 보정 — pushEnabled 유저가 없는 타임존에서도 뱃지 기록 생성
-	 *
-	 * 오케스트레이터가 pushEnabled=true 유저의 TZ만 스윕하므로,
-	 * pushEnabled 유저가 0명인 TZ의 유저들은 주간 뱃지 집계에서 누락됨.
-	 * 이 메서드는 누락된 TZ 중 월요일 07:00인 TZ에 대해 WeeklyAchievement만 실행.
-	 */
-	async #processWeeklyAchievementCatchUp(
-		now: Date,
-		pushEnabledTzList: string[],
-	): Promise<void> {
-		const pushEnabledSet = new Set(pushEnabledTzList);
-
-		const allTzList = await this.cacheService.wrapAllTimezones(async () => {
-			const rows = await this.database.userPreference.findMany({
-				select: { timezone: true },
-				distinct: ["timezone"],
-			});
-			return rows.map((r) => r.timezone);
-		});
-
-		const missingTzList = allTzList.filter((tz) => !pushEnabledSet.has(tz));
-		if (missingTzList.length === 0) return;
-
-		const eligibleTzData = missingTzList
-			.map((tz) => ({ tz, local: dayjs(now).tz(tz) }))
-			.filter(
-				({ local }) =>
-					local.day() === 1 &&
-					local.hour() === NOTIFICATION_SCHEDULE.WEEKLY_ACHIEVEMENT.hour &&
-					local.minute() === NOTIFICATION_SCHEDULE.WEEKLY_ACHIEVEMENT.minute,
-			);
-
-		if (eligibleTzData.length === 0) return;
-
-		const tasks = eligibleTzData.map(({ tz, local }) => {
-			const ctx = this.#buildContext(tz, local.hour(), local.minute());
-			return this.weeklyAchievement.execute(ctx);
-		});
-
-		const results = await Promise.allSettled(tasks);
-		results.forEach((result, index) => {
-			if (result.status === "rejected") {
-				const tz = eligibleTzData[index]?.tz ?? "unknown";
-				this.#logger.error(
-					`WeeklyAchievement catch-up failed for tz=${tz}: ${result.reason}`,
-					result.reason instanceof Error ? result.reason.stack : undefined,
-				);
-			}
-		});
 	}
 
 	#buildContext(


### PR DESCRIPTION
## 📋 개요

`pushEnabled`가 푸시 발송뿐 아니라 알림 DB 적재까지 차단하던 문제를 수정하고, 야간 면제 타입과 스케줄 시간을 정비합니다.

## 📊 전체 알림 동작 매트릭스 (25종)

### 스케줄러 기반 알림 (13종)

| 시간 | 타입 | 탭 | 빈도 | 대상 | DB 적재 | 야간 면제 | pushEnabled=false | nightPush=false + 야간 |
|------|------|-----|------|------|---------|----------|-------------------|----------------------|
| 07:00 (기본/커스텀) | `WEATHER_MORNING` | 할일 | 매일 | 전체 (위치+활성화) | ✅ 항상 | ✅ **면제** | DB ✅ 푸시 ❌ | DB ✅ 푸시 ✅ |
| 07:00 | `WEEKLY_ACHIEVEMENT` | 할일 | 월요일 | 전체 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| ~07:30 | `AI_SUGGESTION` | 할일 | 매일 | 프리미엄 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 08:00 (무료) / 커스텀 (프리미엄) | `MORNING_REMINDER` | 할일 | 매일 | 전체 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 09:00 | `WEEKLY_REPORT` | 할일 | 월요일 | 프리미엄 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 10:00 | `MONTHLY_REPORT` | 할일 | 매월 1일 | 프리미엄 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 12:00 | `WINBACK` | 할일 | 매일 | 전체 (비활성 3~30일) | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 12:30 | `LUNCH_NUDGE` | 할일 | 매일 | 전체 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 14:00 | `NUDGE_SUGGEST` | 소셜 | 매일 | 전체 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 18:00 (기본/커스텀) | `WEATHER_EVENING` | 할일 | 매일 | 전체 (위치+활성화) | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| 18:00 (무료) / 커스텀 (프리미엄) | `EVENING_REMINDER` | 할일 | 매일 | 전체 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| ~18:30 | `SOCIAL_DIGEST` | 소셜 | 매일 | 전체 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| **20:00** | `STREAK_AT_RISK` | 할일 | 매일 | 전체 (streak≥3) | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| — | `SYSTEM_NOTICE` (온보딩) | 공지 | 가입 후 0,1,2,3,5,7일 | 전체 (신규) | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |

### 이벤트 기반 알림 (8종) — 즉시 발송

| 타입 | 트리거 | 탭 | DB 적재 | 야간 면제 | pushEnabled=false | nightPush=false + 야간 |
|------|--------|-----|---------|----------|-------------------|----------------------|
| `FOLLOW_NEW` | 팔로우 요청 | 소셜 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `FOLLOW_ACCEPTED` | 팔로우 수락 | 소셜 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `NUDGE_RECEIVED` | 콕 찌르기 | 소셜 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `CHEER_RECEIVED` | 응원 | 소셜 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `FRIEND_COMPLETED` | 친구 할일 전체 완료 | 소셜 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `TODO_SHARED` | 할일 공유 받음 | 할일 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `TODO_REMINDER` | 할일 알림 시간 도달 | 할일 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `DAILY_COMPLETE` | 오늘 할일 전부 완료 | 할일 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |

### 시스템/관리자 알림 (3종)

| 타입 | 트리거 | 탭 | DB 적재 | 야간 면제 | pushEnabled=false | nightPush=false + 야간 |
|------|--------|-----|---------|----------|-------------------|----------------------|
| `SYSTEM_NOTICE` | 시스템/관리자 | 공지 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `ADMIN_BROADCAST` | 전체 공지 | 공지 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |
| `ADMIN_TARGETED` | 특정 유저 대상 공지 | 공지 | ✅ 항상 | - | DB ✅ 푸시 ❌ | DB ✅ 푸시 ❌ |

### 클라이언트 알림 탭 분류 요약

| 탭 | 포함 타입 |
|----|----------|
| **전체** | 모든 알림 (25종) |
| **공지** | `SYSTEM_NOTICE`, `ADMIN_BROADCAST`, `ADMIN_TARGETED` |
| **할일** | `TODO_REMINDER`, `TODO_SHARED`, `DAILY_COMPLETE`, `MORNING_REMINDER`, `EVENING_REMINDER`, `WEEKLY_ACHIEVEMENT`, `WEEKLY_REPORT`, `MONTHLY_REPORT`, `AI_SUGGESTION`, `WINBACK`, `LUNCH_NUDGE`, `STREAK_AT_RISK`, `WEATHER_MORNING`, `WEATHER_EVENING` |
| **소셜** | `FOLLOW_NEW`, `FOLLOW_ACCEPTED`, `NUDGE_RECEIVED`, `CHEER_RECEIVED`, `FRIEND_COMPLETED`, `SOCIAL_DIGEST`, `NUDGE_SUGGEST` |

### 설정별 동작 요약

| 설정 조합 | 알림 목록 (인앱) | 푸시 알림 (폰) |
|----------|----------------|---------------|
| `pushEnabled=true` + `nightPush=true` | 모든 알림 보임 | 모든 알림 울림 |
| `pushEnabled=true` + `nightPush=false` | 모든 알림 보임 | 주간만 울림 + `WEATHER_MORNING`만 야간도 울림 |
| `pushEnabled=false` | 모든 알림 보임 | 아무것도 안 울림 |

---

## 🏷️ 변경 유형

- [x] ♻️ `refactor` - 코드 리팩토링

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드

## 📝 변경 내용

### DB 적재 분리 (pushEnabled와 독립)
- 13개 스케줄러 전략에서 `pushEnabled: true` 사전 필터 제거
- DB 레코드는 항상 생성, 푸시 발송만 `PushDeliveryService`가 판단
- Timezone 오케스트레이터에서 `pushEnabled` 필터 제거 (모든 TZ 스윕)
- 불필요해진 `WeeklyAchievement` catch-up 로직 삭제
- `WeeklyAchievementStrategy`에서 pushEnabled 필터 쿼리 제거 및 로직 간소화

### 야간 면제 타입 정비
- `NUDGE_RECEIVED`, `STREAK_AT_RISK` 야간 면제에서 제거
- `WEATHER_MORNING`만 야간 면제로 유지 (사용자가 직접 선택한 아침 시간)

### 스케줄 시간 변경
- `STREAK_AT_RISK` 발송 시간: 21:00 → **20:00** (야간 시작 전 마지막 넛지)

### 설계 원칙
```
DB 적재 = 사실의 기록 (알림 목록) → pushEnabled 무관, 항상 적재
푸시 발송 = 폰을 울려서 알림     → pushEnabled, nightPushEnabled로 제어
```

## 🧪 테스트

### 테스트 방법

```bash
pnpm --filter @aido/api test
pnpm --filter @aido/api typecheck
```

### 테스트 결과

- [x] 단위 테스트 통과 (142 suites, 2003 passed)
- [x] 타입체크 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #478