### PR TITLE
docs: 프로젝트 문서 버전 업데이트 및 content 필드 참조 정리 (#540)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Turborepo + pnpm 모노레포
 ## 기술 스택
 
 - **API**: NestJS 11 + Prisma 7 + PostgreSQL
-- **Mobile**: Expo SDK 54 + React Native 0.81 + React 19.1
+- **Mobile**: Expo SDK 55 + React Native 0.83 + React 19.2
 - **공통**: TypeScript 5.9, Zod 4.3
 
 ## 구조
@@ -45,7 +45,7 @@ pnpm dev          # 전체 개발 서버
 
 ## 규칙
 
-- **린트/포맷**: Biome 2.2
+- **린트/포맷**: Biome 2.4
 - **커밋**: Conventional Commits (`pnpm commit`)
 - **타입**: TypeScript strict 모드
 - **DTO**: Zod 스키마 (@aido/validators)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ AI 기반 할 일 관리 애플리케이션. Turborepo + pnpm 모노레포.
 |------|------|
 | Monorepo | Turborepo 2.7, pnpm 9.15 |
 | Backend | NestJS 11, Prisma 7, PostgreSQL 16 |
-| Mobile | Expo 54, React Native 0.81, React 19.1 |
+| Mobile | Expo 55, React Native 0.83, React 19.2 |
 | Validation | Zod 4.3, nestjs-zod |
 | Testing | Jest 29, Vitest, Testcontainers |
-| Code Quality | Biome 2.3 |
+| Code Quality | Biome 2.4 |
 
 ## 구조
 

--- a/apps/api/.claude/validators.md
+++ b/apps/api/.claude/validators.md
@@ -65,11 +65,18 @@ export const createTodoSchema = z
       .min(1, '제목은 필수입니다')
       .max(200, '제목은 200자 이내')
       .describe('할 일 제목'),
-    dueDate: z
-      .string()
-      .datetime()
-      .optional()
-      .describe('마감일'),
+    categoryId: z
+      .number()
+      .int()
+      .positive('유효하지 않은 카테고리 ID입니다')
+      .describe('카테고리 ID'),
+    startDate: z.iso
+      .date()
+      .describe('시작 날짜 (YYYY-MM-DD)'),
+    endDate: z.iso
+      .date()
+      .nullish()
+      .describe('종료 날짜 (YYYY-MM-DD, 선택)'),
   })
   .describe('Todo 생성 요청');
 
@@ -85,10 +92,11 @@ import { z } from 'zod';
 /** Todo 응답 스키마 */
 export const todoResponseSchema = z
   .object({
-    id: z.string().cuid().describe('고유 ID'),
+    id: z.number().int().describe('고유 ID'),
     title: z.string().describe('제목'),
     completed: z.boolean().describe('완료 여부'),
-    dueDate: z.string().datetime().nullable().describe('마감일'),
+    startDate: z.string().describe('시작 날짜 (YYYY-MM-DD)'),
+    endDate: z.string().nullable().describe('종료 날짜'),
     createdAt: z.string().datetime().describe('생성일시'),
     updatedAt: z.string().datetime().describe('수정일시'),
   })
