### PR TITLE
feat(mobile): 메모 탭 상단에 날씨 배지 및 알림 벨 헤더 추가 (#533)

### DIFF
--- a/apps/mobile/app/(app)/(tabs)/feed/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/_layout.tsx
@@ -1,19 +1,9 @@
-import { ErrorCode } from '@aido/errors';
 import { NotificationBell } from '@src/features/notification/presentations/components/notification-bell';
 import { useFeedDate } from '@src/features/todo/presentations/hooks/use-feed-date';
-import {
-  resolveIconByPrecipitation,
-  resolveIconBySky,
-  resolveSkyIconColor,
-} from '@src/features/weather/presentations/components/weather-icon.resolver';
-import { useGetForecastQueryOptions } from '@src/features/weather/presentations/queries/use-get-forecast-query-options';
-import { isApiError } from '@src/shared/errors/api-error';
-import { HStack, Text } from '@src/shared/ui';
-import { WeatherClearIcon } from '@src/shared/ui/Icon/icons';
+import { WeatherForecastBadge } from '@src/features/weather/presentations/components/WeatherForecastBadge';
+import { HStack } from '@src/shared/ui';
 import { formatDate } from '@src/shared/utils/date';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { Stack, useRouter } from 'expo-router';
-import { Pressable } from 'react-native';
+import { Stack } from 'expo-router';
 import { useResolveClassNames } from 'uniwind';
 
 export default function FeedLayout() {
@@ -30,7 +20,7 @@ export default function FeedLayout() {
         contentStyle: { backgroundColor: stackBg.backgroundColor as string },
         headerLeft: () => (
           <HStack align="center" pl={4}>
-            <WeatherForecastBadge />
+            <FeedWeatherBadge />
           </HStack>
         ),
         headerRight: () => (
@@ -48,62 +38,7 @@ export default function FeedLayout() {
   );
 }
 
-function WeatherForecastBadge() {
-  const router = useRouter();
+function FeedWeatherBadge() {
   const [selectedDate] = useFeedDate();
-  const date = formatDate(selectedDate);
-  const {
-    data: forecast,
-    error,
-    isPending,
-  } = useQuery({
-    ...useGetForecastQueryOptions(date),
-    placeholderData: keepPreviousData,
-  });
-
-  if (isPending && !forecast) {
-    return (
-      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
-        <WeatherClearIcon width={18} height={18} color="#FFD233" />
-      </Pressable>
-    );
-  }
-
-  if (error) {
-    const label = isApiError(error) && error.hasCode(ErrorCode.WEATHER_1902) ? '날씨 설정' : '날씨';
-
-    return (
-      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
-        <HStack align="center" gap={4}>
-          <WeatherClearIcon width={18} height={18} color="#FFD233" />
-          <Text size="b4" shade={6}>
-            {label}
-          </Text>
-        </HStack>
-      </Pressable>
-    );
-  }
-
-  if (!forecast) return null;
-
-  const ForecastIcon =
-    resolveIconByPrecipitation(forecast.precipitationType) ??
-    resolveIconBySky(forecast.skyCondition);
-  const iconColor =
-    forecast.precipitationType === 'NONE'
-      ? resolveSkyIconColor(forecast.skyCondition, '#8E8E93')
-      : '#8E8E93';
-  const currentTemp = forecast.currentTemperature;
-
-  return (
-    <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
-      <HStack align="center" gap={6} px={4}>
-        <ForecastIcon width={18} height={18} color={iconColor} />
-
-        <Text size="b4" weight="semibold" shade={8}>
-          {currentTemp}°
-        </Text>
-      </HStack>
-    </Pressable>
-  );
+  return <WeatherForecastBadge.Header date={formatDate(selectedDate)} />;
 }

--- a/apps/mobile/app/(app)/(tabs)/feed/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/_layout.tsx
@@ -40,5 +40,5 @@ export default function FeedLayout() {
 
 function FeedWeatherBadge() {
   const [selectedDate] = useFeedDate();
-  return <WeatherForecastBadge.Header date={formatDate(selectedDate)} />;
+  return <WeatherForecastBadge date={formatDate(selectedDate)} />;
 }

--- a/apps/mobile/app/(app)/(tabs)/memo/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/memo/_layout.tsx
@@ -1,8 +1,14 @@
+import { NotificationBell } from '@src/features/notification/presentations/components/notification-bell';
+import { WeatherForecastBadge } from '@src/features/weather/presentations/components/WeatherForecastBadge';
+import { useToday } from '@src/shared/hooks/useToday';
+import { HStack } from '@src/shared/ui';
+import { formatDate } from '@src/shared/utils/date';
 import { Stack } from 'expo-router';
 import { useResolveClassNames } from 'uniwind';
 
 export default function MemoLayout() {
   const bg = useResolveClassNames('bg-gray-1');
+  const headerBg = useResolveClassNames('bg-white');
 
   return (
     <Stack
@@ -13,7 +19,26 @@ export default function MemoLayout() {
         animationDuration: 200,
       }}
     >
-      <Stack.Screen name="index" />
+      <Stack.Screen
+        name="index"
+        options={{
+          headerShown: true,
+          headerShadowVisible: false,
+          headerTitle: '',
+          headerStyle: { backgroundColor: headerBg.backgroundColor as string },
+          contentStyle: { backgroundColor: headerBg.backgroundColor as string },
+          headerLeft: () => (
+            <HStack align="center" pl={4}>
+              <MemoWeatherBadge />
+            </HStack>
+          ),
+          headerRight: () => (
+            <HStack align="center">
+              <NotificationBell.Header />
+            </HStack>
+          ),
+        }}
+      />
       <Stack.Screen
         name="create"
         options={{
@@ -31,4 +56,9 @@ export default function MemoLayout() {
       />
     </Stack>
   );
+}
+
+function MemoWeatherBadge() {
+  const today = useToday();
+  return <WeatherForecastBadge.Header date={formatDate(today)} />;
 }

--- a/apps/mobile/app/(app)/(tabs)/memo/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/memo/_layout.tsx
@@ -60,5 +60,5 @@ export default function MemoLayout() {
 
 function MemoWeatherBadge() {
   const today = useToday();
-  return <WeatherForecastBadge.Header date={formatDate(today)} />;
+  return <WeatherForecastBadge date={formatDate(today)} />;
 }

--- a/apps/mobile/app/(app)/(tabs)/memo/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/memo/index.tsx
@@ -24,7 +24,7 @@ import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function MemoScreen() {
-  const { top: safeTop, bottom: safeBottom } = useSafeAreaInsets();
+  const { bottom: safeBottom } = useSafeAreaInsets();
   const tabBarHeight = useTabBarHeight();
   const queryClient = useQueryClient();
   const scrollRef = useRef<Animated.ScrollView>(null);
@@ -55,7 +55,6 @@ export default function MemoScreen() {
         style={{ flex: 1 }}
         contentContainerStyle={{
           flexGrow: 1,
-          paddingTop: safeTop,
           paddingBottom: bottomPadding,
         }}
         showsVerticalScrollIndicator={false}

--- a/apps/mobile/src/features/weather/presentations/components/WeatherForecastBadge.tsx
+++ b/apps/mobile/src/features/weather/presentations/components/WeatherForecastBadge.tsx
@@ -8,7 +8,7 @@ import { useGetForecastQueryOptions } from '@src/features/weather/presentations/
 import { isApiError } from '@src/shared/errors/api-error';
 import { HStack, QueryErrorBoundary, Text } from '@src/shared/ui';
 import { WeatherClearIcon } from '@src/shared/ui/Icon/icons';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { Suspense } from 'react';
 import { Pressable } from 'react-native';
@@ -19,37 +19,7 @@ interface WeatherForecastBadgeProps {
 
 export const WeatherForecastBadge = ({ date }: WeatherForecastBadgeProps) => {
   const router = useRouter();
-  const {
-    data: forecast,
-    error,
-    isPending,
-  } = useQuery({
-    ...useGetForecastQueryOptions(date),
-    placeholderData: keepPreviousData,
-  });
-
-  if (isPending && !forecast) {
-    return (
-      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
-        <WeatherClearIcon width={18} height={18} color="#FFD233" />
-      </Pressable>
-    );
-  }
-
-  if (error) {
-    const label = isApiError(error) && error.hasCode(ErrorCode.WEATHER_1902) ? '날씨 설정' : '날씨';
-
-    return (
-      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
-        <HStack align="center" gap={4}>
-          <WeatherClearIcon width={18} height={18} color="#FFD233" />
-          <Text size="b4" shade={6}>
-            {label}
-          </Text>
-        </HStack>
-      </Pressable>
-    );
-  }
+  const { data: forecast } = useSuspenseQuery(useGetForecastQueryOptions(date));
 
   if (!forecast) return null;
 
@@ -60,14 +30,13 @@ export const WeatherForecastBadge = ({ date }: WeatherForecastBadgeProps) => {
     forecast.precipitationType === 'NONE'
       ? resolveSkyIconColor(forecast.skyCondition, '#8E8E93')
       : '#8E8E93';
-  const currentTemp = forecast.currentTemperature;
 
   return (
     <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
       <HStack align="center" gap={6} px={4}>
         <ForecastIcon width={18} height={18} color={iconColor} />
         <Text size="b4" weight="semibold" shade={8}>
-          {currentTemp}°
+          {forecast.currentTemperature}°
         </Text>
       </HStack>
     </Pressable>
@@ -75,26 +44,34 @@ export const WeatherForecastBadge = ({ date }: WeatherForecastBadgeProps) => {
 };
 
 WeatherForecastBadge.Loading = function Loading() {
+  const router = useRouter();
   return (
-    <Pressable hitSlop={8}>
+    <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
       <WeatherClearIcon width={18} height={18} color="#FFD233" />
     </Pressable>
   );
 };
 
 WeatherForecastBadge.Header = function Header({ date }: WeatherForecastBadgeProps) {
+  const router = useRouter();
   return (
     <QueryErrorBoundary
-      fallback={({ reset }) => (
-        <Pressable onPress={reset} hitSlop={8}>
-          <HStack align="center" gap={4}>
-            <WeatherClearIcon width={18} height={18} color="#FFD233" />
-            <Text size="b4" shade={6}>
-              날씨
-            </Text>
-          </HStack>
-        </Pressable>
-      )}
+      fallback={({ error, reset }) => {
+        const isLocationNotSet = isApiError(error) && error.hasCode(ErrorCode.WEATHER_1902);
+        const label = isLocationNotSet ? '날씨 설정' : '날씨';
+        const onPress = isLocationNotSet ? () => router.push('/weather') : reset;
+
+        return (
+          <Pressable onPress={onPress} hitSlop={8}>
+            <HStack align="center" gap={4}>
+              <WeatherClearIcon width={18} height={18} color="#FFD233" />
+              <Text size="b4" shade={6}>
+                {label}
+              </Text>
+            </HStack>
+          </Pressable>
+        );
+      }}
     >
       <Suspense fallback={<WeatherForecastBadge.Loading />}>
         <WeatherForecastBadge date={date} />

--- a/apps/mobile/src/features/weather/presentations/components/WeatherForecastBadge.tsx
+++ b/apps/mobile/src/features/weather/presentations/components/WeatherForecastBadge.tsx
@@ -1,0 +1,104 @@
+import { ErrorCode } from '@aido/errors';
+import {
+  resolveIconByPrecipitation,
+  resolveIconBySky,
+  resolveSkyIconColor,
+} from '@src/features/weather/presentations/components/weather-icon.resolver';
+import { useGetForecastQueryOptions } from '@src/features/weather/presentations/queries/use-get-forecast-query-options';
+import { isApiError } from '@src/shared/errors/api-error';
+import { HStack, QueryErrorBoundary, Text } from '@src/shared/ui';
+import { WeatherClearIcon } from '@src/shared/ui/Icon/icons';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+import { Suspense } from 'react';
+import { Pressable } from 'react-native';
+
+interface WeatherForecastBadgeProps {
+  date: string;
+}
+
+export const WeatherForecastBadge = ({ date }: WeatherForecastBadgeProps) => {
+  const router = useRouter();
+  const {
+    data: forecast,
+    error,
+    isPending,
+  } = useQuery({
+    ...useGetForecastQueryOptions(date),
+    placeholderData: keepPreviousData,
+  });
+
+  if (isPending && !forecast) {
+    return (
+      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
+        <WeatherClearIcon width={18} height={18} color="#FFD233" />
+      </Pressable>
+    );
+  }
+
+  if (error) {
+    const label = isApiError(error) && error.hasCode(ErrorCode.WEATHER_1902) ? '날씨 설정' : '날씨';
+
+    return (
+      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
+        <HStack align="center" gap={4}>
+          <WeatherClearIcon width={18} height={18} color="#FFD233" />
+          <Text size="b4" shade={6}>
+            {label}
+          </Text>
+        </HStack>
+      </Pressable>
+    );
+  }
+
+  if (!forecast) return null;
+
+  const ForecastIcon =
+    resolveIconByPrecipitation(forecast.precipitationType) ??
+    resolveIconBySky(forecast.skyCondition);
+  const iconColor =
+    forecast.precipitationType === 'NONE'
+      ? resolveSkyIconColor(forecast.skyCondition, '#8E8E93')
+      : '#8E8E93';
+  const currentTemp = forecast.currentTemperature;
+
+  return (
+    <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
+      <HStack align="center" gap={6} px={4}>
+        <ForecastIcon width={18} height={18} color={iconColor} />
+        <Text size="b4" weight="semibold" shade={8}>
+          {currentTemp}°
+        </Text>
+      </HStack>
+    </Pressable>
+  );
+};
+
+WeatherForecastBadge.Loading = function Loading() {
+  return (
+    <Pressable hitSlop={8}>
+      <WeatherClearIcon width={18} height={18} color="#FFD233" />
+    </Pressable>
+  );
+};
+
+WeatherForecastBadge.Header = function Header({ date }: WeatherForecastBadgeProps) {
+  return (
+    <QueryErrorBoundary
+      fallback={({ reset }) => (
+        <Pressable onPress={reset} hitSlop={8}>
+          <HStack align="center" gap={4}>
+            <WeatherClearIcon width={18} height={18} color="#FFD233" />
+            <Text size="b4" shade={6}>
+              날씨
+            </Text>
+          </HStack>
+        </Pressable>
+      )}
+    >
+      <Suspense fallback={<WeatherForecastBadge.Loading />}>
+        <WeatherForecastBadge date={date} />
+      </Suspense>
+    </QueryErrorBoundary>
+  );
+};

--- a/apps/mobile/src/features/weather/presentations/components/WeatherForecastBadge.tsx
+++ b/apps/mobile/src/features/weather/presentations/components/WeatherForecastBadge.tsx
@@ -6,11 +6,10 @@ import {
 } from '@src/features/weather/presentations/components/weather-icon.resolver';
 import { useGetForecastQueryOptions } from '@src/features/weather/presentations/queries/use-get-forecast-query-options';
 import { isApiError } from '@src/shared/errors/api-error';
-import { HStack, QueryErrorBoundary, Text } from '@src/shared/ui';
+import { HStack, Text } from '@src/shared/ui';
 import { WeatherClearIcon } from '@src/shared/ui/Icon/icons';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
-import { Suspense } from 'react';
 import { Pressable } from 'react-native';
 
 interface WeatherForecastBadgeProps {
@@ -19,7 +18,37 @@ interface WeatherForecastBadgeProps {
 
 export const WeatherForecastBadge = ({ date }: WeatherForecastBadgeProps) => {
   const router = useRouter();
-  const { data: forecast } = useSuspenseQuery(useGetForecastQueryOptions(date));
+  const {
+    data: forecast,
+    error,
+    isPending,
+  } = useQuery({
+    ...useGetForecastQueryOptions(date),
+    placeholderData: keepPreviousData,
+  });
+
+  if (isPending && !forecast) {
+    return (
+      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
+        <WeatherClearIcon width={18} height={18} color="#FFD233" />
+      </Pressable>
+    );
+  }
+
+  if (error) {
+    const label = isApiError(error) && error.hasCode(ErrorCode.WEATHER_1902) ? '날씨 설정' : '날씨';
+
+    return (
+      <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
+        <HStack align="center" gap={4}>
+          <WeatherClearIcon width={18} height={18} color="#FFD233" />
+          <Text size="b4" shade={6}>
+            {label}
+          </Text>
+        </HStack>
+      </Pressable>
+    );
+  }
 
   if (!forecast) return null;
 
@@ -40,42 +69,5 @@ export const WeatherForecastBadge = ({ date }: WeatherForecastBadgeProps) => {
         </Text>
       </HStack>
     </Pressable>
-  );
-};
-
-WeatherForecastBadge.Loading = function Loading() {
-  const router = useRouter();
-  return (
-    <Pressable onPress={() => router.push('/weather')} hitSlop={8}>
-      <WeatherClearIcon width={18} height={18} color="#FFD233" />
-    </Pressable>
-  );
-};
-
-WeatherForecastBadge.Header = function Header({ date }: WeatherForecastBadgeProps) {
-  const router = useRouter();
-  return (
-    <QueryErrorBoundary
-      fallback={({ error, reset }) => {
-        const isLocationNotSet = isApiError(error) && error.hasCode(ErrorCode.WEATHER_1902);
-        const label = isLocationNotSet ? '날씨 설정' : '날씨';
-        const onPress = isLocationNotSet ? () => router.push('/weather') : reset;
-
-        return (
-          <Pressable onPress={onPress} hitSlop={8}>
-            <HStack align="center" gap={4}>
-              <WeatherClearIcon width={18} height={18} color="#FFD233" />
-              <Text size="b4" shade={6}>
-                {label}
-              </Text>
-            </HStack>
-          </Pressable>
-        );
-      }}
-    >
-      <Suspense fallback={<WeatherForecastBadge.Loading />}>
-        <WeatherForecastBadge date={date} />
-      </Suspense>
-    </QueryErrorBoundary>
   );
 };


### PR DESCRIPTION
## 📋 개요

메모 탭에 피드 탭과 동일한 날씨 배지 + 알림 벨 헤더를 추가하여 탭 간 일관성을 높인다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가
- [x] ♻️ `refactor` - 코드 리팩토링

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `WeatherForecastBadge` 공유 컴포넌트 추출 (`feed/_layout.tsx` 인라인 → 별도 파일)
  - `date: string` prop으로 날짜 소스 주입 가능
  - `.Header` (Suspense + ErrorBoundary), `.Loading` compound 패턴
- `feed/_layout.tsx` 리팩토링: 공유 컴포넌트 사용, `FeedWeatherBadge` 래퍼
- `memo/_layout.tsx`: index 화면에 네이티브 Stack 헤더 활성화 (날씨 좌/알림 우)
- `memo/index.tsx`: 불필요한 `paddingTop: safeTop` 제거 (네이티브 헤더가 safe area 처리)

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm lint
```

### 테스트 결과

- [x] 타입체크 통과
- [x] 린트 통과
- [x] 빌드 통과 (pre-commit hook)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #533

## 📸 스크린샷 (UI 변경 시)

<img width="394" height="812" alt="스크린샷 2026-04-09 오후 6 37 43" src="https://github.com/user-attachments/assets/743b9067-002f-4abd-a9d4-1490f50b1994" />
