### PR TITLE
fix(mobile): 메모 화면 fade_from_bottom 첫 렌더 애니메이션 미작동 수정

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -28,12 +28,8 @@ const AppLayout = () => {
       <Stack.Screen name="weather" />
       <Stack.Screen name="webview/[url]" />
       <Stack.Screen
-        name="memo/[id]"
-        options={{ animation: 'fade_from_bottom', animationDuration: 200 }}
-      />
-      <Stack.Screen
-        name="memo/create"
-        options={{ animation: 'fade_from_bottom', animationDuration: 250, gestureEnabled: true }}
+        name="memo"
+        options={{ headerShown: false, animation: 'fade_from_bottom', animationDuration: 200 }}
       />
     </Stack>
   );

--- a/apps/mobile/app/(app)/memo/_layout.tsx
+++ b/apps/mobile/app/(app)/memo/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router';
+import { useResolveClassNames } from 'uniwind';
+
+export default function MemoLayout() {
+  const { backgroundColor } = useResolveClassNames('bg-white');
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: 'fade_from_bottom',
+        animationDuration: 200,
+        contentStyle: { backgroundColor: backgroundColor as string },
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/(app)/memo/create.tsx
+++ b/apps/mobile/app/(app)/memo/create.tsx
@@ -12,7 +12,7 @@ import {
 import { cn } from '@src/shared/utils/cn';
 import { fontScaledSize } from '@src/shared/utils/scale';
 import { useMutation } from '@tanstack/react-query';
-import { useFocusEffect, useRouter } from 'expo-router';
+import { useFocusEffect, useNavigation, useRouter } from 'expo-router';
 import { PressableFeedback } from 'heroui-native';
 import { useCallback, useRef } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -27,15 +27,16 @@ type CreateMemoFormInput = z.infer<typeof createMemoSchema>;
 
 export default function MemoCreateScreen() {
   const router = useRouter();
+  const navigation = useNavigation();
   const inputRef = useRef<TextInput>(null);
 
   useFocusEffect(
     useCallback(() => {
-      const timer = setTimeout(() => {
-        inputRef.current?.focus();
-      }, 300);
-      return () => clearTimeout(timer);
-    }, []),
+      const unsub = navigation.addListener('transitionEnd', (e) => {
+        if (!e.data.closing) inputRef.current?.focus();
+      });
+      return unsub;
+    }, [navigation]),
   );
 
   const {

--- a/apps/mobile/app/(app)/memo/create.tsx
+++ b/apps/mobile/app/(app)/memo/create.tsx
@@ -12,8 +12,9 @@ import {
 import { cn } from '@src/shared/utils/cn';
 import { fontScaledSize } from '@src/shared/utils/scale';
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
 import { PressableFeedback } from 'heroui-native';
+import { useCallback, useRef } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAvoidingView, Platform, TextInput } from 'react-native';
 import { withUniwind } from 'uniwind';
@@ -26,6 +27,16 @@ type CreateMemoFormInput = z.infer<typeof createMemoSchema>;
 
 export default function MemoCreateScreen() {
   const router = useRouter();
+  const inputRef = useRef<TextInput>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      const timer = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 300);
+      return () => clearTimeout(timer);
+    }, []),
+  );
 
   const {
     control,
@@ -99,10 +110,10 @@ export default function MemoCreateScreen() {
             name="content"
             render={({ field: { value, onChange } }) => (
               <StyledTextInput
+                ref={inputRef}
                 placeholder="아이디어를 자유롭게 적어보세요..."
                 value={value}
                 onChangeText={onChange}
-                autoFocus
                 multiline
                 textAlignVertical="top"
                 allowFontScaling={false}


### PR DESCRIPTION
## 📋 개요

메모 화면을 `(tabs)/memo/`에서 `(app)/memo/`로 분리한 이후, 첫 네비게이션에서 `fade_from_bottom` 애니메이션이 작동하지 않던 버그를 수정합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `memo/_layout.tsx` 추가: 중첩 Stack 구조로 변경하여 루트 Stack이 가벼운 Layout 컴포넌트를 push하도록 개선
- `_layout.tsx`: `memo/[id]`, `memo/create` 개별 등록 → `memo` 그룹으로 통합
- `create.tsx`: `autoFocus` → `useFocusEffect` + `setTimeout`으로 중첩 Stack 애니메이션 완료 후 키보드 포커스

## 🔍 문제 원인

`react-native-screens`에서 Stack의 첫 push 시 애니메이션을 **의도적으로 스킵**하는 동작이 하드코딩되어 있음:

- **Android** (`ScreenStack.kt`): `topScreenWrapper`가 null이면 `stackAnimation = StackAnimation.NONE`
- **iOS** (`RNSScreenStack.mm`): `firstTimePush`이면 `animated:NO`

### 이전 구조 (동작함)
```
(tabs)/memo/_layout.tsx  ← 탭 선택 시 Stack 이미 mount
(tabs)/memo/index.tsx    ← 초기 화면 (애니메이션 스킵 — 상관없음)
(tabs)/memo/create.tsx   ← 두 번째 push → 애니메이션 정상 ✓
```

### 변경 후 구조 (미작동)
```
(app)/_layout.tsx        ← 루트 Stack
(app)/memo/[id].tsx      ← 루트 Stack에서 직접 push (무거운 컴포넌트) → 스킵 ✗
(app)/memo/create.tsx    ← 루트 Stack에서 직접 push → 스킵 ✗
```

### 수정 후 구조 (동작함)
```
(app)/_layout.tsx        ← 루트 Stack → memo 그룹을 fade_from_bottom으로 push
(app)/memo/_layout.tsx   ← 가벼운 MemoLayout (빠르게 mount → 애니메이션 정상) ✓
(app)/memo/[id].tsx      ← 내부 Stack 초기 화면 (이미 컨테이너가 애니메이션됨)
```

루트 Stack이 무거운 화면 컴포넌트 대신 **가벼운 `MemoLayout`을 push**하여 마운트 타이밍과 애니메이션이 겹치지 않도록 해결.

### 키보드 이중 호출

중첩 Stack 구조에서 `autoFocus`가 있으면 루트 Stack 애니메이션 중 레이아웃 재계산으로 키보드가 두 번 올라옴. `useFocusEffect` + `setTimeout(300ms)`으로 애니메이션 완료 후 포커스하여 해결.

## 🧪 테스트

### 테스트 결과

- [x] 수동 테스트 완료

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

## 🔗 관련 이슈

Closes #542