### PR TITLE
fix(mobile): 날씨 화면 강수 아이콘과 텍스트 라벨 불일치 수정

### DIFF
--- a/apps/mobile/app/(app)/weather/index.tsx
+++ b/apps/mobile/app/(app)/weather/index.tsx
@@ -261,13 +261,13 @@ function WeatherLocation({ latitude, longitude }: LocationCoords) {
 
 function TodayTemperature({ forecast }: { forecast: WeatherForecastViewModel }) {
   const palette = useTimePalette();
+  const showPrecipitation = WeatherPolicy.shouldShowPrecipitation(forecast);
   const ForecastIcon =
-    resolveIconByPrecipitation(forecast.precipitationType) ??
+    (showPrecipitation && resolveIconByPrecipitation(forecast.precipitationType)) ||
     resolveIconBySky(forecast.skyCondition);
-  const forecastIconColor =
-    forecast.precipitationType === 'NONE'
-      ? resolveSkyIconColor(forecast.skyCondition, palette.text)
-      : palette.text;
+  const forecastIconColor = showPrecipitation
+    ? palette.text
+    : resolveSkyIconColor(forecast.skyCondition, palette.text);
   const currentTemp = forecast.currentTemperature;
 
   return (
@@ -298,7 +298,9 @@ function TodayTemperature({ forecast }: { forecast: WeatherForecastViewModel }) 
       <HStack gap={8} align="center" className="mt-2">
         <ForecastIcon width={18} height={18} color={forecastIconColor} />
         <Text size="b2" weight="semibold" style={{ color: palette.text }}>
-          {SKY_CONDITION_LABEL[forecast.skyCondition]}
+          {showPrecipitation
+            ? PRECIPITATION_TYPE_LABEL[forecast.precipitationType]
+            : SKY_CONDITION_LABEL[forecast.skyCondition]}
         </Text>
       </HStack>
 


### PR DESCRIPTION
## 📋 개요

날씨 화면에서 아이콘/텍스트/강수 배지의 판단 기준이 각각 달라 불일치가 발생하던 문제를 `shouldShowPrecipitation` 기준으로 통일.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- 아이콘/텍스트/배지 모두 `WeatherPolicy.shouldShowPrecipitation` (강수 타입 존재 + 확률 ≥ 30%) 기준으로 통일
- 아이콘 색상도 동일 기준으로 분기하도록 수정

### 모든 경우의 수

**강수 없음 (precipitationType: NONE)**

| skyCondition | 아이콘 | 텍스트 | 배지 |
|---|---|---|---|
| `CLEAR` | ☀️ 맑음 | 맑음 | - |
| `PARTLY_CLOUDY` | ⛅ 구름많음 | 구름많음 | - |
| `CLOUDY` | ☁️ 흐림 | 흐림 | - |

**강수 있음 + 확률 < 30% → 하늘 상태 기준으로 표시**

| precipitationType | skyCondition | 아이콘 | 텍스트 | 배지 |
|---|---|---|---|---|
| `RAIN` | `CLEAR` | ☀️ 맑음 | 맑음 | - |
| `RAIN` | `PARTLY_CLOUDY` | ⛅ 구름많음 | 구름많음 | - |
| `RAIN` | `CLOUDY` | ☁️ 흐림 | 흐림 | - |
| `RAIN_SNOW` / `SNOW` / `SHOWER` | 동일 | 동일 | 동일 | - |

**강수 있음 + 확률 ≥ 30% → 강수 기준으로 표시**

| precipitationType | 아이콘 | 텍스트 | 배지 |
|---|---|---|---|
| `RAIN` | 🌧️ 비 | 비 | 비 N% |
| `RAIN_SNOW` | 🌧️ 비 | 비/눈 | 비/눈 N% |
| `SNOW` | ❄️ 눈 | 눈 | 눈 N% |
| `SHOWER` | 🌦️ 소나기 | 소나기 | 소나기 N% |

## 🧪 테스트

### 테스트 결과

- [x] 수동 테스트 완료

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

## 🔗 관련 이슈

Closes #510