### PR TITLE
fix(mobile): 푸시알림 및 화면 전환 시 이중 전환/화면 겹침 수정 (#504)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -15,7 +15,7 @@ interface EnvironmentConfig {
 
 const PROJECT_SLUG = 'aido';
 const OWNER = 'aido-team';
-const VERSION = '1.2.2';
+const VERSION = '1.2.3';
 
 const APP_NAME = 'Aido';
 const BUNDLE_IDENTIFIER = 'com.aido.mobile';

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aido/mobile",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/mobile/src/bootstrap/providers/notification-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/notification-provider.tsx
@@ -1,4 +1,7 @@
-import { useNotificationHandler } from '@src/features/notification/presentations/hooks/use-notification-handler';
+import {
+  type NotificationResponseOptions,
+  useNotificationHandler,
+} from '@src/features/notification/presentations/hooks/use-notification-handler';
 import * as Notifications from 'expo-notifications';
 import { createContext, type PropsWithChildren, use, useEffect, useMemo, useRef } from 'react';
 import { Platform } from 'react-native';
@@ -7,7 +10,10 @@ import { useAuth } from './auth-provider';
 import { useLogger, useNotificationService } from './di-provider';
 
 interface NotificationContextValue {
-  handleNotificationResponse: (response: Notifications.NotificationResponse) => Promise<void>;
+  handleNotificationResponse: (
+    response: Notifications.NotificationResponse,
+    options?: NotificationResponseOptions,
+  ) => Promise<void>;
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
@@ -54,9 +60,14 @@ const NativeNotificationProvider = ({ children }: PropsWithChildren) => {
     if (isAuthResolved) {
       // 인증 완료: 즉시 처리
       if (lastResponseHandled.current !== responseId) {
+        const isColdStart = pendingColdStartResponse.current !== null;
         lastResponseHandled.current = responseId;
         pendingColdStartResponse.current = null;
-        handleNotificationResponse(responseToProcess).catch((e) =>
+        // Cold start: replace로 초기 화면을 알림 대상으로 교체하여 이중 전환 방지
+        handleNotificationResponse(
+          responseToProcess,
+          isColdStart ? { replace: true } : undefined,
+        ).catch((e) =>
           logger.error(
             '[Notification] Response handling failed',
             e instanceof Error ? e : undefined,

--- a/apps/mobile/src/features/notification/presentations/components/notification-bell.tsx
+++ b/apps/mobile/src/features/notification/presentations/components/notification-bell.tsx
@@ -11,7 +11,7 @@ export const NotificationBell = () => {
   const hasUnread = (unreadCount ?? 0) > 0;
 
   return (
-    <Pressable onPress={() => router.push('/notifications')} hitSlop={8} className="p-2">
+    <Pressable onPress={() => router.navigate('/notifications')} hitSlop={8} className="p-2">
       <BellIcon width={24} height={24} colorClassName="text-gray-9" />
       {hasUnread && <View className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-main" />}
     </Pressable>

--- a/apps/mobile/src/features/notification/presentations/components/notification-item.tsx
+++ b/apps/mobile/src/features/notification/presentations/components/notification-item.tsx
@@ -49,7 +49,7 @@ export function NotificationItem({ notification }: NotificationItemProps) {
 
     // 4. 타입 + context 기반 내부 라우팅
     const route = NotificationPolicy.internalRoute(notification);
-    if (route) router.push(route as Href);
+    if (route) router.navigate(route as Href);
   };
 
   return (

--- a/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
+++ b/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
@@ -17,12 +17,18 @@ interface UseNotificationHandlerOptions {
   isAuthenticated: boolean;
 }
 
+export interface NotificationResponseOptions {
+  /** true면 router.replace()로 현재 화면을 교체 (cold start 용) */
+  replace?: boolean;
+}
+
 export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandlerOptions) => {
   const notificationService = useNotificationService();
   const { trackEvent } = useTrack();
   const queryClient = useQueryClient();
   const logger = useLogger();
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const lastNavigationTimeRef = useRef(0);
 
   // ref로 최신 auth 상태를 추적하여 deferred 실행 시 stale closure 방지
   const isAuthenticatedRef = useRef(isAuthenticated);
@@ -31,7 +37,10 @@ export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandl
   }, [isAuthenticated]);
 
   const handleNotificationResponse = useCallback(
-    async (response: Notifications.NotificationResponse): Promise<void> => {
+    async (
+      response: Notifications.NotificationResponse,
+      options?: NotificationResponseOptions,
+    ): Promise<void> => {
       const rawData = response.notification.request.content.data;
 
       // 1. Zod 검증으로 타입 안정성 확보
@@ -69,7 +78,11 @@ export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandl
         }
       }
 
-      // 4. Action Type 기반 분기 처리
+      // 4. Action Type 기반 분기 처리 (연타 방지: 500ms 잠금)
+      const now = Date.now();
+      if (now - lastNavigationTimeRef.current < 500) return;
+      lastNavigationTimeRef.current = now;
+
       match(data.action?.type)
         .with('BROWSER', () => {
           if (data.action?.url) {
@@ -86,7 +99,11 @@ export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandl
             data.action?.url ?? getInternalRoute(data.type as NotificationType, data.context);
 
           if (route) {
-            router.push(route as Href);
+            if (options?.replace) {
+              router.replace(route as Href);
+            } else {
+              router.navigate(route as Href);
+            }
           }
         });
     },

--- a/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
+++ b/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
@@ -41,6 +41,11 @@ export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandl
       response: Notifications.NotificationResponse,
       options?: NotificationResponseOptions,
     ): Promise<void> => {
+      // 0. 연타 방지: 500ms 잠금 (모든 사이드 이펙트 실행 전 차단)
+      const now = Date.now();
+      if (now - lastNavigationTimeRef.current < 500) return;
+      lastNavigationTimeRef.current = now;
+
       const rawData = response.notification.request.content.data;
 
       // 1. Zod 검증으로 타입 안정성 확보
@@ -78,11 +83,7 @@ export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandl
         }
       }
 
-      // 4. Action Type 기반 분기 처리 (연타 방지: 500ms 잠금)
-      const now = Date.now();
-      if (now - lastNavigationTimeRef.current < 500) return;
-      lastNavigationTimeRef.current = now;
-
+      // 4. Action Type 기반 분기 처리
       match(data.action?.type)
         .with('BROWSER', () => {
           if (data.action?.url) {

--- a/apps/mobile/src/shared/ui/PremiumDialog/PremiumDialog.tsx
+++ b/apps/mobile/src/shared/ui/PremiumDialog/PremiumDialog.tsx
@@ -15,7 +15,7 @@ export function PremiumDialog({
   const handleSubscribe = () => {
     onOpenChange(false);
     onConfirm?.();
-    router.push('/settings/subscription');
+    router.navigate('/settings/subscription');
   };
 
   return (


### PR DESCRIPTION
## 📋 개요

푸시알림 클릭 시 또는 화면 전환 시 화면이 겹쳐 보이거나 이중으로 전환되는 문제를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

### 근본 원인
앱 전체에서 `router.navigate()`를 사용하지 않고 모든 곳에서 `router.push()`만 사용하여:
- 이미 존재하는 화면으로도 중복 push가 발생
- Cold start 시 loading→app→대상 이중 전환
- 연타 방지 메커니즘 부재

### 수정 사항
- **알림 핸들러** (`use-notification-handler.ts`): `router.push()` → `router.navigate()`로 변경, cold start 시 `router.replace()` 옵션 추가, 500ms 연타 방지 잠금
- **알림 프로바이더** (`notification-provider.tsx`): cold start 큐잉된 알림에 `{ replace: true }` 전달하여 단일 전환
- **알림 아이템** (`notification-item.tsx`): `router.push()` → `router.navigate()`
- **알림 벨** (`notification-bell.tsx`): `router.push()` → `router.navigate()`
- **프리미엄 다이얼로그** (`PremiumDialog.tsx`): `router.push()` → `router.navigate()`

### push vs navigate 차이
- `router.push()`: 항상 새 화면을 스택에 추가 (같은 route여도 중복)
- `router.navigate()`: 이미 스택에 있으면 포커스 이동 (중복 방지)
- `router.replace()`: 현재 화면을 대체 (cold start 시 단일 전환용)

## 🧪 테스트

### 테스트 방법

1. 피드 탭에서 `/feed`로 라우팅되는 푸시알림 탭 → 화면 중복 없이 현재 피드 유지
2. 알림 화면에서 알림 아이템 탭 → 올바른 백스택
3. 앱 종료 상태에서 푸시알림 탭 (cold start) → 단일 전환으로 대상 화면 직행
4. 알림 아이템 빠른 더블탭 → 한 번만 네비게이션
5. WEBVIEW 타입 알림 → 여전히 push로 스택에 쌓임 (의도된 동작)

### 테스트 결과

- [x] `pnpm lint` 통과
- [x] `pnpm typecheck` 통과
- [x] `pnpm build` 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #504