### PR TITLE
feat(api): 메모 기능 추가 (#512)

### DIFF
--- a/apps/api/prisma/migrations/20260406012814_add_memo_model/migration.sql
+++ b/apps/api/prisma/migrations/20260406012814_add_memo_model/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Memo" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT NOT NULL,
+    "content" VARCHAR(5000) NOT NULL,
+    "isPinned" BOOLEAN NOT NULL DEFAULT false,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Memo_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Memo_userId_isPinned_sortOrder_idx" ON "Memo"("userId", "isPinned", "sortOrder");
+
+-- CreateIndex
+CREATE INDEX "Memo_userId_sortOrder_idx" ON "Memo"("userId", "sortOrder");
+
+-- AddForeignKey
+ALTER TABLE "Memo" ADD CONSTRAINT "Memo_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -83,6 +83,9 @@ model User {
   aiReports            AiReport[]
   recurringSuggestions RecurringSuggestion[]
 
+  // 관계: 메모
+  memos Memo[]
+
   // 관계: 위치
   location UserLocation?
 
@@ -917,4 +920,24 @@ model RecurringSuggestion {
   @@index([userId, status])
   @@index([userId, expiresAt])
   @@index([userId, updatedAt]) // findRecentResponded 이력 조회용
+}
+
+// =============================================================================
+// 메모
+// =============================================================================
+
+/// 빠른 메모 (최대 20개/유저)
+model Memo {
+  id        Int      @id @default(autoincrement())
+  userId    String
+  content   String   @db.VarChar(5000)
+  isPinned  Boolean  @default(false)
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, isPinned, sortOrder])
+  @@index([userId, sortOrder])
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -35,6 +35,7 @@ import { DailyCompletionModule } from "@/modules/daily-completion";
 import { FollowModule } from "@/modules/follow";
 import { HealthModule } from "@/modules/health";
 import { InquiryModule } from "@/modules/inquiry";
+import { MemoModule } from "@/modules/memo";
 import { NotificationModule } from "@/modules/notification";
 import { NudgeModule } from "@/modules/nudge";
 import { SchedulerModule } from "@/modules/scheduler";
@@ -108,6 +109,7 @@ import { AppService } from "./app.service";
 		FollowModule,
 		HealthModule,
 		InquiryModule,
+		MemoModule,
 		NotificationModule,
 		NudgeModule,
 		SchedulerModule,

--- a/apps/api/src/common/exception/services/business-exception.service.ts
+++ b/apps/api/src/common/exception/services/business-exception.service.ts
@@ -752,4 +752,19 @@ export class BusinessExceptions {
 	static weatherLocationNotFound() {
 		return new BusinessException(ErrorCode.WEATHER_1902);
 	}
+
+	// =========================================================================
+	// 메모 (Memo)
+	// =========================================================================
+	static memoNotFound(memoId: number) {
+		return new BusinessException(ErrorCode.MEMO_2001, { memoId });
+	}
+
+	static memoReorderTargetNotFound(targetMemoId: number) {
+		return new BusinessException(ErrorCode.MEMO_2002, { targetMemoId });
+	}
+
+	static memoLimitExceeded(current: number, limit: number) {
+		return new BusinessException(ErrorCode.MEMO_2003, { current, limit });
+	}
 }

