### PR TITLE
hotfix(api): Todo content 필드 복원 — 구버전 앱 하위 호환성 (#549)

### DIFF
--- a/apps/api/src/modules/todo/todo.mapper.spec.ts
+++ b/apps/api/src/modules/todo/todo.mapper.spec.ts
@@ -73,6 +73,7 @@ describe("TodoMapper — 할 일 매퍼", () => {
 				id: 1,
 				userId: "user-123",
 				title: "테스트 할 일",
+				content: null,
 				sortOrder: 0,
 				completed: false,
 				completedAt: null,

--- a/apps/api/src/modules/todo/todo.mapper.ts
+++ b/apps/api/src/modules/todo/todo.mapper.ts
@@ -66,6 +66,7 @@ export abstract class TodoMapper {
 			id: entity.id,
 			userId: entity.userId,
 			title: entity.title,
+			content: null, // deprecated: 하위 호환용
 			sortOrder: entity.sortOrder,
 			completed: entity.completed,
 			completedAt: toISOStringOrNull(entity.completedAt),

--- a/packages/validators/src/domains/todo/todo.response.ts
+++ b/packages/validators/src/domains/todo/todo.response.ts
@@ -28,6 +28,7 @@ export const todoSchema = z
     id: z.number().int().describe('할 일 고유 ID (양의 정수)'),
     userId: z.cuid().describe('사용자 ID (CUID 25자)'),
     title: z.string().describe('할 일 제목'),
+    content: z.string().nullable().optional().describe('할 일 내용 (deprecated, 하위 호환용 — 항상 null)'),
     sortOrder: z.number().int().describe('정렬 순서 (작을수록 위)'),
     completed: z.boolean().describe('완료 상태'),
     completedAt: nullableDatetimeSchema.describe(


### PR DESCRIPTION
## 📋 개요

v1.3.0-api 서버 배포 후, **구버전 앱(v1.2.4) 유저가 할 일 목록을 조회할 수 없는 프로덕션 장애** 긴급 수정.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정 (프로덕션 장애)

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [x] `packages/validators` - Zod 스키마

## 📝 원인 분석

### 장애 플로우

```
PR #539: Todo content 필드 제거 (DB 컬럼 + API 응답 + validators 스키마)
  ↓
v1.3.0-api 서버 배포: 서버가 content 없이 Todo 응답
  ↓
구버전 앱(v1.2.4): todoListResponseSchema.safeParse() 
  → 스키마에 content: z.string().nullable()이 필수 필드
  → 서버 응답에 content 키 없음 → Zod 파싱 실패
  ↓
ParseError throw → ErrorBoundary → "할 일을 불러오는 중에 오류가 발생했습니다"
```

### 왜 서버 로그에 에러가 안 보였는가

서버는 200 OK로 정상 응답. 문제는 **클라이언트의 Zod 파싱 단계**에서 발생. 서버 로그만으로는 감지 불가.

## 📝 수정 내용

| 파일 | 변경 |
|------|------|
| `packages/validators/.../todo.response.ts` | `content: z.string().nullable().optional()` 복원 (deprecated 명시) |
| `apps/api/.../todo.mapper.ts` | `content: null` 하드코딩 추가 |
| `apps/api/.../todo.mapper.spec.ts` | 테스트 expected에 `content: null` 추가 |

- DB에 `content` 컬럼을 다시 추가하지 **않음** (이미 삭제됨)
- mapper에서 `null` 하드코딩으로 응답에 포함 (DB 조회 없음)
- 구버전 앱은 `content` 값을 화면에 표시하지 않으므로 `null`이면 충분

## 🧪 테스트

- [x] 단위 테스트: 2167 passed
- [x] E2E 테스트: 353 passed
- [x] 빌드: 성공

## ✅ 체크리스트

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] 모든 테스트가 통과합니다
- [x] DB 마이그레이션 불필요 (코드 변경만)
- [x] 구버전 앱(v1.2.4) 하위 호환 복원
- [x] 신버전 앱에도 영향 없음 (optional 필드)

## 🔗 관련 이슈

Closes #549