@@ -205,7 +213,7 @@ export function CreateTodoScreen() {
 
   const handleSubmit = async () => {
     // 클라이언트 사전 검증
-    const result = createTodoSchema.safeParse({ title });
+    const result = createTodoSchema.safeParse({ title, categoryId: 1, startDate: '2026-04-11' });
     
     if (!result.success) {
       // Zod 에러를 폼 에러로 변환

--- a/apps/api/.claude/validators.md
+++ b/apps/api/.claude/validators.md
@@ -65,11 +65,6 @@ export const createTodoSchema = z
       .min(1, '제목은 필수입니다')
       .max(200, '제목은 200자 이내')
       .describe('할 일 제목'),
-    content: z
-      .string()
-      .max(5000, '내용은 5000자 이내')
-      .optional()
-      .describe('상세 내용'),
     dueDate: z
       .string()
       .datetime()
@@ -92,7 +87,6 @@ export const todoResponseSchema = z
   .object({
     id: z.string().cuid().describe('고유 ID'),
     title: z.string().describe('제목'),
-    content: z.string().nullable().describe('내용'),
     completed: z.boolean().describe('완료 여부'),
     dueDate: z.string().datetime().nullable().describe('마감일'),
     createdAt: z.string().datetime().describe('생성일시'),
@@ -207,12 +201,11 @@ import { createTodo } from '../api/todo.api';
 
 export function CreateTodoScreen() {
   const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const handleSubmit = async () => {
     // 클라이언트 사전 검증
-    const result = createTodoSchema.safeParse({ title, content });
+    const result = createTodoSchema.safeParse({ title });
     
     if (!result.success) {
       // Zod 에러를 폼 에러로 변환
@@ -254,7 +247,6 @@ export function useCreateTodoForm() {
     resolver: zodResolver(createTodoSchema),
     defaultValues: {
       title: '',
-      content: '',
     },
   });
 }
@@ -328,11 +320,6 @@ export const createExampleSchema = z
       .min(1, '제목은 필수입니다')
       .max(200, '제목은 200자 이내')
       .describe('제목'),
-    content: z
-      .string()
-      .max(5000, '내용은 5000자 이내')
-      .optional()
-      .describe('내용 (선택)'),
   })
   .describe('예시 생성 요청');
 
@@ -395,7 +382,6 @@ export const exampleResponseSchema = z
   .object({
     id: z.string().cuid().describe('고유 ID'),
     title: z.string().describe('제목'),
-    content: z.string().nullable().describe('내용'),
     createdAt: z.string().datetime().describe('생성일시'),
   })
   .describe('예시 응답');
@@ -619,14 +605,16 @@ describe('createTodoSchema', () => {
   it('유효한 데이터를 통과시켜야 한다', () => {
     const result = createTodoSchema.safeParse({
       title: '테스트 제목',
-      content: '테스트 내용',
+      categoryId: 1,
+      startDate: '2026-04-11',
     });
     expect(result.success).toBe(true);
   });
 
   it('제목이 없으면 실패해야 한다', () => {
     const result = createTodoSchema.safeParse({
-      content: '내용만',
+      categoryId: 1,
+      startDate: '2026-04-11',
     });
     expect(result.success).toBe(false);
     expect(result.error?.issues[0].path).toContain('title');
@@ -636,5 +624,5 @@ describe('createTodoSchema', () => {
 
 ---
 
-**문서 버전**: 3.0.0
-**최종 수정일**: 2026-03-22
+**문서 버전**: 3.1.0
+**최종 수정일**: 2026-04-11

--- a/apps/mobile/.claude/CLAUDE.md
+++ b/apps/mobile/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Mobile App - AI 개발 가이드
 
-Expo 54 + React Native 0.81 기반 모바일 앱.
+Expo 55 + React Native 0.83 기반 모바일 앱.
 
 ## 아키텍처
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,12 +1,12 @@
 # @aido/mobile
 
-Expo 54 기반 React Native 모바일 앱.
+Expo 55 기반 React Native 모바일 앱.
 
 ## 기술 스택
 
 | 분류 | 기술 |
 |------|------|
-| Framework | Expo 54, React Native 0.81 |
+| Framework | Expo 55, React Native 0.83 |
 | Routing | Expo Router |
 | State | TanStack Query v5 |
 | HTTP | Ky |


### PR DESCRIPTION
## 📋 개요

프로젝트 문서의 기술 스택 버전을 실제 package.json에 맞게 업데이트하고, Todo content 필드 제거에 따른 문서 잔여 참조를 정리합니다.

## 🏷️ 변경 유형

- [x] 📝 `docs` - 문서 수정

## 📦 영향 범위

- [x] 루트 (`CLAUDE.md`, `README.md`)
- [x] `apps/api` - validators.md
- [x] `apps/mobile` - CLAUDE.md, README.md

## 📝 변경 내용

### 버전 업데이트
| 기술 | 이전 | 이후 |
|------|------|------|
| Expo SDK | 54 | **55** |
| React Native | 0.81 | **0.83** |
| React | 19.1 | **19.2** |
| Biome | 2.2/2.3 | **2.4** |

### validators.md 정리
- Todo `content` 필드 예제 6곳 제거
- 테스트 예제를 실제 스키마(`categoryId`, `startDate` 필수)에 맞게 업데이트
- 문서 버전 3.0.0 → 3.1.0

## ✅ 체크리스트

### 작성자 확인

- [x] 모든 문서가 실제 코드와 일치합니다
- [x] `grep`으로 잔여 참조 0건 확인
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다

## 🔗 관련 이슈

Closes #540