### PR TITLE
feat(mobile): 반복 피커 시작일 변경 및 삭제 버튼 추가

### DIFF
--- a/apps/mobile/src/features/todo/presentations/components/AddTodoBottomSheet.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/AddTodoBottomSheet.tsx
@@ -47,7 +47,7 @@ import { formatTodoDateLabel } from '../utils/format-todo-date-label';
 import type { TodoItemViewModel } from '../view-models/todo-item.view-model';
 import { CategorySelectContent } from './CategorySelectBottomSheet';
 import { TodoDatePickerContent } from './TodoDatePickerContent';
-import { TodoRepeatPickerContent } from './TodoRepeatPickerContent';
+import { type RepeatPickerCloseResult, TodoRepeatPickerContent } from './TodoRepeatPickerContent';
 import { TodoTimePickerContent } from './TodoTimePickerContent';
 
 interface AddTodoBottomSheetBaseProps {
@@ -266,37 +266,42 @@ export const AddTodoBottomSheet = (props: AddTodoBottomSheetProps) => {
 
   const openRepeatPicker = () => {
     Keyboard.dismiss();
-    let pickerResult: { daysOfWeek: DayOfWeek[]; repeatEndDate: Date | null } | null = null;
-    overlay.open<{ daysOfWeek: DayOfWeek[]; repeatEndDate: Date | null } | null>(
-      ({ isOpen, close, exit }) => (
-        <ModalBottomSheet
-          isOpen={isOpen}
-          onClose={() => close(null)}
-          onExit={() => {
-            exit();
-            if (pickerResult) {
+    let pickerResult: RepeatPickerCloseResult | null = null;
+    overlay.open<RepeatPickerCloseResult | null>(({ isOpen, close, exit }) => (
+      <ModalBottomSheet
+        isOpen={isOpen}
+        onClose={() => close({ type: 'cancel' })}
+        onExit={() => {
+          exit();
+          match(pickerResult)
+            .with({ type: 'reset' }, () => {
+              methods.setValue('isRecurring', false);
+              methods.setValue('daysOfWeek', []);
+              methods.setValue('repeatEndDate', null);
+            })
+            .with({ type: 'confirm' }, ({ value }) => {
               methods.setValue('isRecurring', true);
-              methods.setValue('daysOfWeek', pickerResult.daysOfWeek);
-              methods.setValue('repeatEndDate', pickerResult.repeatEndDate);
-            }
-            focusTodoInput();
+              methods.setValue('daysOfWeek', value.daysOfWeek);
+              methods.setValue('repeatEndDate', value.repeatEndDate);
+              methods.setValue('startDate', value.startDate);
+            })
+            .otherwise(() => {});
+          focusTodoInput();
+        }}
+      >
+        <TodoRepeatPickerContent
+          startDate={methods.getValues('startDate')}
+          repeat={{
+            daysOfWeek: methods.getValues('daysOfWeek') ?? [],
+            repeatEndDate: methods.getValues('repeatEndDate') ?? null,
           }}
-        >
-          <TodoRepeatPickerContent
-            startDate={methods.getValues('startDate')}
-            repeat={{
-              daysOfWeek: methods.getValues('daysOfWeek') ?? [],
-              repeatEndDate: methods.getValues('repeatEndDate') ?? null,
-            }}
-            onConfirm={(repeat) => {
-              pickerResult = repeat;
-              close(repeat);
-            }}
-            onCancel={() => close(null)}
-          />
-        </ModalBottomSheet>
-      ),
-    );
+          onClose={(result) => {
+            pickerResult = result;
+            close(result);
+          }}
+        />
+      </ModalBottomSheet>
+    ));
   };
 
   const openCategoryPicker = () => {

--- a/apps/mobile/src/features/todo/presentations/components/TodoRepeatPickerContent.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoRepeatPickerContent.tsx
@@ -82,7 +82,7 @@ export const TodoRepeatPickerContent = ({
     });
   };
 
-  const today = new Date();
+  const [today] = useState(() => new Date());
 
   const handleCalendarPress = (date: Date) => {
     if (isBeforeDay(date, today)) return;

--- a/apps/mobile/src/features/todo/presentations/components/TodoRepeatPickerContent.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoRepeatPickerContent.tsx
@@ -1,5 +1,5 @@
 import type { DayOfWeek } from '@aido/validators';
-import { ArrowLeftIcon, ArrowRightIcon, Box, HStack, Text, VStack } from '@src/shared/ui';
+import { ArrowLeftIcon, ArrowRightIcon, Box, Button, HStack, Text, VStack } from '@src/shared/ui';
 import { cn } from '@src/shared/utils/cn';
 import {
   formatMonthDay,
@@ -10,6 +10,7 @@ import {
   isSameMonth,
 } from '@src/shared/utils/date';
 import { PressableFeedback } from 'heroui-native';
+import { useState } from 'react';
 import { useDatePicker } from '../hooks/useDatePicker';
 import { useRepeatSetting } from '../hooks/useRepeatSetting';
 import { DAY_TYPE_TONE, getDatePickerDayStyle, isTodayHighlighted } from '../utils/calendar-day';
@@ -18,16 +19,24 @@ import { CalendarWeekdayHeader } from './Calendar/CalendarWeekdayHeader';
 import { PickerHeader } from './PickerHeader';
 import { DayOfWeekSelector } from './TodoDatePickerContent';
 
-interface RepeatResult {
+interface RepeatInput {
   daysOfWeek: DayOfWeek[];
   repeatEndDate: Date | null;
 }
 
+interface RepeatConfirmResult extends RepeatInput {
+  startDate: Date;
+}
+
+export type RepeatPickerCloseResult =
+  | { type: 'confirm'; value: RepeatConfirmResult }
+  | { type: 'reset' }
+  | { type: 'cancel' };
+
 interface TodoRepeatPickerContentProps {
   startDate: Date;
-  repeat: RepeatResult;
-  onConfirm: (repeat: RepeatResult) => void;
-  onCancel: () => void;
+  repeat: RepeatInput;
+  onClose: (result: RepeatPickerCloseResult) => void;
 }
 
 const getInitialSelectedDays = (startDate: Date, daysOfWeek: DayOfWeek[]): DayOfWeek[] => {
@@ -41,17 +50,20 @@ const getDefaultEndDate = (repeatEndDate: Date | null): Date | null => {
 };
 
 export const TodoRepeatPickerContent = ({
-  startDate,
+  startDate: initialStartDate,
   repeat,
-  onConfirm,
-  onCancel,
+  onClose,
 }: TodoRepeatPickerContentProps) => {
+  const [startDate, setStartDate] = useState(initialStartDate);
   const picker = useDatePicker({ startDate });
   const repeatSetting = useRepeatSetting({
     isEnabled: true,
-    selectedDays: getInitialSelectedDays(startDate, repeat.daysOfWeek),
+    selectedDays: getInitialSelectedDays(initialStartDate, repeat.daysOfWeek),
     endDate: getDefaultEndDate(repeat.repeatEndDate),
   });
+
+  const hasExistingRepeat = repeat.daysOfWeek.length > 0;
+  const hasCompleteRange = repeatSetting.endDate !== null;
 
   const isConfirmDisabled =
     repeatSetting.selectedDays.length === 0 ||
@@ -60,27 +72,39 @@ export const TodoRepeatPickerContent = ({
 
   const handleConfirm = () => {
     if (isConfirmDisabled) return;
-    onConfirm({
-      daysOfWeek: repeatSetting.selectedDays,
-      repeatEndDate: repeatSetting.endDate,
+    onClose({
+      type: 'confirm',
+      value: {
+        daysOfWeek: repeatSetting.selectedDays,
+        repeatEndDate: repeatSetting.endDate,
+        startDate,
+      },
     });
   };
 
-  const handleCalendarPress = (date: Date) => {
-    if (isBeforeDay(date, startDate)) return;
+  const today = new Date();
 
-    if (repeatSetting.endDate === null || !isSameDay(date, repeatSetting.endDate)) {
-      repeatSetting.setEndDate(date);
-    } else {
-      repeatSetting.clearEndDate();
+  const handleCalendarPress = (date: Date) => {
+    if (isBeforeDay(date, today)) return;
+
+    if (!hasCompleteRange) {
+      if (isAfterDay(date, startDate)) {
+        repeatSetting.setEndDate(date);
+      } else if (isBeforeDay(date, startDate)) {
+        setStartDate(date);
+      }
+      return;
     }
+
+    setStartDate(date);
+    repeatSetting.clearEndDate();
   };
 
   return (
     <VStack gap={20}>
       <PickerHeader
         title="반복"
-        onCancel={onCancel}
+        onCancel={() => onClose({ type: 'cancel' })}
         onConfirm={handleConfirm}
         isConfirmDisabled={isConfirmDisabled}
       />
@@ -94,27 +118,41 @@ export const TodoRepeatPickerContent = ({
 
       <RepeatCalendar
         picker={picker}
+        today={today}
         startDate={startDate}
         endDate={repeatSetting.endDate}
         onDatePress={handleCalendarPress}
       />
 
       <VStack className="border-t border-gray-2 px-4 pt-3">
-        <HStack gap={8} align="center">
-          <Text size="b3" tone="neutral" shade={7}>
-            반복 기간
-          </Text>
-          <Text size="b3" tone="neutral" shade={6}>
-            •
-          </Text>
-          {repeatSetting.endDate && !isSameDay(startDate, repeatSetting.endDate) ? (
-            <Text size="b3" tone="brand">
-              {formatMonthDay(startDate)} - {formatMonthDay(repeatSetting.endDate)}
+        <HStack align="center" justify="between" gap={8}>
+          <HStack gap={4} align="center" className="shrink">
+            <Text size="b3" tone="neutral" shade={7}>
+              반복 기간
             </Text>
-          ) : (
-            <Text size="b3" tone="neutral" shade={5}>
-              기간을 선택해주세요
+            <Text size="b3" tone="neutral" shade={6}>
+              •
             </Text>
+            {repeatSetting.endDate && !isSameDay(startDate, repeatSetting.endDate) ? (
+              <Text size="b3" tone="brand">
+                {formatMonthDay(startDate)} - {formatMonthDay(repeatSetting.endDate)}
+              </Text>
+            ) : (
+              <Text size="b3" tone="neutral" shade={5}>
+                기간을 선택해주세요
+              </Text>
+            )}
+          </HStack>
+          {hasExistingRepeat && (
+            <Button
+              size="small"
+              variant="weak"
+              color="danger"
+              display="inline"
+              onPress={() => onClose({ type: 'reset' })}
+            >
+              삭제
+            </Button>
           )}
         </HStack>
       </VStack>
@@ -124,12 +162,19 @@ export const TodoRepeatPickerContent = ({
 
 interface RepeatCalendarProps {
   picker: ReturnType<typeof useDatePicker>;
+  today: Date;
   startDate: Date;
   endDate: Date | null;
   onDatePress: (date: Date) => void;
 }
 
-const RepeatCalendar = ({ picker, startDate, endDate, onDatePress }: RepeatCalendarProps) => {
+const RepeatCalendar = ({
+  picker,
+  today,
+  startDate,
+  endDate,
+  onDatePress,
+}: RepeatCalendarProps) => {
   const { displayMonth, weeks, goToPrevMonth, goToNextMonth } = picker;
 
   return (
@@ -157,6 +202,7 @@ const RepeatCalendar = ({ picker, startDate, endDate, onDatePress }: RepeatCalen
                 <RepeatDateCell
                   key={date.toISOString()}
                   date={date}
+                  today={today}
                   startDate={startDate}
                   endDate={endDate}
                   onPress={onDatePress}
@@ -174,14 +220,15 @@ const RepeatCalendar = ({ picker, startDate, endDate, onDatePress }: RepeatCalen
 
 interface RepeatDateCellProps {
   date: Date;
+  today: Date;
   startDate: Date;
   endDate: Date | null;
   onPress: (date: Date) => void;
 }
 
-const RepeatDateCell = ({ date, startDate, endDate, onPress }: RepeatDateCellProps) => {
+const RepeatDateCell = ({ date, today, startDate, endDate, onPress }: RepeatDateCellProps) => {
   const dayOfMonth = date.getDate();
-  const isDisabled = isBeforeDay(date, startDate);
+  const isDisabled = isBeforeDay(date, today);
   const isStart = isSameDay(date, startDate);
   const isEnd = endDate !== null && isSameDay(date, endDate);
   const isSelected = isStart || isEnd;


### PR DESCRIPTION
## 📋 개요

반복 피커에서 시작일을 변경할 수 있도록 범위 선택 방식으로 개선하고, 기존 반복을 제거할 수 있는 삭제 버튼 추가

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- 반복 피커 캘린더를 시작일/종료일 범위 선택 방식으로 변경
- 시작일 변경 시 투두 날짜도 연동되도록 처리
- 오늘 이전 날짜 비활성화 유지
- 기존 반복 제거용 "삭제" 버튼 추가
- `RepeatPickerCloseResult` 타입으로 confirm/reset/cancel 결과 통합

## 🧪 테스트

### 테스트 결과

- [x] 수동 테스트 완료
- [x] 빌드가 성공합니다 (`pnpm build`)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

## 📸 스크린샷 (UI 변경 시)
<img width="200" height="600" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-04-01 at 22 40 34" src="https://github.com/user-attachments/assets/06276cb6-8cca-4666-bc72-a6a23a0e1f9a" />

