### PR TITLE
fix(mobile): Toast 글꼴 크기 설정 미반영 수정 

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -81,8 +81,8 @@ const AppBootstrapLayout = () => {
     <GestureHandlerProvider>
       <KeyboardProvider>
         <FontScaleProvider>
-          <HeroUIProvider>
-            <ThemeProvider>
+          <ThemeProvider>
+            <HeroUIProvider>
               <QueryProvider>
                 <DIProvider>
                   <AuthProvider>
@@ -98,8 +98,8 @@ const AppBootstrapLayout = () => {
                   </AuthProvider>
                 </DIProvider>
               </QueryProvider>
-            </ThemeProvider>
-          </HeroUIProvider>
+            </HeroUIProvider>
+          </ThemeProvider>
         </FontScaleProvider>
       </KeyboardProvider>
     </GestureHandlerProvider>


### PR DESCRIPTION
## 📋 개요
FontScaleProvider가 HeroUIProvider 하위에 있어 Toast에서 글꼴 크기 설정이 반영되지 않는 버그 수정
- FontScaleProvider는 MMKV 스토리지와 React state만 사용하고, HeroUI·Theme 등 다른 Provider에 의존하지 않아서 상위로 이동해도                                                                       

## 🏷️ 변경 유형
- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위
- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용
- `_layout.tsx`에서 FontScaleProvider를 HeroUIProvider 상위로 이동
- Toast 내부 Text 컴포넌트가 useFontScale() 컨텍스트에 접근 가능하도록 수정

## 🧪 테스트
### 테스트 방법
1. 마이페이지 → 글꼴 크기 → "아주 크게" 선택
2. Toast가 표시되는 동작 수행
3. Toast 텍스트 크기가 설정에 맞게 변경되는지 확인

### 테스트 결과
- [x] 수동 테스트 완료

## ✅ 체크리스트
### 작성자 확인
- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

## 🔗 관련 이슈
Closes #516

## 스크린샷
<img width="206" height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-06 at 23 12 14" src="https://github.com/user-attachments/assets/a711699d-1cf7-429e-9290-a98674107698" />
<img width="206" height="622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-06 at 23 12 01" src="https://github.com/user-attachments/assets/9bf4de25-454d-46b7-a2c8-cf5ce9605140" />
<img width="206" height="622" alt="Screenshot_1775485161" src="https://github.com/user-attachments/assets/f906e1fa-fc0c-401d-b1bc-1d4d312d03d5" />
<img width="206" height="622" alt="Screenshot_1775485184" src="https://github.com/user-attachments/assets/ca0164e5-0c75-46a4-9b06-00f014c2f1d3" />