--- a/apps/api/src/common/swagger/constants/swagger.constant.ts
+++ b/apps/api/src/common/swagger/constants/swagger.constant.ts
@@ -44,6 +44,9 @@ export const SWAGGER_TAGS = {
 	/** 문의 - 사용자 문의 접수 */
 	INQUIRIES: "Inquiries",
 
+	/** 메모 - 빠른 메모 CRUD, 고정, 순서 변경, 할 일 변환 */
+	MEMOS: "Memos",
+
 	/** 날씨 - 위치 등록, 날씨 예보 조회 */
 	WEATHER: "Weather",
 
@@ -125,6 +128,9 @@ export const SWAGGER_TAG_DESCRIPTIONS: Record<SwaggerTag, string> = {
 
 	[SWAGGER_TAGS.INQUIRIES]:
 		"사용자 문의 접수. 카테고리(버그 신고/기능 요청/기타) + 내용을 관리자 이메일로 발송",
+
+	[SWAGGER_TAGS.MEMOS]:
+		"빠른 메모 CRUD. 핀 고정, 순서 변경, 할 일 변환 지원. 최대 20개/유저",
 
 	[SWAGGER_TAGS.WEATHER]:
 		"날씨 알림용 위치 등록, 날씨 예보 조회. 기상청 단기예보 기반, 격자 캐싱",

--- a/apps/api/src/modules/ai-report/utils/__tests__/habit-tracker.spec.ts
+++ b/apps/api/src/modules/ai-report/utils/__tests__/habit-tracker.spec.ts
@@ -94,6 +94,15 @@ describe("classifyHabit", () => {
 describe("analyzeHabitFormation", () => {
 	const TZ = "Asia/Seoul";
 
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date("2026-03-24T00:00:00+09:00"));
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
 	function makeTodo(
 		title: string,
 		date: string,

--- a/apps/api/src/modules/memo/dtos/index.ts
+++ b/apps/api/src/modules/memo/dtos/index.ts
@@ -1,0 +1,19 @@
+// Request DTOs
+
+export { ConvertMemoToTodoDto } from "./request/convert-memo-to-todo.dto";
+export { CreateMemoDto } from "./request/create-memo.dto";
+export { GetMemosQueryDto } from "./request/get-memos-query.dto";
+export { MemoIdParamDto } from "./request/memo-id-param.dto";
+export { ReorderMemoDto } from "./request/reorder-memo.dto";
+export { ToggleMemoPinDto } from "./request/toggle-memo-pin.dto";
+export { UpdateMemoDto } from "./request/update-memo.dto";
+
+// Response DTOs
+export {
+	ConvertMemoToTodoResponseDto,
+	MemoDeleteResponseDto,
+	MemoListResponseDto,
+	MemoMutationResponseDto,
+	MemoResourceLimitResponseDto,
+	MemoResponseDto,
+} from "./response/memo.response.dto";

--- a/apps/api/src/modules/memo/dtos/request/convert-memo-to-todo.dto.ts
+++ b/apps/api/src/modules/memo/dtos/request/convert-memo-to-todo.dto.ts
@@ -1,0 +1,6 @@
+import { convertMemoToTodoSchema } from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class ConvertMemoToTodoDto extends createZodDto(
+	convertMemoToTodoSchema,
+) {}

--- a/apps/api/src/modules/memo/dtos/request/create-memo.dto.ts
+++ b/apps/api/src/modules/memo/dtos/request/create-memo.dto.ts
@@ -1,0 +1,4 @@
+import { createMemoSchema } from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class CreateMemoDto extends createZodDto(createMemoSchema) {}

--- a/apps/api/src/modules/memo/dtos/request/get-memos-query.dto.ts
+++ b/apps/api/src/modules/memo/dtos/request/get-memos-query.dto.ts
@@ -1,0 +1,4 @@
+import { getMemosQuerySchema } from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class GetMemosQueryDto extends createZodDto(getMemosQuerySchema) {}

--- a/apps/api/src/modules/memo/dtos/request/memo-id-param.dto.ts
+++ b/apps/api/src/modules/memo/dtos/request/memo-id-param.dto.ts
@@ -1,0 +1,4 @@
+import { memoIdParamSchema } from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class MemoIdParamDto extends createZodDto(memoIdParamSchema) {}

--- a/apps/api/src/modules/memo/dtos/request/reorder-memo.dto.ts
+++ b/apps/api/src/modules/memo/dtos/request/reorder-memo.dto.ts
@@ -1,0 +1,4 @@
+import { reorderMemoSchema } from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class ReorderMemoDto extends createZodDto(reorderMemoSchema) {}

--- a/apps/api/src/modules/memo/dtos/request/toggle-memo-pin.dto.ts
+++ b/apps/api/src/modules/memo/dtos/request/toggle-memo-pin.dto.ts
@@ -1,0 +1,4 @@
+import { toggleMemoPinSchema } from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class ToggleMemoPinDto extends createZodDto(toggleMemoPinSchema) {}

--- a/apps/api/src/modules/memo/dtos/request/update-memo.dto.ts
+++ b/apps/api/src/modules/memo/dtos/request/update-memo.dto.ts
@@ -1,0 +1,4 @@
+import { updateMemoSchema } from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class UpdateMemoDto extends createZodDto(updateMemoSchema) {}

--- a/apps/api/src/modules/memo/dtos/response/memo.response.dto.ts
+++ b/apps/api/src/modules/memo/dtos/response/memo.response.dto.ts
@@ -1,0 +1,24 @@
+import {
+	convertMemoToTodoResponseSchema,
+	memoDeleteResponseSchema,
+	memoListResponseSchema,
+	memoMutationResponseSchema,
+	memoResourceLimitResponseSchema,
+	memoSchema,
+} from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class MemoResponseDto extends createZodDto(memoSchema) {}
+export class MemoMutationResponseDto extends createZodDto(
+	memoMutationResponseSchema,
+) {}
+export class MemoDeleteResponseDto extends createZodDto(
+	memoDeleteResponseSchema,
+) {}
+export class MemoListResponseDto extends createZodDto(memoListResponseSchema) {}
+export class ConvertMemoToTodoResponseDto extends createZodDto(
+	convertMemoToTodoResponseSchema,
+) {}
+export class MemoResourceLimitResponseDto extends createZodDto(
+	memoResourceLimitResponseSchema,
+) {}

--- a/apps/api/src/modules/memo/index.ts
+++ b/apps/api/src/modules/memo/index.ts
@@ -1,0 +1,2 @@
+export { MemoModule } from "./memo.module";
+export { MemoService } from "./memo.service";

--- a/apps/api/src/modules/memo/memo.controller.spec.ts
+++ b/apps/api/src/modules/memo/memo.controller.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * MemoController 단위 테스트
+ *
+ * Suites + GWT 패턴 적용
+ * - Suites: TestBed.solitary()로 자동 Mock 생성
+ * - GWT: Given/When/Then 주석으로 테스트 구조화
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test memo.controller
+ * ```
+ */
+
+import type { Mocked } from "@suites/doubles.jest";
+import { TestBed } from "@suites/unit";
+
+import type { CurrentUserPayload } from "@/modules/auth/decorators";
+import type {
+	ConvertMemoToTodoDto,
+	CreateMemoDto,
+	GetMemosQueryDto,
+	ReorderMemoDto,
+	ToggleMemoPinDto,
+	UpdateMemoDto,
+} from "./dtos";
+import { MemoController } from "./memo.controller";
+import { MemoService } from "./memo.service";
+
+describe("MemoController — 메모 컨트롤러", () => {
+	let controller: MemoController;
+	let memoService: Mocked<MemoService>;
+
+	const mockUser: CurrentUserPayload = {
+		userId: "user-123",
+		email: "test@example.com",
+		sessionId: "session-123",
+		role: "USER",
+	};
+
+	beforeEach(async () => {
+		const { unit, unitRef } = await TestBed.solitary(MemoController).compile();
+
+		controller = unit;
+		memoService = unitRef.get(MemoService);
+	});
+
+	describe("create", () => {
+		it("메모 생성 요청을 서비스에 위임하고 결과를 반환해야 한다", async () => {
+			// Given - 생성 DTO와 서비스 응답이 준비되었을 때
+			const dto = { content: "테스트 메모" } as unknown as CreateMemoDto;
+			const serviceResult = {
+				message: "메모가 생성되었습니다.",
+				memo: { id: 1, content: "테스트 메모" },
+			};
+			memoService.create.mockResolvedValue(serviceResult as any);
+
+			// When - create를 호출하면
+			const result = await controller.create(mockUser, dto);
+
+			// Then - 서비스에 userId와 content를 전달하고 결과를 반환해야 한다
+			expect(memoService.create).toHaveBeenCalledWith({
+				userId: mockUser.userId,
+				content: dto.content,
+			});
+			expect(result).toEqual(serviceResult);
+		});
+	});
+
+	describe("findMany", () => {
+		it("메모 목록 조회 요청을 서비스에 위임하고 결과를 반환해야 한다", async () => {
+			// Given - 목록 조회 쿼리와 서비스 응답이 준비되었을 때
+			const query = {
+				cursor: undefined,
+				size: 20,
+			} as unknown as GetMemosQueryDto;
+			const serviceResult = {
+				items: [],
+				pagination: { hasNext: false, nextCursor: null, size: 20 },
+			};
+			memoService.findMany.mockResolvedValue(serviceResult as any);
+
+			// When - findMany를 호출하면
+			const result = await controller.findMany(mockUser, query);
+
+			// Then - 서비스에 userId, cursor, size를 전달하고 결과를 반환해야 한다
+			expect(memoService.findMany).toHaveBeenCalledWith({
+				userId: mockUser.userId,
+				cursor: query.cursor,
+				size: query.size,
+			});
+			expect(result).toEqual(serviceResult);
+		});
+	});
+
+	describe("update", () => {
+		it("메모 수정 요청을 서비스에 위임하고 결과를 반환해야 한다", async () => {
+			// Given - 수정 DTO와 서비스 응답이 준비되었을 때
+			const params = { id: 1 };
+			const dto = { content: "수정된 메모" } as unknown as UpdateMemoDto;
+			const serviceResult = {
+				message: "메모가 수정되었습니다.",
+				memo: { id: 1, content: "수정된 메모" },
+			};
+			memoService.update.mockResolvedValue(serviceResult as any);
+
+			// When - update를 호출하면
+			const result = await controller.update(mockUser, params, dto);
+
+			// Then - 서비스에 userId, memoId, content를 전달하고 결과를 반환해야 한다
+			expect(memoService.update).toHaveBeenCalledWith(
+				mockUser.userId,
+				params.id,
+				{ content: dto.content },
+			);
+			expect(result).toEqual(serviceResult);
+		});
+	});
+
+	describe("togglePin", () => {
+		it("메모 고정/해제 요청을 서비스에 위임하고 결과를 반환해야 한다", async () => {
+			// Given - 고정 토글 DTO와 서비스 응답이 준비되었을 때
+			const params = { id: 1 };
+			const dto = { isPinned: true } as unknown as ToggleMemoPinDto;
+			const serviceResult = {
+				message: "메모가 고정되었습니다.",
+				memo: { id: 1, isPinned: true },
+			};
+			memoService.togglePin.mockResolvedValue(serviceResult as any);
+
+			// When - togglePin을 호출하면
+			const result = await controller.togglePin(mockUser, params, dto);
+
+			// Then - 서비스에 userId, memoId, isPinned를 전달하고 결과를 반환해야 한다
+			expect(memoService.togglePin).toHaveBeenCalledWith(
+				mockUser.userId,
+				params.id,
+				dto.isPinned,
+			);
+			expect(result).toEqual(serviceResult);
+		});
+	});
+
+	describe("reorder", () => {
+		it("메모 순서 변경 요청을 서비스에 위임하고 결과를 반환해야 한다", async () => {
+			// Given - 순서 변경 DTO와 서비스 응답이 준비되었을 때
+			const params = { id: 1 };
+			const dto = {
+				targetMemoId: 2,
+				position: "before",
+			} as unknown as ReorderMemoDto;
+			const serviceResult = {
+				message: "메모 순서가 변경되었습니다.",
+				memo: { id: 1, sortOrder: 0 },
+			};
+			memoService.reorder.mockResolvedValue(serviceResult as any);
+
+			// When - reorder를 호출하면
+			const result = await controller.reorder(mockUser, params, dto);
+
+			// Then - 서비스에 memoId, userId, targetMemoId, position을 전달하고 결과를 반환해야 한다
+			expect(memoService.reorder).toHaveBeenCalledWith(
+				params.id,
+				mockUser.userId,
+				{
+					targetMemoId: dto.targetMemoId,
+					position: dto.position,
+				},
+			);
+			expect(result).toEqual(serviceResult);
+		});
+	});
+
+	describe("remove", () => {
+		it("메모 삭제 요청을 서비스에 위임하고 결과를 반환해야 한다", async () => {
+			// Given - 삭제 대상 메모 ID와 서비스 응답이 준비되었을 때
+			const params = { id: 1 };
+			const serviceResult = { message: "메모가 삭제되었습니다." };
+			memoService.delete.mockResolvedValue(serviceResult);
+
+			// When - remove를 호출하면
+			const result = await controller.remove(mockUser, params);
+
+			// Then - 서비스에 userId와 memoId를 전달하고 결과를 반환해야 한다
+			expect(memoService.delete).toHaveBeenCalledWith(
+				mockUser.userId,
+				params.id,
+			);
+			expect(result).toEqual(serviceResult);
+		});
+	});
+
+	describe("convertToTodo", () => {
+		it("메모를 할 일로 변환 요청을 서비스에 위임하고 Date 객체를 전달해야 한다", async () => {
+			// Given - 변환 DTO와 타임존, 서비스 응답이 준비되었을 때
+			const params = { id: 1 };
+			const dto = {
+				categoryId: "category-1",
+				startDate: "2026-04-06",
+				endDate: undefined,
+				scheduledTime: undefined,
+				isAllDay: true,
+				visibility: "PUBLIC",
+			} as unknown as ConvertMemoToTodoDto;
+			const tz = "Asia/Seoul";
+			const serviceResult = {
+				message: "메모가 할 일로 변환되었습니다.",
+				todo: { id: "todo-1" },
+			};
+			memoService.convertToTodo.mockResolvedValue(serviceResult as any);
+
+			// When - convertToTodo를 호출하면
+			const result = await controller.convertToTodo(mockUser, params, dto, tz);
+
+			// Then - 서비스에 Date 객체가 전달되고 결과를 반환해야 한다
+			expect(memoService.convertToTodo).toHaveBeenCalledWith(
+				mockUser.userId,
+				params.id,
+				{
+					categoryId: dto.categoryId,
+					startDate: expect.any(Date),
+					endDate: undefined,
+					scheduledTime: undefined,
+					isAllDay: dto.isAllDay,
+					visibility: dto.visibility,
+				},
+			);
+			expect(result).toEqual(serviceResult);
+		});
+
+		it("endDate와 scheduledTime이 있으면 Date 객체로 변환하여 전달해야 한다", async () => {
+			// Given - endDate와 scheduledTime이 포함된 DTO가 준비되었을 때
+			const params = { id: 1 };
+			const dto = {
+				categoryId: "category-1",
+				startDate: "2026-04-06",
+				endDate: "2026-04-07",
+				scheduledTime: "14:00",
+				isAllDay: false,
+				visibility: "PRIVATE",
+			} as unknown as ConvertMemoToTodoDto;
+			const tz = "Asia/Seoul";
+			const serviceResult = {
+				message: "메모가 할 일로 변환되었습니다.",
+				todo: { id: "todo-1" },
+			};
+			memoService.convertToTodo.mockResolvedValue(serviceResult as any);
+
+			// When - convertToTodo를 호출하면
+			const result = await controller.convertToTodo(mockUser, params, dto, tz);
+
+			// Then - endDate와 scheduledTime이 Date 객체로 변환되어 전달되어야 한다
+			expect(memoService.convertToTodo).toHaveBeenCalledWith(
+				mockUser.userId,
+				params.id,
+				{
+					categoryId: dto.categoryId,
+					startDate: expect.any(Date),
+					endDate: expect.any(Date),
+					scheduledTime: expect.any(Date),
+					isAllDay: dto.isAllDay,
+					visibility: dto.visibility,
+				},
+			);
+			expect(result).toEqual(serviceResult);
+		});
+	});
+
+	describe("getResourceLimit", () => {
+		it("메모 리소스 제한 정보 조회를 서비스에 위임하고 결과를 반환해야 한다", async () => {
+			// Given - 리소스 제한 정보 서비스 응답이 준비되었을 때
+			const serviceResult = { currentCount: 5, maxPerUser: 50 };
+			memoService.getResourceLimitInfo.mockResolvedValue(serviceResult);
+
+			// When - getResourceLimit를 호출하면
+			const result = await controller.getResourceLimit(mockUser);
+
+			// Then - 서비스에 userId를 전달하고 결과를 반환해야 한다
+			expect(memoService.getResourceLimitInfo).toHaveBeenCalledWith(
+				mockUser.userId,
+			);
+			expect(result).toEqual(serviceResult);
+		});
+	});
+});

--- a/apps/api/src/modules/memo/memo.controller.ts
+++ b/apps/api/src/modules/memo/memo.controller.ts
@@ -1,0 +1,260 @@
+import { ErrorCode } from "@aido/errors";
+import { MEMO_LIMITS } from "@aido/validators";
+import {
+	Body,
+	Controller,
+	Delete,
+	Get,
+	HttpCode,
+	HttpStatus,
+	Logger,
+	Param,
+	Patch,
+	Post,
+	Query,
+} from "@nestjs/common";
+import { ApiBearerAuth, ApiHeader, ApiTags } from "@nestjs/swagger";
+import { parseDateOnly } from "@/common/date/utils/parse";
+import { parseLocalDateTime } from "@/common/date/utils/timezone";
+import { Timezone } from "@/common/decorators";
+
+import {
+	ApiBadRequestError,
+	ApiCreatedResponse,
+	ApiDoc,
+	ApiForbiddenError,
+	ApiNotFoundError,
+	ApiSuccessResponse,
+	ApiUnauthorizedError,
+	SWAGGER_TAGS,
+} from "@/common/swagger";
+
+import { CurrentUser, type CurrentUserPayload } from "../auth/decorators";
+
+import {
+	ConvertMemoToTodoDto,
+	ConvertMemoToTodoResponseDto,
+	CreateMemoDto,
+	GetMemosQueryDto,
+	MemoDeleteResponseDto,
+	MemoIdParamDto,
+	MemoListResponseDto,
+	MemoMutationResponseDto,
+	MemoResourceLimitResponseDto,
+	ReorderMemoDto,
+	ToggleMemoPinDto,
+	UpdateMemoDto,
+} from "./dtos";
+import { MemoService } from "./memo.service";
+
+@ApiTags(SWAGGER_TAGS.MEMOS)
+@ApiBearerAuth()
+@Controller("memos")
+export class MemoController {
+	readonly #logger = new Logger(MemoController.name);
+
+	constructor(private readonly memoService: MemoService) {}
+
+	@Get("resource-limit")
+	@ApiDoc({
+		summary: "메모 리소스 제한 정보 조회",
+		operationId: "getMemoResourceLimit",
+		description: `사용자의 현재 메모 개수와 최대 한도를 조회합니다.
+
+**응답 필드**
+- \`currentCount\`: 현재 메모 개수
+- \`maxPerUser\`: 사용자당 최대 메모 수 (${MEMO_LIMITS.MAX_PER_USER}개)`,
+	})
+	@ApiSuccessResponse({ type: MemoResourceLimitResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	async getResourceLimit(
+		@CurrentUser() user: CurrentUserPayload,
+	): Promise<MemoResourceLimitResponseDto> {
+		return this.memoService.getResourceLimitInfo(user.userId);
+	}
+
+	@Post()
+	@ApiDoc({
+		summary: "메모 생성",
+		operationId: "createMemo",
+		description: `새로운 메모를 생성합니다.
+
+**필수 필드**
+- \`content\`: 메모 내용 (1-${MEMO_LIMITS.MAX_CONTENT_LENGTH}자)
+
+### 제한사항
+
+| 항목 | 제한 |
+|------|------|
+| 사용자당 최대 메모 | ${MEMO_LIMITS.MAX_PER_USER}개 |
+| 메모 내용 길이 | 1-${MEMO_LIMITS.MAX_CONTENT_LENGTH}자 |`,
+	})
+	@ApiCreatedResponse({ type: MemoMutationResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiBadRequestError(ErrorCode.SYS_0002)
+	@ApiForbiddenError(ErrorCode.MEMO_2003)
+	async create(
+		@CurrentUser() user: CurrentUserPayload,
+		@Body() dto: CreateMemoDto,
+	): Promise<MemoMutationResponseDto> {
+		this.#logger.debug(`메모 생성: user=${user.userId}`);
+
+		return this.memoService.create({
+			userId: user.userId,
+			content: dto.content,
+		});
+	}
+
+	@Get()
+	@ApiDoc({
+		summary: "메모 목록 조회",
+		operationId: "getMemos",
+		description: `메모 목록을 조회합니다. 고정된 메모가 먼저 표시됩니다.
+
+**정렬 순서**: 고정 여부(고정 우선) → 수동 순서(오름차순) → ID(오름차순)
+
+**페이지네이션**: 커서 기반. \`pagination.nextCursor\`를 다음 요청의 \`cursor\`에 전달합니다.`,
+	})
+	@ApiSuccessResponse({ type: MemoListResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	async findMany(
+		@CurrentUser() user: CurrentUserPayload,
+		@Query() query: GetMemosQueryDto,
+	): Promise<MemoListResponseDto> {
+		return this.memoService.findMany({
+			userId: user.userId,
+			cursor: query.cursor,
+			size: query.size,
+		});
+	}
+
+	@Patch(":id")
+	@ApiDoc({
+		summary: "메모 수정",
+		operationId: "updateMemo",
+		description: "메모 내용을 수정합니다.",
+	})
+	@ApiSuccessResponse({ type: MemoMutationResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiBadRequestError(ErrorCode.SYS_0002)
+	@ApiNotFoundError(ErrorCode.MEMO_2001)
+	async update(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: MemoIdParamDto,
+		@Body() dto: UpdateMemoDto,
+	): Promise<MemoMutationResponseDto> {
+		return this.memoService.update(user.userId, params.id, {
+			content: dto.content,
+		});
+	}
+
+	@Patch(":id/pin")
+	@ApiDoc({
+		summary: "메모 고정/해제",
+		operationId: "toggleMemoPin",
+		description:
+			"메모를 고정하거나 해제합니다. 고정된 메모는 목록 상단에 표시됩니다.",
+	})
+	@ApiSuccessResponse({ type: MemoMutationResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.MEMO_2001)
+	async togglePin(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: MemoIdParamDto,
+		@Body() dto: ToggleMemoPinDto,
+	): Promise<MemoMutationResponseDto> {
+		return this.memoService.togglePin(user.userId, params.id, dto.isPinned);
+	}
+
+	@Patch(":id/reorder")
+	@ApiDoc({
+		summary: "메모 순서 변경",
+		operationId: "reorderMemo",
+		description: `메모의 순서를 변경합니다.
+
+- \`targetMemoId\`: 기준 메모 ID (생략 시 맨 앞/뒤로 이동)
+- \`position\`: \`before\`(기준 앞) 또는 \`after\`(기준 뒤)`,
+	})
+	@ApiSuccessResponse({ type: MemoMutationResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.MEMO_2001)
+	@ApiNotFoundError(ErrorCode.MEMO_2002)
+	@ApiBadRequestError(ErrorCode.SYS_0002)
+	async reorder(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: MemoIdParamDto,
+		@Body() dto: ReorderMemoDto,
+	): Promise<MemoMutationResponseDto> {
+		return this.memoService.reorder(params.id, user.userId, {
+			targetMemoId: dto.targetMemoId,
+			position: dto.position,
+		});
+	}
+
+	@Delete(":id")
+	@HttpCode(HttpStatus.OK)
+	@ApiDoc({
+		summary: "메모 삭제",
+		operationId: "deleteMemo",
+		description: "메모를 영구 삭제합니다.",
+	})
+	@ApiSuccessResponse({ type: MemoDeleteResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.MEMO_2001)
+	async remove(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: MemoIdParamDto,
+	): Promise<MemoDeleteResponseDto> {
+		return this.memoService.delete(user.userId, params.id);
+	}
+
+	@Post(":id/convert-to-todo")
+	@ApiHeader({
+		name: "X-Timezone",
+		required: false,
+		description: "사용자 타임존 (IANA, 기본값: UTC)",
+		example: "Asia/Seoul",
+	})
+	@ApiDoc({
+		summary: "메모를 할 일로 변환",
+		operationId: "convertMemoToTodo",
+		description: `메모를 할 일로 변환합니다. 변환 후 원본 메모는 삭제됩니다.
+
+**필수 필드**
+- \`categoryId\`: 할 일 카테고리 ID
+- \`startDate\`: 시작 날짜 (YYYY-MM-DD)
+
+**선택 필드**
+- \`endDate\`: 종료 날짜 (YYYY-MM-DD)
+- \`scheduledTime\`: 예정 시간 (HH:mm). \`X-Timezone\` 헤더 기반으로 UTC 변환
+- \`isAllDay\`: 종일 여부 (기본값: true)
+- \`visibility\`: 공개 범위 (PUBLIC/PRIVATE, 기본값: PUBLIC)
+- \`items\`: 하위 항목 배열 (선택, 최대 20개). 할 일과 함께 체크리스트를 일괄 생성합니다.
+
+메모 내용이 할 일의 \`title\`(최대 200자)로 변환됩니다. 200자를 초과하면 잘립니다.`,
+	})
+	@ApiCreatedResponse({ type: ConvertMemoToTodoResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.MEMO_2001)
+	@ApiNotFoundError(ErrorCode.TODO_CATEGORY_0851)
+	@ApiForbiddenError(ErrorCode.TODO_0811)
+	@ApiBadRequestError(ErrorCode.SYS_0002)
+	async convertToTodo(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: MemoIdParamDto,
+		@Body() dto: ConvertMemoToTodoDto,
+		@Timezone() tz: string,
+	): Promise<ConvertMemoToTodoResponseDto> {
+		return this.memoService.convertToTodo(user.userId, params.id, {
+			categoryId: dto.categoryId,
+			startDate: parseDateOnly(dto.startDate),
+			endDate: dto.endDate ? parseDateOnly(dto.endDate) : undefined,
+			scheduledTime: dto.scheduledTime
+				? parseLocalDateTime(dto.startDate, dto.scheduledTime, tz)
+				: undefined,
+			isAllDay: dto.isAllDay,
+			visibility: dto.visibility,
+			items: dto.items,
+		});
+	}
+}

--- a/apps/api/src/modules/memo/memo.mapper.spec.ts
+++ b/apps/api/src/modules/memo/memo.mapper.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * MemoMapper 매퍼 단위 테스트
+ *
+ * @description
+ * MemoMapper의 변환 로직을 테스트합니다.
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test memo.mapper
+ * ```
+ */
+import { MemoBuilder } from "@test/builders";
+import { MemoMapper } from "./memo.mapper";
+
+describe("MemoMapper — 메모 매퍼", () => {
+	beforeEach(() => {
+		MemoBuilder.resetIdCounter();
+	});
+
+	describe("toResponse", () => {
+		it("Memo 엔티티를 응답 DTO로 변환한다", () => {
+			// Given
+			const memo = MemoBuilder.create("user-1")
+				.withId(1)
+				.withContent("테스트 메모")
+				.withSortOrder(3)
+				.build();
+
+			// When
+			const result = MemoMapper.toResponse(memo);
+
+			// Then
+			expect(result.id).toBe(1);
+			expect(result.userId).toBe("user-1");
+			expect(result.content).toBe("테스트 메모");
+			expect(result.isPinned).toBe(false);
+			expect(result.sortOrder).toBe(3);
+			expect(typeof result.createdAt).toBe("string");
+			expect(typeof result.updatedAt).toBe("string");
+		});
+
+		it("고정된 메모의 isPinned을 true로 변환한다", () => {
+			// Given
+			const memo = MemoBuilder.create("user-1").pinned().build();
+
+			// When
+			const result = MemoMapper.toResponse(memo);
+
+			// Then
+			expect(result.isPinned).toBe(true);
+		});
+
+		it("Date를 ISO 문자열로 변환한다", () => {
+			// Given
+			const fixedDate = new Date("2025-01-15T09:00:00.000Z");
+			const memo = MemoBuilder.create("user-1")
+				.withCreatedAt(fixedDate)
+				.build();
+
+			// When
+			const result = MemoMapper.toResponse(memo);
+
+			// Then
+			expect(result.createdAt).toBe("2025-01-15T09:00:00.000Z");
+		});
+	});
+
+	describe("toManyResponse", () => {
+		it("Memo 배열을 응답 DTO 배열로 변환한다", () => {
+			// Given
+			const memos = [
+				MemoBuilder.create("user-1").withId(1).withContent("메모 1").build(),
+				MemoBuilder.create("user-2").withId(2).withContent("메모 2").build(),
+			];
+
+			// When
+			const result = MemoMapper.toManyResponse(memos);
+
+			// Then
+			expect(result).toHaveLength(2);
+			expect(result[0]?.id).toBe(1);
+			expect(result[0]?.content).toBe("메모 1");
+			expect(result[1]?.id).toBe(2);
+			expect(result[1]?.content).toBe("메모 2");
+		});
+
+		it("빈 배열을 전달하면 빈 배열을 반환한다", () => {
+			// Given
+			const memos: ReturnType<typeof MemoBuilder.prototype.build>[] = [];
+
+			// When
+			const result = MemoMapper.toManyResponse(memos);
+
+			// Then
+			expect(result).toEqual([]);
+		});
+	});
+});

--- a/apps/api/src/modules/memo/memo.mapper.ts
+++ b/apps/api/src/modules/memo/memo.mapper.ts
@@ -1,0 +1,21 @@
+import type { Memo as MemoResponse } from "@aido/validators";
+import { toISOString } from "@/common/date/utils/format";
+import type { Memo } from "@/generated/prisma/client";
+
+export abstract class MemoMapper {
+	static toResponse(entity: Memo): MemoResponse {
+		return {
+			id: entity.id,
+			userId: entity.userId,
+			content: entity.content,
+			isPinned: entity.isPinned,
+			sortOrder: entity.sortOrder,
+			createdAt: toISOString(entity.createdAt),
+			updatedAt: toISOString(entity.updatedAt),
+		};
+	}
+
+	static toManyResponse(entities: Memo[]): MemoResponse[] {
+		return entities.map((e) => MemoMapper.toResponse(e));
+	}
+}

--- a/apps/api/src/modules/memo/memo.module.ts
+++ b/apps/api/src/modules/memo/memo.module.ts
@@ -1,0 +1,27 @@
+/**
+ * 메모 모듈
+ *
+ * 빠른 메모 CRUD, 고정, 순서 변경, 할 일 변환 기능을 제공합니다.
+ *
+ * @module MemoModule
+ *
+ * ## 의존성
+ * - TodoModule: 메모 → 할 일 변환 시 TodoService 사용
+ *
+ * ## 제한사항
+ * - 사용자당 최대 20개
+ * - 메모 내용 최대 5000자
+ */
+import { Module } from "@nestjs/common";
+import { TodoModule } from "../todo/todo.module";
+import { MemoController } from "./memo.controller";
+import { MemoRepository } from "./memo.repository";
+import { MemoService } from "./memo.service";
+
+@Module({
+	imports: [TodoModule],
+	controllers: [MemoController],
+	providers: [MemoRepository, MemoService],
+	exports: [MemoService],
+})
+export class MemoModule {}

--- a/apps/api/src/modules/memo/memo.repository.spec.ts
+++ b/apps/api/src/modules/memo/memo.repository.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * MemoRepository 단위 테스트
+ *
+ * @description
+ * MemoRepository의 데이터 접근 메서드를 격리 테스트합니다.
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test memo.repository
+ * ```
+ */
+import type { Mocked } from "@suites/doubles.jest";
+import { TestBed } from "@suites/unit";
+
+import { DatabaseService } from "@/database";
+
+import { MemoRepository } from "./memo.repository";
+
+describe("MemoRepository — 메모 리포지토리", () => {
+	let repository: MemoRepository;
+	let db: Mocked<DatabaseService>;
+
+	beforeEach(async () => {
+		const { unit, unitRef } = await TestBed.solitary(MemoRepository).compile();
+
+		repository = unit;
+		db = unitRef.get(DatabaseService);
+	});
+
+	describe("findManyByUserId", () => {
+		const userId = "user-123";
+
+		it("isPinned desc, sortOrder asc, id asc 순서로 정렬하여 조회해야 한다", async () => {
+			// Given - 빈 결과가 준비되었을 때
+			(db.memo.findMany as jest.Mock).mockResolvedValue([]);
+
+			// When - findManyByUserId를 호출하면
+			await repository.findManyByUserId({
+				userId,
+				cursor: undefined,
+				size: 20,
+			});
+
+			// Then - orderBy가 [isPinned desc, sortOrder asc, id asc]이어야 한다
+			expect(db.memo.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					orderBy: [{ isPinned: "desc" }, { sortOrder: "asc" }, { id: "asc" }],
+				}),
+			);
+		});
+
+		it("take를 size + 1로 설정하여 다음 페이지 존재 여부를 확인해야 한다", async () => {
+			// Given - 빈 결과가 준비되었을 때
+			(db.memo.findMany as jest.Mock).mockResolvedValue([]);
+			const size = 20;
+
+			// When - findManyByUserId를 호출하면
+			await repository.findManyByUserId({ userId, cursor: undefined, size });
+
+			// Then - take가 size + 1이어야 한다
+			expect(db.memo.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					take: size + 1,
+				}),
+			);
+		});
+
+		it("커서가 없으면 skip과 cursor 없이 조회해야 한다", async () => {
+			// Given - 커서 없이 조회할 때
+			(db.memo.findMany as jest.Mock).mockResolvedValue([]);
+
+			// When - cursor를 undefined로 호출하면
+			await repository.findManyByUserId({
+				userId,
+				cursor: undefined,
+				size: 20,
+			});
+
+			// Then - skip과 cursor가 포함되지 않아야 한다
+			const calledArgs = (db.memo.findMany as jest.Mock).mock.calls[0][0];
+			expect(calledArgs.skip).toBeUndefined();
+			expect(calledArgs.cursor).toBeUndefined();
+		});
+
+		it("커서가 있으면 skip: 1과 cursor를 설정하여 조회해야 한다", async () => {
+			// Given - 커서가 있을 때
+			(db.memo.findMany as jest.Mock).mockResolvedValue([]);
+			const cursor = 5;
+
+			// When - cursor를 전달하여 호출하면
+			await repository.findManyByUserId({ userId, cursor, size: 20 });
+
+			// Then - skip: 1과 cursor: { id: cursor }가 설정되어야 한다
+			expect(db.memo.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					skip: 1,
+					cursor: { id: cursor },
+				}),
+			);
+		});
+	});
+
+	describe("countByUserId", () => {
+		it("userId로 메모 개수를 조회해야 한다", async () => {
+			// Given - 메모 5개가 존재할 때
+			const userId = "user-123";
+			(db.memo.count as jest.Mock).mockResolvedValue(5);
+
+			// When - countByUserId를 호출하면
+			const result = await repository.countByUserId(userId);
+
+			// Then - where: { userId }로 조회하고 결과를 반환해야 한다
+			expect(db.memo.count).toHaveBeenCalledWith({
+				where: { userId },
+			});
+			expect(result).toBe(5);
+		});
+	});
+
+	describe("shiftSortOrders", () => {
+		const userId = "user-123";
+
+		it("gte와 lte 범위로 sortOrder를 증감해야 한다", async () => {
+			// Given - updateMany가 2개 행을 업데이트할 때
+			(db.memo.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+			// When - shiftSortOrders를 호출하면
+			const result = await repository.shiftSortOrders(userId, 3, 7, 1);
+
+			// Then - gte/lte 범위와 increment delta로 updateMany가 호출되어야 한다
+			expect(db.memo.updateMany).toHaveBeenCalledWith({
+				where: {
+					userId,
+					sortOrder: {
+						gte: 3,
+						lte: 7,
+					},
+				},
+				data: { sortOrder: { increment: 1 } },
+			});
+			expect(result).toBe(2);
+		});
+
+		it("toSortOrder가 null이면 lte 조건 없이 조회해야 한다", async () => {
+			// Given - updateMany가 3개 행을 업데이트할 때
+			(db.memo.updateMany as jest.Mock).mockResolvedValue({ count: 3 });
+
+			// When - toSortOrder를 null로 호출하면
+			const result = await repository.shiftSortOrders(userId, 5, null, -1);
+
+			// Then - lte 조건 없이 gte만 설정되어야 한다
+			expect(db.memo.updateMany).toHaveBeenCalledWith({
+				where: {
+					userId,
+					sortOrder: {
+						gte: 5,
+					},
+				},
+				data: { sortOrder: { increment: -1 } },
+			});
+			expect(result).toBe(3);
+		});
+	});
+
+	describe("getMaxSortOrder", () => {
+		const userId = "user-123";
+
+		it("가장 큰 sortOrder 값을 반환해야 한다", async () => {
+			// Given - 최대 sortOrder가 3일 때
+			(db.memo.aggregate as jest.Mock).mockResolvedValue({
+				_max: { sortOrder: 3 },
+			});
+
+			// When - getMaxSortOrder를 호출하면
+			const result = await repository.getMaxSortOrder(userId);
+
+			// Then - aggregate로 _max.sortOrder를 조회하고 결과를 반환해야 한다
+			expect(db.memo.aggregate).toHaveBeenCalledWith({
+				where: { userId },
+				_max: { sortOrder: true },
+			});
+			expect(result).toBe(3);
+		});
+
+		it("메모가 없으면 -1을 반환해야 한다", async () => {
+			// Given - 메모가 없어서 _max.sortOrder가 null일 때
+			(db.memo.aggregate as jest.Mock).mockResolvedValue({
+				_max: { sortOrder: null },
+			});
+
+			// When - getMaxSortOrder를 호출하면
+			const result = await repository.getMaxSortOrder(userId);
+
+			// Then - -1을 반환해야 한다
+			expect(result).toBe(-1);
+		});
+	});
+});

--- a/apps/api/src/modules/memo/memo.repository.ts
+++ b/apps/api/src/modules/memo/memo.repository.ts
@@ -1,0 +1,113 @@
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "@/database/database.service";
+import type { Memo, Prisma } from "@/generated/prisma/client";
+import type { FindMemosParams, TransactionClient } from "./types";
+
+@Injectable()
+export class MemoRepository {
+	constructor(private readonly database: DatabaseService) {}
+
+	async create(
+		data: Prisma.MemoCreateInput,
+		tx?: TransactionClient,
+	): Promise<Memo> {
+		const client = tx ?? this.database;
+		return client.memo.create({ data });
+	}
+
+	async findByIdAndUserId(
+		id: number,
+		userId: string,
+		tx?: TransactionClient,
+	): Promise<Memo | null> {
+		const client = tx ?? this.database;
+		return client.memo.findFirst({
+			where: { id, userId },
+		});
+	}
+
+	async findManyByUserId(
+		params: FindMemosParams,
+		tx?: TransactionClient,
+	): Promise<Memo[]> {
+		const { userId, cursor, size } = params;
+		const client = tx ?? this.database;
+
+		return client.memo.findMany({
+			where: { userId },
+			take: size + 1,
+			...(cursor != null && {
+				skip: 1,
+				cursor: { id: cursor },
+			}),
+			orderBy: [{ isPinned: "desc" }, { sortOrder: "asc" }, { id: "asc" }],
+		});
+	}
+
+	async countByUserId(userId: string, tx?: TransactionClient): Promise<number> {
+		const client = tx ?? this.database;
+		return client.memo.count({ where: { userId } });
+	}
+
+	async update(
+		id: number,
+		data: Prisma.MemoUpdateInput,
+		tx?: TransactionClient,
+	): Promise<Memo> {
+		const client = tx ?? this.database;
+		return client.memo.update({
+			where: { id },
+			data,
+		});
+	}
+
+	async delete(id: number, tx?: TransactionClient): Promise<Memo> {
+		const client = tx ?? this.database;
+		return client.memo.delete({ where: { id } });
+	}
+
+	async getMaxSortOrder(
+		userId: string,
+		tx?: TransactionClient,
+	): Promise<number> {
+		const client = tx ?? this.database;
+		const result = await client.memo.aggregate({
+			where: { userId },
+			_max: { sortOrder: true },
+		});
+		return result._max.sortOrder ?? -1;
+	}
+
+	async shiftSortOrders(
+		userId: string,
+		fromSortOrder: number,
+		toSortOrder: number | null,
+		delta: number,
+		tx?: TransactionClient,
+	): Promise<number> {
+		const client = tx ?? this.database;
+		const result = await client.memo.updateMany({
+			where: {
+				userId,
+				sortOrder: {
+					gte: fromSortOrder,
+					...(toSortOrder !== null && { lte: toSortOrder }),
+				},
+			},
+			data: { sortOrder: { increment: delta } },
+		});
+		return result.count;
+	}
+
+	async updateSortOrder(
+		id: number,
+		sortOrder: number,
+		tx?: TransactionClient,
+	): Promise<Memo> {
+		const client = tx ?? this.database;
+		return client.memo.update({
+			where: { id },
+			data: { sortOrder },
+		});
+	}
+}

--- a/apps/api/src/modules/memo/memo.service.spec.ts
+++ b/apps/api/src/modules/memo/memo.service.spec.ts
@@ -1,0 +1,330 @@
+/**
+ * MemoService 단위 테스트
+ *
+ * Suites + Builder + GWT 패턴 적용
+ * - Suites: TestBed.solitary()로 자동 Mock 생성
+ * - Builder: MemoBuilder로 테스트 데이터 생성
+ * - GWT: Given/When/Then 주석으로 테스트 구조 명확화
+ */
+
+import { MEMO_LIMITS } from "@aido/validators";
+import type { Mocked } from "@suites/doubles.jest";
+import { TestBed } from "@suites/unit";
+import { MemoBuilder } from "@test/builders";
+import { PaginationService } from "@/common/pagination";
+import { DatabaseService } from "@/database/database.service";
+import { TodoService } from "@/modules/todo/todo.service";
+import { MemoRepository } from "./memo.repository";
+import { MemoService } from "./memo.service";
+
+describe("MemoService — 메모 서비스", () => {
+	let service: MemoService;
+	let memoRepo: Mocked<MemoRepository>;
+	let database: Mocked<DatabaseService>;
+	let todoService: Mocked<TodoService>;
+	let _paginationService: Mocked<PaginationService>;
+
+	const mockUserId = "user-123";
+
+	beforeEach(async () => {
+		// Given - ID 카운터 리셋으로 테스트 간 격리 보장
+		MemoBuilder.resetIdCounter();
+
+		const { unit, unitRef } = await TestBed.solitary(MemoService).compile();
+
+		service = unit;
+		memoRepo = unitRef.get(MemoRepository);
+		database = unitRef.get(DatabaseService);
+		todoService = unitRef.get(TodoService);
+		_paginationService = unitRef.get(PaginationService);
+
+		// Given - 기본 transaction mock 설정
+		(database.$transaction as jest.Mock).mockImplementation(
+			(callback: (tx: unknown) => Promise<unknown>) => callback({}),
+		);
+	});
+
+	describe("create", () => {
+		it("최대 sortOrder + 1로 새 메모를 생성해야 한다", async () => {
+			// Given - 현재 5개 메모, 최대 sortOrder 3
+			(memoRepo.countByUserId as jest.Mock).mockResolvedValue(5);
+			(memoRepo.getMaxSortOrder as jest.Mock).mockResolvedValue(3);
+			const expectedMemo = MemoBuilder.create(mockUserId)
+				.withSortOrder(4)
+				.build();
+			(memoRepo.create as jest.Mock).mockResolvedValue(expectedMemo);
+
+			// When
+			const result = await service.create({
+				userId: mockUserId,
+				content: "새 메모",
+			});
+
+			// Then
+			expect(result.message).toBeDefined();
+			expect(result.memo).toBeDefined();
+			expect(memoRepo.create).toHaveBeenCalledWith(
+				expect.objectContaining({ sortOrder: 4 }),
+				expect.anything(),
+			);
+		});
+
+		it("20개 초과 시 memoLimitExceeded 에러를 던져야 한다", async () => {
+			// Given - 이미 20개 메모 존재
+			(memoRepo.countByUserId as jest.Mock).mockResolvedValue(
+				MEMO_LIMITS.MAX_PER_USER,
+			);
+
+			// When & Then
+			await expect(
+				service.create({ userId: mockUserId, content: "초과 메모" }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("getResourceLimitInfo", () => {
+		it("현재 메모 개수와 최대 한도를 반환해야 한다", async () => {
+			// Given
+			(memoRepo.countByUserId as jest.Mock).mockResolvedValue(7);
+
+			// When
+			const result = await service.getResourceLimitInfo(mockUserId);
+
+			// Then
+			expect(result).toEqual({
+				currentCount: 7,
+				maxPerUser: MEMO_LIMITS.MAX_PER_USER,
+			});
+		});
+	});
+
+	describe("update", () => {
+		it("메모 내용을 수정해야 한다", async () => {
+			// Given
+			const memo = MemoBuilder.create(mockUserId).build();
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(memo);
+			const updatedMemo = MemoBuilder.create(mockUserId)
+				.withId(memo.id)
+				.withContent("수정된 내용")
+				.build();
+			(memoRepo.update as jest.Mock).mockResolvedValue(updatedMemo);
+
+			// When
+			const result = await service.update(mockUserId, memo.id, {
+				content: "수정된 내용",
+			});
+
+			// Then
+			expect(result.message).toBeDefined();
+			expect(result.memo).toBeDefined();
+			expect(memoRepo.update).toHaveBeenCalledWith(memo.id, {
+				content: "수정된 내용",
+			});
+		});
+
+		it("메모가 없으면 에러를 던져야 한다", async () => {
+			// Given
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(null);
+
+			// When & Then
+			await expect(
+				service.update(mockUserId, 999, { content: "test" }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("togglePin", () => {
+		it("메모를 고정해야 한다", async () => {
+			// Given
+			const memo = MemoBuilder.create(mockUserId).build();
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(memo);
+			const pinnedMemo = MemoBuilder.create(mockUserId)
+				.withId(memo.id)
+				.pinned()
+				.build();
+			(memoRepo.update as jest.Mock).mockResolvedValue(pinnedMemo);
+
+			// When
+			const result = await service.togglePin(mockUserId, memo.id, true);
+
+			// Then
+			expect(result.message).toBeDefined();
+			expect(result.memo).toBeDefined();
+			expect(memoRepo.update).toHaveBeenCalledWith(memo.id, {
+				isPinned: true,
+			});
+		});
+
+		it("메모가 없으면 에러를 던져야 한다", async () => {
+			// Given
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(null);
+
+			// When & Then
+			await expect(service.togglePin(mockUserId, 999, true)).rejects.toThrow();
+		});
+	});
+
+	describe("reorder", () => {
+		it("targetMemoId가 자기 자신이면 그대로 반환해야 한다", async () => {
+			// Given
+			const memo = MemoBuilder.create(mockUserId).withSortOrder(2).build();
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(memo);
+
+			// When
+			const result = await service.reorder(memo.id, mockUserId, {
+				targetMemoId: memo.id,
+				position: "before",
+			});
+
+			// Then
+			expect(result.message).toBeDefined();
+			expect(result.memo).toBeDefined();
+			expect(memoRepo.shiftSortOrders).not.toHaveBeenCalled();
+			expect(memoRepo.updateSortOrder).not.toHaveBeenCalled();
+		});
+
+		it("기준 메모 앞으로 이동해야 한다", async () => {
+			// Given - memo(id=1, sortOrder=3)를 target(id=2, sortOrder=1) 앞으로 이동
+			const memo = MemoBuilder.create(mockUserId).withSortOrder(3).build();
+			const targetMemo = MemoBuilder.create(mockUserId)
+				.withSortOrder(1)
+				.build();
+			(memoRepo.findByIdAndUserId as jest.Mock)
+				.mockResolvedValueOnce(memo)
+				.mockResolvedValueOnce(targetMemo);
+			(memoRepo.shiftSortOrders as jest.Mock).mockResolvedValue(1);
+			const reorderedMemo = MemoBuilder.create(mockUserId)
+				.withId(memo.id)
+				.withSortOrder(1)
+				.build();
+			(memoRepo.updateSortOrder as jest.Mock).mockResolvedValue(reorderedMemo);
+
+			// When
+			const result = await service.reorder(memo.id, mockUserId, {
+				targetMemoId: targetMemo.id,
+				position: "before",
+			});
+
+			// Then
+			expect(result.message).toBeDefined();
+			expect(memoRepo.shiftSortOrders).toHaveBeenCalled();
+			expect(memoRepo.updateSortOrder).toHaveBeenCalled();
+		});
+
+		it("기준 메모가 없으면 에러를 던져야 한다", async () => {
+			// Given
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(null);
+
+			// When & Then
+			await expect(
+				service.reorder(999, mockUserId, {
+					targetMemoId: 1,
+					position: "before",
+				}),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("delete", () => {
+		it("메모를 삭제해야 한다", async () => {
+			// Given
+			const memo = MemoBuilder.create(mockUserId).build();
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(memo);
+			(memoRepo.delete as jest.Mock).mockResolvedValue(memo);
+
+			// When
+			const result = await service.delete(mockUserId, memo.id);
+
+			// Then
+			expect(result.message).toBeDefined();
+			expect(memoRepo.delete).toHaveBeenCalledWith(memo.id);
+		});
+
+		it("메모가 없으면 에러를 던져야 한다", async () => {
+			// Given
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(null);
+
+			// When & Then
+			await expect(service.delete(mockUserId, 999)).rejects.toThrow();
+		});
+	});
+
+	describe("convertToTodo", () => {
+		const convertData = {
+			categoryId: 1,
+			startDate: new Date("2024-01-15"),
+			isAllDay: true,
+			visibility: "PUBLIC" as const,
+		};
+
+		it("메모를 할 일로 변환하고 메모를 삭제해야 한다", async () => {
+			// Given
+			const memo = MemoBuilder.create(mockUserId)
+				.withContent("할 일로 변환할 메모")
+				.build();
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(memo);
+			(todoService.create as jest.Mock).mockResolvedValue({
+				id: 1,
+				title: "할 일로 변환할 메모",
+			});
+			(memoRepo.delete as jest.Mock).mockResolvedValue(memo);
+
+			// When
+			const result = await service.convertToTodo(
+				mockUserId,
+				memo.id,
+				convertData,
+			);
+
+			// Then
+			expect(result.message).toBeDefined();
+			expect(result.todo).toBeDefined();
+			expect(todoService.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					userId: mockUserId,
+					title: "할 일로 변환할 메모",
+				}),
+			);
+			expect(memoRepo.delete).toHaveBeenCalledWith(memo.id);
+		});
+
+		it("200자 초과 메모는 title이 200자로 잘려야 한다", async () => {
+			// Given - 200자 초과 메모
+			const longContent = "가".repeat(201);
+			const memo = MemoBuilder.create(mockUserId)
+				.withContent(longContent)
+				.build();
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(memo);
+			(todoService.create as jest.Mock).mockResolvedValue({
+				id: 1,
+				title: longContent.substring(0, 200),
+			});
+			(memoRepo.delete as jest.Mock).mockResolvedValue(memo);
+
+			// When
+			await service.convertToTodo(mockUserId, memo.id, convertData);
+
+			// Then
+			expect(todoService.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: longContent.substring(0, 200),
+				}),
+			);
+			expect(todoService.create).toHaveBeenCalledWith(
+				expect.not.objectContaining({
+					content: expect.anything(),
+				}),
+			);
+		});
+
+		it("메모가 없으면 에러를 던져야 한다", async () => {
+			// Given
+			(memoRepo.findByIdAndUserId as jest.Mock).mockResolvedValue(null);
+
+			// When & Then
+			await expect(
+				service.convertToTodo(mockUserId, 999, convertData),
+			).rejects.toThrow();
+		});
+	});
+});

--- a/apps/api/src/modules/memo/memo.service.ts
+++ b/apps/api/src/modules/memo/memo.service.ts
@@ -1,0 +1,338 @@
+import {
+	MEMO_LIMITS,
+	type Memo as MemoResponse,
+	type Todo,
+} from "@aido/validators";
+import { Injectable, Logger } from "@nestjs/common";
+import type { TransactionClient } from "@/common/database";
+import { BusinessExceptions } from "@/common/exception/services/business-exception.service";
+import type { CursorPaginatedResponse } from "@/common/pagination";
+import { PaginationService } from "@/common/pagination";
+import { DatabaseService } from "@/database/database.service";
+import { TodoService } from "../todo/todo.service";
+import { MemoMapper } from "./memo.mapper";
+import { MemoRepository } from "./memo.repository";
+import type {
+	ConvertMemoToTodoData,
+	CreateMemoData,
+	UpdateMemoData,
+} from "./types";
+
+@Injectable()
+export class MemoService {
+	readonly #logger = new Logger(MemoService.name);
+
+	constructor(
+		private readonly memoRepository: MemoRepository,
+		private readonly paginationService: PaginationService,
+		private readonly database: DatabaseService,
+		private readonly todoService: TodoService,
+	) {}
+
+	/**
+	 * 메모 생성
+	 */
+	async create(
+		data: CreateMemoData,
+	): Promise<{ message: string; memo: MemoResponse }> {
+		// TX 내에서 제한 체크 + sortOrder 결정 + 생성 (race condition 방지)
+		const memo = await this.database.$transaction(async (tx) => {
+			const count = await this.memoRepository.countByUserId(data.userId, tx);
+			if (count >= MEMO_LIMITS.MAX_PER_USER) {
+				throw BusinessExceptions.memoLimitExceeded(
+					count,
+					MEMO_LIMITS.MAX_PER_USER,
+				);
+			}
+
+			const maxSortOrder = await this.memoRepository.getMaxSortOrder(
+				data.userId,
+				tx,
+			);
+
+			return this.memoRepository.create(
+				{
+					user: { connect: { id: data.userId } },
+					content: data.content,
+					sortOrder: maxSortOrder + 1,
+				},
+				tx,
+			);
+		});
+
+		this.#logger.log(`Memo created: ${memo.id} for user: ${data.userId}`);
+
+		return {
+			message: "메모가 생성되었습니다.",
+			memo: MemoMapper.toResponse(memo),
+		};
+	}
+
+	/**
+	 * 메모 목록 조회 (커서 기반 페이지네이션)
+	 */
+	async findMany(params: {
+		userId: string;
+		cursor?: number;
+		size?: number;
+	}): Promise<CursorPaginatedResponse<MemoResponse, number>> {
+		const { cursor, size } =
+			this.paginationService.normalizeCursorPagination<number>({
+				cursor: params.cursor,
+				size: params.size,
+			});
+
+		const memos = await this.memoRepository.findManyByUserId({
+			userId: params.userId,
+			cursor,
+			size,
+		});
+
+		return this.paginationService.createCursorPaginatedResponse<
+			MemoResponse,
+			number
+		>({
+			items: MemoMapper.toManyResponse(memos),
+			size,
+		});
+	}
+
+	/**
+	 * 메모 리소스 제한 정보 조회
+	 */
+	async getResourceLimitInfo(
+		userId: string,
+	): Promise<{ currentCount: number; maxPerUser: number }> {
+		const currentCount = await this.memoRepository.countByUserId(userId);
+		return { currentCount, maxPerUser: MEMO_LIMITS.MAX_PER_USER };
+	}
+
+	/**
+	 * 메모 수정
+	 */
+	async update(
+		userId: string,
+		memoId: number,
+		data: UpdateMemoData,
+	): Promise<{ message: string; memo: MemoResponse }> {
+		const memo = await this.memoRepository.findByIdAndUserId(memoId, userId);
+		if (!memo) {
+			throw BusinessExceptions.memoNotFound(memoId);
+		}
+
+		const updated = await this.memoRepository.update(memoId, {
+			content: data.content,
+		});
+
+		this.#logger.log(`Memo updated: ${memoId} for user: ${userId}`);
+
+		return {
+			message: "메모가 수정되었습니다.",
+			memo: MemoMapper.toResponse(updated),
+		};
+	}
+
+	/**
+	 * 메모 핀 토글
+	 */
+	async togglePin(
+		userId: string,
+		memoId: number,
+		isPinned: boolean,
+	): Promise<{ message: string; memo: MemoResponse }> {
+		const memo = await this.memoRepository.findByIdAndUserId(memoId, userId);
+		if (!memo) {
+			throw BusinessExceptions.memoNotFound(memoId);
+		}
+
+		const updated = await this.memoRepository.update(memoId, { isPinned });
+
+		this.#logger.log(
+			`Memo ${isPinned ? "pinned" : "unpinned"}: ${memoId} for user: ${userId}`,
+		);
+
+		return {
+			message: isPinned
+				? "메모가 고정되었습니다."
+				: "메모 고정이 해제되었습니다.",
+			memo: MemoMapper.toResponse(updated),
+		};
+	}
+
+	/**
+	 * 메모 순서 변경
+	 */
+	async reorder(
+		id: number,
+		userId: string,
+		data: { targetMemoId?: number; position: "before" | "after" },
+	): Promise<{ message: string; memo: MemoResponse }> {
+		const { targetMemoId, position } = data;
+
+		return this.database.$transaction(async (tx) => {
+			const memo = await this.memoRepository.findByIdAndUserId(id, userId, tx);
+			if (!memo) {
+				throw BusinessExceptions.memoNotFound(id);
+			}
+
+			if (targetMemoId === id) {
+				return {
+					message: "메모 순서가 변경되었습니다.",
+					memo: MemoMapper.toResponse(memo),
+				};
+			}
+
+			const newSortOrder = targetMemoId
+				? await this.#reorderRelativeTo(
+						memo.sortOrder,
+						targetMemoId,
+						position,
+						userId,
+						tx,
+					)
+				: await this.#reorderToEdge(memo.sortOrder, position, userId, tx);
+
+			const updated = await this.memoRepository.updateSortOrder(
+				id,
+				newSortOrder,
+				tx,
+			);
+
+			this.#logger.log(
+				`Memo reordered: ${id} to sortOrder ${newSortOrder} for user: ${userId}`,
+			);
+
+			return {
+				message: "메모 순서가 변경되었습니다.",
+				memo: MemoMapper.toResponse(updated),
+			};
+		});
+	}
+
+	/**
+	 * 메모 삭제
+	 */
+	async delete(userId: string, memoId: number): Promise<{ message: string }> {
+		const memo = await this.memoRepository.findByIdAndUserId(memoId, userId);
+		if (!memo) {
+			throw BusinessExceptions.memoNotFound(memoId);
+		}
+
+		await this.memoRepository.delete(memoId);
+
+		this.#logger.log(`Memo deleted: ${memoId} for user: ${userId}`);
+
+		return { message: "메모가 삭제되었습니다." };
+	}
+
+	/**
+	 * 메모를 할 일로 변환
+	 */
+	async convertToTodo(
+		userId: string,
+		memoId: number,
+		data: ConvertMemoToTodoData,
+	): Promise<{ message: string; todo: Todo }> {
+		// 1. 메모 존재/소유권 확인 (읽기 전용, TX 외부)
+		const memo = await this.memoRepository.findByIdAndUserId(memoId, userId);
+		if (!memo) {
+			throw BusinessExceptions.memoNotFound(memoId);
+		}
+
+		// 2. Todo 생성 (TodoService.create 내부 TX)
+		const todo = await this.todoService.create({
+			userId,
+			title: memo.content.substring(0, 200),
+			categoryId: data.categoryId,
+			startDate: data.startDate,
+			endDate: data.endDate,
+			scheduledTime: data.scheduledTime,
+			isAllDay: data.isAllDay ?? true,
+			visibility: data.visibility ?? "PUBLIC",
+			items: data.items,
+		});
+
+		// 3. 메모 삭제 (Todo 생성 커밋 후)
+		await this.memoRepository.delete(memoId);
+
+		this.#logger.log(
+			`Memo ${memoId} converted to todo ${todo.id} for user: ${userId}`,
+		);
+
+		return { message: "메모가 할 일로 변환되었습니다.", todo };
+	}
+
+	// =========================================================================
+	// Private helpers — reorder
+	// =========================================================================
+
+	async #reorderRelativeTo(
+		currentSortOrder: number,
+		targetMemoId: number,
+		position: "before" | "after",
+		userId: string,
+		tx: TransactionClient,
+	): Promise<number> {
+		const targetMemo = await this.memoRepository.findByIdAndUserId(
+			targetMemoId,
+			userId,
+			tx,
+		);
+
+		if (!targetMemo) {
+			throw BusinessExceptions.memoReorderTargetNotFound(targetMemoId);
+		}
+
+		let newSortOrder =
+			position === "before" ? targetMemo.sortOrder : targetMemo.sortOrder + 1;
+
+		if (currentSortOrder < newSortOrder) {
+			await this.memoRepository.shiftSortOrders(
+				userId,
+				currentSortOrder + 1,
+				newSortOrder - 1,
+				-1,
+				tx,
+			);
+			newSortOrder -= 1;
+		} else {
+			await this.memoRepository.shiftSortOrders(
+				userId,
+				newSortOrder,
+				currentSortOrder - 1,
+				1,
+				tx,
+			);
+		}
+
+		return newSortOrder;
+	}
+
+	async #reorderToEdge(
+		currentSortOrder: number,
+		position: "before" | "after",
+		userId: string,
+		tx: TransactionClient,
+	): Promise<number> {
+		if (position === "before") {
+			await this.memoRepository.shiftSortOrders(
+				userId,
+				0,
+				currentSortOrder - 1,
+				1,
+				tx,
+			);
+			return 0;
+		}
+
+		const maxSortOrder = await this.memoRepository.getMaxSortOrder(userId, tx);
+		await this.memoRepository.shiftSortOrders(
+			userId,
+			currentSortOrder + 1,
+			null,
+			-1,
+			tx,
+		);
+		return maxSortOrder;
+	}
+}

--- a/apps/api/src/modules/memo/types/index.ts
+++ b/apps/api/src/modules/memo/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./memo.types";

--- a/apps/api/src/modules/memo/types/memo.types.ts
+++ b/apps/api/src/modules/memo/types/memo.types.ts
@@ -1,0 +1,28 @@
+import type { TransactionClient } from "@/common/database";
+
+export interface CreateMemoData {
+	userId: string;
+	content: string;
+}
+
+export interface UpdateMemoData {
+	content: string;
+}
+
+export interface FindMemosParams {
+	userId: string;
+	cursor?: number;
+	size: number;
+}
+
+export interface ConvertMemoToTodoData {
+	categoryId: number;
+	startDate: Date;
+	endDate?: Date | null;
+	scheduledTime?: Date | null;
+	isAllDay?: boolean;
+	visibility?: "PUBLIC" | "PRIVATE";
+	items?: { title: string }[];
+}
+
+export type { TransactionClient };

--- a/apps/api/test/builders/index.ts
+++ b/apps/api/test/builders/index.ts
@@ -22,6 +22,7 @@ export {
 	type FollowWithUser,
 } from "./follow.builder";
 export { LoginAttemptBuilder } from "./login-attempt.builder";
+export { MemoBuilder } from "./memo.builder";
 export { NotificationBuilder } from "./notification.builder";
 export {
 	NudgeBuilder,

--- a/apps/api/test/builders/memo.builder.ts
+++ b/apps/api/test/builders/memo.builder.ts
@@ -1,0 +1,57 @@
+import type { Memo } from "@/generated/prisma/client";
+
+export class MemoBuilder {
+	private data: Memo;
+	private static idCounter = 0;
+
+	private constructor(userId: string) {
+		const now = new Date();
+		MemoBuilder.idCounter += 1;
+		this.data = {
+			id: MemoBuilder.idCounter,
+			userId,
+			content: "테스트 메모",
+			isPinned: false,
+			sortOrder: 0,
+			createdAt: now,
+			updatedAt: now,
+		};
+	}
+
+	static create(userId: string): MemoBuilder {
+		return new MemoBuilder(userId);
+	}
+
+	static resetIdCounter(): void {
+		MemoBuilder.idCounter = 0;
+	}
+
+	withId(id: number): this {
+		this.data.id = id;
+		return this;
+	}
+
+	withContent(content: string): this {
+		this.data.content = content;
+		return this;
+	}
+
+	pinned(): this {
+		this.data.isPinned = true;
+		return this;
+	}
+
+	withSortOrder(order: number): this {
+		this.data.sortOrder = order;
+		return this;
+	}
+
+	withCreatedAt(date: Date): this {
+		this.data.createdAt = date;
+		return this;
+	}
+
+	build(): Memo {
+		return { ...this.data };
+	}
+}

--- a/apps/api/test/setup/test-database.ts
+++ b/apps/api/test/setup/test-database.ts
@@ -153,6 +153,7 @@ export class TestDatabase {
 			// Todo
 			this.prisma.todo.deleteMany(),
 			this.prisma.todoCategory.deleteMany(),
+			this.prisma.memo.deleteMany(),
 			this.prisma.pushToken.deleteMany(),
 
 			// 사용자 (부모 테이블)

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -269,6 +269,13 @@ export const ErrorCode = {
   // =========================================================================
   WEATHER_1901: 'WEATHER_1901',
   WEATHER_1902: 'WEATHER_1902',
+
+  // =========================================================================
+  // 메모 (MEMO_2000-2099)
+  // =========================================================================
+  MEMO_2001: 'MEMO_2001',
+  MEMO_2002: 'MEMO_2002',
+  MEMO_2003: 'MEMO_2003',
 } as const;
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -1229,5 +1236,27 @@ export const Errors: Record<ErrorCodeType, ErrorDefinition> = {
     message: '위치 정보가 등록되지 않았습니다.',
     description: '날씨 알림을 받으려면 먼저 위치를 등록해주세요.',
     httpStatus: HttpStatus.NOT_FOUND,
+  },
+
+  // =========================================================================
+  // 메모 (MEMO_2000-2099)
+  // =========================================================================
+  [ErrorCode.MEMO_2001]: {
+    code: 'MEMO_2001',
+    message: '메모를 찾을 수 없습니다.',
+    description: '해당 ID의 메모가 존재하지 않거나 접근 권한이 없습니다.',
+    httpStatus: HttpStatus.NOT_FOUND,
+  },
+  [ErrorCode.MEMO_2002]: {
+    code: 'MEMO_2002',
+    message: '이동할 위치의 메모를 찾을 수 없습니다.',
+    description: '순서 변경 시 기준이 되는 메모가 존재하지 않습니다.',
+    httpStatus: HttpStatus.NOT_FOUND,
+  },
+  [ErrorCode.MEMO_2003]: {
+    code: 'MEMO_2003',
+    message: '메모 개수가 최대 한도에 도달했습니다.',
+    description: '사용자당 최대 메모 개수를 초과했습니다. 기존 메모를 정리해주세요.',
+    httpStatus: HttpStatus.FORBIDDEN,
   },
 };

--- a/packages/validators/src/domains/memo/index.ts
+++ b/packages/validators/src/domains/memo/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Memo Domain
+ *
+ * 빠른 메모 관련 스키마 및 타입
+ */
+
+// 상수
+export * from './memo.constants';
+
+// 요청 스키마 (Request)
+export * from './memo.request';
+
+// 응답 스키마 (Response)
+export * from './memo.response';

--- a/packages/validators/src/domains/memo/memo.constants.ts
+++ b/packages/validators/src/domains/memo/memo.constants.ts
@@ -1,0 +1,4 @@
+export const MEMO_LIMITS = {
+  MAX_CONTENT_LENGTH: 5000,
+  MAX_PER_USER: 20,
+} as const;

--- a/packages/validators/src/domains/memo/memo.request.ts
+++ b/packages/validators/src/domains/memo/memo.request.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import { todoVisibilitySchema } from '../todo/todo.common';
+import { TODO_ITEM_LIMITS } from '../todo/todo.constants';
+import { reorderPositionSchema } from '../todo-category/todo-category.common';
+import { MEMO_LIMITS } from './memo.constants';
+
+export const createMemoSchema = z.object({
+  content: z
+    .string()
+    .min(1, '메모 내용을 입력해주세요')
+    .max(
+      MEMO_LIMITS.MAX_CONTENT_LENGTH,
+      `메모는 ${MEMO_LIMITS.MAX_CONTENT_LENGTH}자 이내여야 합니다`,
+    )
+    .describe(`메모 내용 (1-${MEMO_LIMITS.MAX_CONTENT_LENGTH}자)`),
+});
+
+export type CreateMemoInput = z.infer<typeof createMemoSchema>;
+
+export const updateMemoSchema = z.object({
+  content: z
+    .string()
+    .min(1, '메모 내용을 입력해주세요')
+    .max(
+      MEMO_LIMITS.MAX_CONTENT_LENGTH,
+      `메모는 ${MEMO_LIMITS.MAX_CONTENT_LENGTH}자 이내여야 합니다`,
+    )
+    .describe(`메모 내용 (1-${MEMO_LIMITS.MAX_CONTENT_LENGTH}자)`),
+});
+
+export type UpdateMemoInput = z.infer<typeof updateMemoSchema>;
+
+export const getMemosQuerySchema = z.object({
+  cursor: z.coerce
+    .number()
+    .int()
+    .nonnegative('유효하지 않은 커서입니다')
+    .optional()
+    .describe('페이지네이션 커서 (0 이상의 정수)'),
+  size: z.coerce
+    .number()
+    .int()
+    .min(1, '최소 1개 이상 조회해야 합니다')
+    .max(200, '최대 200개까지 조회 가능합니다')
+    .default(20)
+    .describe('조회할 개수 (1-200, 기본값: 20)'),
+});
+
+export type GetMemosQuery = z.infer<typeof getMemosQuerySchema>;
+
+export const memoIdParamSchema = z.object({
+  id: z.coerce
+    .number()
+    .int()
+    .positive('유효하지 않은 메모 ID입니다')
+    .describe('메모 고유 ID (양의 정수, 예: 1)'),
+});
+
+export type MemoIdParam = z.infer<typeof memoIdParamSchema>;
+
+export const toggleMemoPinSchema = z.object({
+  isPinned: z.boolean().describe('고정 여부 (true: 고정, false: 해제)'),
+});
+
+export type ToggleMemoPinInput = z.infer<typeof toggleMemoPinSchema>;
+
+export const reorderMemoSchema = z.object({
+  targetMemoId: z
+    .number()
+    .int()
+    .positive('유효하지 않은 메모 ID입니다')
+    .optional()
+    .describe('기준 메모 ID (선택, 생략 시 맨 앞/뒤로 이동, 예: 123)'),
+  position: reorderPositionSchema.describe('이동 위치 (before: 기준 앞으로, after: 기준 뒤로)'),
+});
+
+export type ReorderMemoInput = z.infer<typeof reorderMemoSchema>;
+
+export const convertMemoToTodoSchema = z.object({
+  categoryId: z
+    .number()
+    .int()
+    .positive('유효하지 않은 카테고리 ID입니다')
+    .describe('카테고리 ID (양의 정수)'),
+  startDate: z.iso.date().describe('시작 날짜 (YYYY-MM-DD, 예: 2026-01-15)'),
+  endDate: z.iso.date().optional().describe('종료 날짜 (YYYY-MM-DD, 선택)'),
+  scheduledTime: z
+    .string()
+    .regex(/^\d{2}:\d{2}$/, 'HH:mm 형식이어야 합니다')
+    .optional()
+    .describe('예정 시간 (HH:mm, 24시간 형식, 선택)'),
+  isAllDay: z.boolean().default(true).describe('종일 여부 (기본값: true)'),
+  visibility: todoVisibilitySchema
+    .default('PUBLIC')
+    .describe('공개 범위 (PUBLIC/PRIVATE, 기본값: PUBLIC)'),
+  items: z
+    .array(
+      z.object({
+        title: z
+          .string()
+          .min(1, '제목을 입력해주세요')
+          .max(200, '제목은 200자 이하로 입력해주세요')
+          .describe('하위 항목 제목'),
+      }),
+    )
+    .max(
+      TODO_ITEM_LIMITS.MAX_PER_TODO,
+      `하위 항목은 최대 ${TODO_ITEM_LIMITS.MAX_PER_TODO}개까지 추가할 수 있습니다`,
+    )
+    .optional()
+    .describe('할 일 생성 시 함께 만들 체크리스트 (선택, 최대 20개)'),
+});
+
+export type ConvertMemoToTodoInput = z.infer<typeof convertMemoToTodoSchema>;

--- a/packages/validators/src/domains/memo/memo.response.ts
+++ b/packages/validators/src/domains/memo/memo.response.ts
@@ -1,0 +1,137 @@
+import { z } from 'zod';
+import { datetimeSchema } from '../../common/datetime';
+import { numberCursorPaginationInfoSchema } from '../../common/pagination';
+import { todoSchema } from '../todo/todo.response';
+
+export const memoSchema = z
+  .object({
+    id: z.number().int().positive().describe('메모 ID (양의 정수)'),
+    userId: z.cuid().describe('사용자 ID (CUID 25자)'),
+    content: z.string().describe('메모 내용'),
+    isPinned: z.boolean().describe('고정 여부'),
+    sortOrder: z.number().int().describe('정렬 순서'),
+    createdAt: datetimeSchema.describe('생성 시각 (ISO 8601 UTC)'),
+    updatedAt: datetimeSchema.describe('수정 시각 (ISO 8601 UTC)'),
+  })
+  .meta({
+    example: {
+      id: 1,
+      userId: 'clz7x5p8k0001qz0z8z8z8z8z',
+      content: '장보기: 우유, 계란, 빵',
+      isPinned: false,
+      sortOrder: 0,
+      createdAt: '2026-01-17T10:00:00.000Z',
+      updatedAt: '2026-01-17T10:00:00.000Z',
+    },
+  });
+
+export type Memo = z.infer<typeof memoSchema>;
+
+export const memoListResponseSchema = z
+  .object({
+    items: z.array(memoSchema).describe('메모 목록'),
+    pagination: numberCursorPaginationInfoSchema.describe('페이지네이션 정보'),
+  })
+  .meta({
+    example: {
+      items: [
+        {
+          id: 1,
+          userId: 'clz7x5p8k0001qz0z8z8z8z8z',
+          content: '장보기: 우유, 계란, 빵',
+          isPinned: true,
+          sortOrder: 0,
+          createdAt: '2026-01-17T10:00:00.000Z',
+          updatedAt: '2026-01-17T10:00:00.000Z',
+        },
+      ],
+      pagination: {
+        nextCursor: null,
+        hasNext: false,
+        size: 20,
+      },
+    },
+  });
+
+export type MemoListResponse = z.infer<typeof memoListResponseSchema>;
+
+export const memoMutationResponseSchema = z
+  .object({
+    message: z.string().describe('응답 메시지'),
+    memo: memoSchema.describe('메모 정보'),
+  })
+  .meta({
+    example: {
+      message: '메모가 생성되었습니다.',
+      memo: {
+        id: 1,
+        userId: 'clz7x5p8k0001qz0z8z8z8z8z',
+        content: '장보기: 우유, 계란, 빵',
+        isPinned: false,
+        sortOrder: 0,
+        createdAt: '2026-01-17T10:00:00.000Z',
+        updatedAt: '2026-01-17T10:00:00.000Z',
+      },
+    },
+  });
+
+export type MemoMutationResponse = z.infer<typeof memoMutationResponseSchema>;
+
+export const memoDeleteResponseSchema = z
+  .object({
+    message: z.string().describe('응답 메시지'),
+  })
+  .meta({
+    example: {
+      message: '메모가 삭제되었습니다.',
+    },
+  });
+
+export type MemoDeleteResponse = z.infer<typeof memoDeleteResponseSchema>;
+
+export const convertMemoToTodoResponseSchema = z
+  .object({
+    message: z.string().describe('응답 메시지'),
+    todo: todoSchema.describe('변환된 할 일 정보'),
+  })
+  .meta({
+    example: {
+      message: '메모가 할 일로 변환되었습니다.',
+      todo: {
+        id: 1,
+        userId: 'clz7x5p8k0001qz0z8z8z8z8z',
+        title: '장보기: 우유, 계란, 빵',
+        content: null,
+        sortOrder: 0,
+        completed: false,
+        completedAt: null,
+        startDate: '2026-01-17',
+        endDate: null,
+        scheduledTime: null,
+        isAllDay: true,
+        visibility: 'PUBLIC',
+        recurrenceGroupId: null,
+        category: { id: 1, name: '기본', color: '#4A90D9', sortOrder: 0 },
+        items: [],
+        itemStats: { total: 0, completed: 0 },
+        createdAt: '2026-01-17T10:00:00.000Z',
+        updatedAt: '2026-01-17T10:00:00.000Z',
+      },
+    },
+  });
+
+export type ConvertMemoToTodoResponse = z.infer<typeof convertMemoToTodoResponseSchema>;
+
+export const memoResourceLimitResponseSchema = z
+  .object({
+    currentCount: z.number().int().nonnegative().describe('현재 메모 개수'),
+    maxPerUser: z.number().int().positive().describe('사용자당 최대 메모 수'),
+  })
+  .meta({
+    example: {
+      currentCount: 5,
+      maxPerUser: 20,
+    },
+  });
+
+export type MemoResourceLimitResponse = z.infer<typeof memoResourceLimitResponseSchema>;

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -12,6 +12,7 @@ export * from './domains/cheer';
 export * from './domains/daily-completion';
 export * from './domains/follow';
 export * from './domains/inquiry';
+export * from './domains/memo';
 export * from './domains/notification';
 export * from './domains/nudge';
 export * from './domains/subscription';

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,7 @@
       "outputs": []
     },
     "test:e2e": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "inputs": ["src/**", "test/**", "jest.config.*"],
       "outputs": ["coverage/**"],
       "passThroughEnv": [


### PR DESCRIPTION
## 📋 개요

빠른 메모 CRUD, 핀 고정, 순서 변경, 할 일 변환 기능을 추가합니다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [x] `packages/validators` - Zod 스키마
- [x] `packages/errors` - 에러 코드

## 📝 변경 내용

### Prisma
- `Memo` 모델 추가 (id, userId, content, isPinned, sortOrder, timestamps)
- User 모델에 `memos` relation 추가
- 복합 인덱스 `[userId, isPinned, sortOrder]`, `[userId, sortOrder]`

### API 엔드포인트 (8개)
| Method | Path | 설명 |
|--------|------|------|
| GET | `/memos/resource-limit` | 리소스 제한 정보 (현재 개수/최대 20개) |
| POST | `/memos` | 메모 생성 (20개 제한, race condition 방지 TX) |
| GET | `/memos` | 메모 목록 (핀 우선, 커서 페이지네이션) |
| PATCH | `/memos/:id` | 메모 수정 |
| PATCH | `/memos/:id/pin` | 핀 토글 (목록 최상단 표시) |
| PATCH | `/memos/:id/reorder` | 순서 변경 (shift 알고리즘) |
| DELETE | `/memos/:id` | 메모 삭제 |
| POST | `/memos/:id/convert-to-todo` | 할 일로 변환 (카테고리/날짜/체크리스트 지정) |

### 에러 코드
- `MEMO_2001` - 메모 미존재 (404)
- `MEMO_2002` - 리오더 대상 메모 미존재 (404)
- `MEMO_2003` - 메모 개수 초과 (403)

### 기타
- `turbo.json` E2E `dependsOn` 수정: `build` → `^build` (의존 패키지만 빌드)
- `test-database.ts` cleanup에 `memo.deleteMany()` 추가
- `habit-tracker.spec.ts` 날짜 의존 테스트 `jest.useFakeTimers` 적용

## 🧪 테스트

### 테스트 방법

```bash
pnpm test                    # 전체 단위 테스트
pnpm --filter @aido/api test memo  # 메모 테스트만
```

### 테스트 결과

- [x] 단위 테스트 통과 (159 suites, 2140 passed)
- [x] 메모 테스트 (mapper, service, controller, repository — 107 tests)
- [x] 타입체크 통과
- [x] Biome 린트 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #512