### PR TITLE
fix(mobile): 폰트 스케일링 누락 수정 — HeroUI·헤더·Tabs.Label (#483)

### DIFF
--- a/apps/mobile/app/(app)/achievements/_layout.tsx
+++ b/apps/mobile/app/(app)/achievements/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -6,6 +8,7 @@ import { useResolveClassNames } from 'uniwind';
 const AchievementsLayout = () => {
   const headerBg = useResolveClassNames('bg-gray-1');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -15,7 +18,7 @@ const AchievementsLayout = () => {
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         contentStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/app/(app)/friends/_layout.tsx
+++ b/apps/mobile/app/(app)/friends/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon, SearchIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -6,6 +8,7 @@ import { useResolveClassNames } from 'uniwind';
 const FriendsLayout = () => {
   const headerBg = useResolveClassNames('bg-white');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -15,7 +18,7 @@ const FriendsLayout = () => {
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         contentStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/app/(app)/notifications/_layout.tsx
+++ b/apps/mobile/app/(app)/notifications/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -6,6 +8,7 @@ import { useResolveClassNames } from 'uniwind';
 const NotificationsLayout = () => {
   const headerBg = useResolveClassNames('bg-white');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -14,7 +17,7 @@ const NotificationsLayout = () => {
         headerShadowVisible: false,
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/app/(app)/reports/_layout.tsx
+++ b/apps/mobile/app/(app)/reports/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -6,6 +8,7 @@ import { useResolveClassNames } from 'uniwind';
 const ReportsLayout = () => {
   const headerBg = useResolveClassNames('bg-gray-1');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -15,7 +18,7 @@ const ReportsLayout = () => {
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         contentStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/app/(app)/reports/index.tsx
+++ b/apps/mobile/app/(app)/reports/index.tsx
@@ -126,10 +126,22 @@ function ReportTypeTabs({
       <Tabs.List>
         <Tabs.Indicator />
         <Tabs.Trigger value="WEEKLY">
-          <Tabs.Label className="text-b4">주간</Tabs.Label>
+          {({ isSelected }) => (
+            <Tabs.Label>
+              <Text size="b4" className={isSelected ? 'text-main font-semibold' : 'text-gray-5'}>
+                주간
+              </Text>
+            </Tabs.Label>
+          )}
         </Tabs.Trigger>
         <Tabs.Trigger value="MONTHLY">
-          <Tabs.Label className="text-b4">월간</Tabs.Label>
+          {({ isSelected }) => (
+            <Tabs.Label>
+              <Text size="b4" className={isSelected ? 'text-main font-semibold' : 'text-gray-5'}>
+                월간
+              </Text>
+            </Tabs.Label>
+          )}
         </Tabs.Trigger>
       </Tabs.List>
     </Tabs>

--- a/apps/mobile/app/(app)/settings/_layout.tsx
+++ b/apps/mobile/app/(app)/settings/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -6,6 +8,7 @@ import { useResolveClassNames } from 'uniwind';
 export default function SettingsLayout() {
   const headerBg = useResolveClassNames('bg-gray-1');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -14,7 +17,7 @@ export default function SettingsLayout() {
         headerShadowVisible: false,
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/app/(app)/settings/font-size.tsx
+++ b/apps/mobile/app/(app)/settings/font-size.tsx
@@ -2,6 +2,7 @@ import { useTrack } from '@src/shared/analytics';
 import { type FontScale, isFontScale } from '@src/shared/preferences/font-scale.preference';
 import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { StyledSafeAreaView } from '@src/shared/ui';
+import { SCALED_FONT_STYLES } from '@src/shared/utils/font-scale';
 import { Radio, RadioGroup } from 'heroui-native';
 import { Text as RNText, ScrollView, View } from 'react-native';
 
@@ -38,31 +39,6 @@ const FontSizeSettingsScreen = () => {
 
 export default FontSizeSettingsScreen;
 
-/**
- * 각 FontScale에서 본문 텍스트(b2)가 리매핑되는 디자인 토큰의 실제 px 값.
- *
- * RNText를 사용하여 FontScaleProvider를 우회하므로, 디자인 토큰을 직접 참조할 수 없어
- * global.css에 정의된 px 값을 하드코딩합니다.
- *
- * | FontScale | b2 → 토큰 | fontSize | lineHeight |
- * |-----------|-----------|----------|------------|
- * | xsmall    | b2 → b4   | 13px     | 19px       |
- * | small     | b2 → b3   | 15px     | 20px       |
- * | medium    | b2        | 16px     | 23px       |
- * | large     | b2 → b1   | 17px     | 24px       |
- * | xlarge    | b2 → t3   | 20px     | 28px       |
- *
- * @see font-scale-provider.tsx SCALE_MAP — 리매핑 테이블
- * @see global.css @theme — 디자인 토큰 원본 정의
- */
-const PREVIEW_FONT_SIZES = {
-  xsmall: { fontSize: 13, lineHeight: 19 },
-  small: { fontSize: 15, lineHeight: 20 },
-  medium: { fontSize: 16, lineHeight: 23 },
-  large: { fontSize: 17, lineHeight: 24 },
-  xlarge: { fontSize: 20, lineHeight: 28 },
-} as const;
-
 interface FontScaleRadioItemProps {
   value: FontScale;
   label: string;
@@ -80,7 +56,7 @@ function FontScaleRadioItem({ value, label }: FontScaleRadioItemProps) {
             <RNText
               allowFontScaling={false}
               className="text-gray-6 font-normal"
-              style={PREVIEW_FONT_SIZES[value]}
+              style={SCALED_FONT_STYLES[value]}
             >
               가나다라마바사 ABC 123
             </RNText>

--- a/apps/mobile/app/(app)/suggestions/_layout.tsx
+++ b/apps/mobile/app/(app)/suggestions/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -6,6 +8,7 @@ import { useResolveClassNames } from 'uniwind';
 const SuggestionsLayout = () => {
   const headerBg = useResolveClassNames('bg-gray-1');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -14,7 +17,7 @@ const SuggestionsLayout = () => {
         headerShadowVisible: false,
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/app/(app)/todos/_layout.tsx
+++ b/apps/mobile/app/(app)/todos/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -6,6 +8,7 @@ import { useResolveClassNames } from 'uniwind';
 const TodosLayout = () => {
   const headerBg = useResolveClassNames('bg-white');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -14,7 +17,7 @@ const TodosLayout = () => {
         headerShadowVisible: false,
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -1,4 +1,6 @@
+import { useFontScale } from '@src/shared/providers/font-scale-provider';
 import { ArrowLeftIcon } from '@src/shared/ui';
+import { getScaledFontSize } from '@src/shared/utils/font-scale';
 import { router, Stack } from 'expo-router';
 import { Platform, Pressable, View } from 'react-native';
 import { useResolveClassNames } from 'uniwind';
@@ -7,6 +9,7 @@ const AuthLayout = () => {
   const { backgroundColor } = useResolveClassNames('bg-white');
   const headerBg = useResolveClassNames('bg-background');
   const titleColor = useResolveClassNames('text-gray-9');
+  const { fontScale } = useFontScale();
 
   return (
     <Stack
@@ -18,7 +21,7 @@ const AuthLayout = () => {
         headerShadowVisible: false,
         headerStyle: { backgroundColor: headerBg.backgroundColor as string },
         headerTitleStyle: {
-          fontSize: 16,
+          fontSize: getScaledFontSize(fontScale),
           fontWeight: '600',
           color: titleColor.color as string,
         },

--- a/apps/mobile/src/bootstrap/providers/hero-ui-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/hero-ui-provider.tsx
@@ -5,6 +5,7 @@ export const HeroUIProvider = ({ children }: PropsWithChildren) => {
   return (
     <HeroUINativeProvider
       config={{
+        textProps: { allowFontScaling: false },
         toast: {
           defaultProps: {
             placement: 'top',

--- a/apps/mobile/src/shared/utils/font-scale.test.ts
+++ b/apps/mobile/src/shared/utils/font-scale.test.ts
@@ -1,0 +1,91 @@
+import type { FontScale } from '@src/shared/preferences/font-scale.preference';
+import { getScaledFontSize, SCALED_FONT_STYLES } from './font-scale';
+
+describe('SCALED_FONT_STYLES', () => {
+  it('5개의 FontScale에 대한 스타일을 모두 포함한다', () => {
+    // Given
+    const scales: FontScale[] = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+
+    // When & Then
+    for (const scale of scales) {
+      expect(SCALED_FONT_STYLES[scale]).toBeDefined();
+      expect(SCALED_FONT_STYLES[scale].fontSize).toBeGreaterThan(0);
+      expect(SCALED_FONT_STYLES[scale].lineHeight).toBeGreaterThan(0);
+    }
+  });
+
+  it('fontSize는 scale이 커질수록 증가한다', () => {
+    // Given & When
+    const xsmall = SCALED_FONT_STYLES.xsmall.fontSize;
+    const small = SCALED_FONT_STYLES.small.fontSize;
+    const medium = SCALED_FONT_STYLES.medium.fontSize;
+    const large = SCALED_FONT_STYLES.large.fontSize;
+    const xlarge = SCALED_FONT_STYLES.xlarge.fontSize;
+
+    // Then
+    expect(small).toBeGreaterThan(xsmall);
+    expect(medium).toBeGreaterThan(small);
+    expect(large).toBeGreaterThan(medium);
+    expect(xlarge).toBeGreaterThan(large);
+  });
+
+  it('lineHeight는 항상 fontSize보다 크다', () => {
+    // Given
+    const scales: FontScale[] = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+
+    // When & Then
+    for (const scale of scales) {
+      const { fontSize, lineHeight } = SCALED_FONT_STYLES[scale];
+      expect(lineHeight).toBeGreaterThan(fontSize);
+    }
+  });
+});
+
+describe('getScaledFontSize', () => {
+  it('medium이면 기본 b2 크기인 16px을 반환한다', () => {
+    // Given
+    const scale: FontScale = 'medium';
+
+    // When
+    const result = getScaledFontSize(scale);
+
+    // Then
+    expect(result).toBe(16);
+  });
+
+  it('xsmall이면 b4 크기인 13px을 반환한다', () => {
+    // Given
+    const scale: FontScale = 'xsmall';
+
+    // When
+    const result = getScaledFontSize(scale);
+
+    // Then
+    expect(result).toBe(13);
+  });
+
+  it('xlarge이면 t3 크기인 20px을 반환한다', () => {
+    // Given
+    const scale: FontScale = 'xlarge';
+
+    // When
+    const result = getScaledFontSize(scale);
+
+    // Then
+    expect(result).toBe(20);
+  });
+
+  it.each([
+    ['xsmall', 13],
+    ['small', 15],
+    ['medium', 16],
+    ['large', 17],
+    ['xlarge', 20],
+  ] as const)('%s이면 %dpx을 반환한다', (scale, expected) => {
+    // Given & When
+    const result = getScaledFontSize(scale);
+
+    // Then
+    expect(result).toBe(expected);
+  });
+});

--- a/apps/mobile/src/shared/utils/font-scale.ts
+++ b/apps/mobile/src/shared/utils/font-scale.ts
@@ -1,0 +1,28 @@
+import type { FontScale } from '@src/shared/preferences/font-scale.preference';
+
+/**
+ * FontScale별로 b2 토큰이 리매핑되는 실제 px 값.
+ *
+ * | FontScale | b2 → 토큰 | fontSize | lineHeight |
+ * |-----------|-----------|----------|------------|
+ * | xsmall    | b2 → b4   | 13px     | 19px       |
+ * | small     | b2 → b3   | 15px     | 20px       |
+ * | medium    | b2        | 16px     | 23px       |
+ * | large     | b2 → b1   | 17px     | 24px       |
+ * | xlarge    | b2 → t3   | 20px     | 28px       |
+ *
+ * @see font-scale-provider.tsx SCALE_MAP — 리매핑 테이블
+ * @see global.css @theme — 디자인 토큰 원본 정의
+ */
+export const SCALED_FONT_STYLES: Record<FontScale, { fontSize: number; lineHeight: number }> = {
+  xsmall: { fontSize: 13, lineHeight: 19 },
+  small: { fontSize: 15, lineHeight: 20 },
+  medium: { fontSize: 16, lineHeight: 23 },
+  large: { fontSize: 17, lineHeight: 24 },
+  xlarge: { fontSize: 20, lineHeight: 28 },
+};
+
+/** FontScale에 대응하는 b2 기준 fontSize(px)를 반환한다. */
+export const getScaledFontSize = (scale: FontScale): number => {
+  return SCALED_FONT_STYLES[scale].fontSize;
+};


### PR DESCRIPTION
## 📋 개요

앱 폰트 스케일(xsmall~xlarge) 변경 시 일부 텍스트에 반영되지 않던 문제 수정 및 폰트 스케일 유틸리티 통합

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

### 1. HeroUIProvider에 `allowFontScaling: false` 추가
- HeroUI 내부 텍스트(`HeroText`)가 시스템 접근성 글꼴 크기와 앱 자체 폰트 스케일을 이중으로 적용하던 문제 방지

### 2. 리포트 Tabs.Label에 앱 Text 컴포넌트 래핑
- `reports/index.tsx`의 "주간/월간" 탭이 bare RN Text로 렌더링되어 폰트 스케일 미반영
- 다른 Tabs 사용처(notifications, friends, category-settings)와 동일한 render prop + Text 래핑 패턴 적용

### 3. 네비게이션 헤더 타이틀 동적 fontSize 적용
- 8개 `_layout.tsx`의 `fontSize: 16` 하드코딩 → `useFontScale()` + `getScaledFontSize()` 적용
- 대상: auth, reports, todos, notifications, achievements, friends, settings, suggestions

### 4. 폰트 스케일 유틸리티 통합
- `font-size.tsx`의 `PREVIEW_FONT_SIZES`와 동일한 매핑을 `SCALED_FONT_STYLES`로 통합 (`src/shared/utils/font-scale.ts`)
- `getScaledFontSize()` 함수 제공 (헤더 등 fontSize만 필요한 곳)
- `SCALED_FONT_STYLES` 상수 제공 (fontSize + lineHeight 모두 필요한 곳)
- 테스트 코드 추가 (11개 케이스)

## 🧪 테스트

### 테스트 방법

```bash
pnpm test -- src/shared/utils/font-scale.test.ts
```

### 테스트 결과

- [x] 단위 테스트 통과 (11/11)
- [x] 타입체크 통과
- [x] 린트 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #483

## 📸 스크린샷 (UI 변경 시)

|          Before           |           After           |
| :-----------------------: | :-----------------------: |
| <!-- 변경 전 스크린샷 --> | <!-- 변경 후 스크린샷 --> |