### PR TITLE
feat(mobile): 할일 반복 설정에 주중/주말 프리셋 칩 추가

### DIFF
--- a/apps/mobile/src/features/todo/presentations/components/TodoDatePickerContent.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoDatePickerContent.tsx
@@ -7,6 +7,7 @@ import { PressableFeedback } from 'heroui-native';
 import { useMemo } from 'react';
 import { ScrollView } from 'react-native';
 import { type DatePicker, useDatePicker } from '../hooks/useDatePicker';
+import type { RepeatSetting } from '../hooks/useRepeatSetting';
 import { DAY_TYPE_TONE, getDatePickerDayStyle, isTodayHighlighted } from '../utils/calendar-day';
 import { CalendarWeekdayHeader } from './Calendar/CalendarWeekdayHeader';
 import { PickerHeader } from './PickerHeader';
@@ -201,10 +202,7 @@ const DAY_LABELS: { key: DayOfWeek; label: string }[] = [
 ];
 
 interface DayOfWeekSelectorProps {
-  selectedDays: DayOfWeek[];
-  onToggleDay: (day: DayOfWeek) => void;
-  onToggleAll: () => void;
-  isAllSelected: boolean;
+  repeatSetting: RepeatSetting;
 }
 
 const formatSelectedDays = (days: DayOfWeek[]): string => {
@@ -213,12 +211,60 @@ const formatSelectedDays = (days: DayOfWeek[]): string => {
   return sorted.map((d) => DAY_LABELS.find((l) => l.key === d)?.label ?? '').join(', ');
 };
 
-export const DayOfWeekSelector = ({
+const getRepeatSummary = ({
   selectedDays,
-  onToggleDay,
-  onToggleAll,
   isAllSelected,
-}: DayOfWeekSelectorProps) => {
+  isWeekdaysSelected,
+  isWeekendsSelected,
+}: {
+  selectedDays: DayOfWeek[];
+  isAllSelected: boolean;
+  isWeekdaysSelected: boolean;
+  isWeekendsSelected: boolean;
+}): string => {
+  if (isAllSelected) return '매일 반복';
+  if (isWeekdaysSelected) return '주중 반복';
+  if (isWeekendsSelected) return '주말 반복';
+  return `매주 ${formatSelectedDays(selectedDays)} 반복`;
+};
+
+interface PresetChipProps {
+  label: string;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+const PresetChip = ({ label, isSelected, onPress }: PresetChipProps) => (
+  <PressableFeedback
+    onPress={onPress}
+    className={cn(
+      'h-8 items-center justify-center rounded-4xl px-3',
+      isSelected ? 'bg-main' : 'bg-gray-2',
+    )}
+  >
+    <Text
+      size="b4"
+      weight="medium"
+      className={isSelected ? 'text-white' : undefined}
+      shade={isSelected ? undefined : 7}
+    >
+      {label}
+    </Text>
+  </PressableFeedback>
+);
+
+export const DayOfWeekSelector = ({ repeatSetting }: DayOfWeekSelectorProps) => {
+  const {
+    selectedDays,
+    toggleDay,
+    toggleAllDays,
+    toggleWeekdays,
+    toggleWeekends,
+    isAllDaysSelected,
+    isWeekdaysSelected,
+    isWeekendsSelected,
+  } = repeatSetting;
+
   return (
     <VStack gap={12}>
       <ScrollView
@@ -226,12 +272,15 @@ export const DayOfWeekSelector = ({
         showsHorizontalScrollIndicator={false}
         contentContainerClassName="gap-1.5 px-4"
       >
+        <PresetChip label="매일" isSelected={isAllDaysSelected} onPress={toggleAllDays} />
+        <PresetChip label="주중" isSelected={isWeekdaysSelected} onPress={toggleWeekdays} />
+        <PresetChip label="주말" isSelected={isWeekendsSelected} onPress={toggleWeekends} />
         {DAY_LABELS.map(({ key, label }) => {
           const isSelected = selectedDays.includes(key);
           return (
             <PressableFeedback
               key={key}
-              onPress={() => onToggleDay(key)}
+              onPress={() => toggleDay(key)}
               className={cn(
                 'size-8 items-center justify-center rounded-4xl',
                 isSelected ? 'bg-main' : 'bg-gray-2',
@@ -248,26 +297,16 @@ export const DayOfWeekSelector = ({
             </PressableFeedback>
           );
         })}
-        <PressableFeedback
-          onPress={onToggleAll}
-          className={cn(
-            'h-8 items-center justify-center rounded-4xl px-3',
-            isAllSelected ? 'bg-main' : 'bg-gray-2',
-          )}
-        >
-          <Text
-            size="b4"
-            weight="medium"
-            className={isAllSelected ? 'text-white' : undefined}
-            shade={isAllSelected ? undefined : 7}
-          >
-            매일
-          </Text>
-        </PressableFeedback>
       </ScrollView>
       {selectedDays.length > 0 ? (
         <Text size="b3" tone="brand" align="right" className="px-4">
-          * {isAllSelected ? '매일 반복' : `매주 ${formatSelectedDays(selectedDays)} 반복`}
+          *{' '}
+          {getRepeatSummary({
+            selectedDays,
+            isAllSelected: isAllDaysSelected,
+            isWeekdaysSelected,
+            isWeekendsSelected,
+          })}
         </Text>
       ) : (
         <Text size="b3" tone="neutral" shade={5} align="right" className="px-4">

--- a/apps/mobile/src/features/todo/presentations/components/TodoRepeatPickerContent.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoRepeatPickerContent.tsx
@@ -109,12 +109,7 @@ export const TodoRepeatPickerContent = ({
         isConfirmDisabled={isConfirmDisabled}
       />
 
-      <DayOfWeekSelector
-        selectedDays={repeatSetting.selectedDays}
-        onToggleDay={repeatSetting.toggleDay}
-        onToggleAll={repeatSetting.toggleAllDays}
-        isAllSelected={repeatSetting.isAllDaysSelected}
-      />
+      <DayOfWeekSelector repeatSetting={repeatSetting} />
 
       <RepeatCalendar
         picker={picker}

--- a/apps/mobile/src/features/todo/presentations/hooks/useRepeatSetting.test.ts
+++ b/apps/mobile/src/features/todo/presentations/hooks/useRepeatSetting.test.ts
@@ -155,4 +155,52 @@ describe('repeatSettingReducer', () => {
       expect(next.selectedDays).toEqual(['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']);
     });
   });
+
+  describe('toggleWeekdays', () => {
+    it('주중(월~금)이 정확히 선택되어 있으면 모두 해제한다', () => {
+      // Given
+      const state = createState({ selectedDays: ['FRI', 'MON', 'WED', 'TUE', 'THU'] });
+
+      // When
+      const next = repeatSettingReducer(state, { type: 'toggleWeekdays' });
+
+      // Then
+      expect(next.selectedDays).toEqual([]);
+    });
+
+    it('다른 조합이 선택되어 있으면 주중(월~금)으로 덮어쓴다', () => {
+      // Given
+      const state = createState({ selectedDays: ['SAT', 'SUN'] });
+
+      // When
+      const next = repeatSettingReducer(state, { type: 'toggleWeekdays' });
+
+      // Then
+      expect(next.selectedDays).toEqual(['MON', 'TUE', 'WED', 'THU', 'FRI']);
+    });
+  });
+
+  describe('toggleWeekends', () => {
+    it('주말(토,일)이 정확히 선택되어 있으면 모두 해제한다', () => {
+      // Given
+      const state = createState({ selectedDays: ['SUN', 'SAT'] });
+
+      // When
+      const next = repeatSettingReducer(state, { type: 'toggleWeekends' });
+
+      // Then
+      expect(next.selectedDays).toEqual([]);
+    });
+
+    it('다른 조합이 선택되어 있으면 주말(토,일)로 덮어쓴다', () => {
+      // Given
+      const state = createState({ selectedDays: ['MON', 'TUE', 'WED', 'THU', 'FRI'] });
+
+      // When
+      const next = repeatSettingReducer(state, { type: 'toggleWeekends' });
+
+      // Then
+      expect(next.selectedDays).toEqual(['SAT', 'SUN']);
+    });
+  });
 });

--- a/apps/mobile/src/features/todo/presentations/hooks/useRepeatSetting.ts
+++ b/apps/mobile/src/features/todo/presentations/hooks/useRepeatSetting.ts
@@ -5,6 +5,11 @@ import { match } from 'ts-pattern';
 import { getDayOfWeekFromDate } from '../utils/day-of-week';
 
 const ALL_DAYS: DayOfWeek[] = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+const WEEKDAYS: DayOfWeek[] = ['MON', 'TUE', 'WED', 'THU', 'FRI'];
+const WEEKEND_DAYS: DayOfWeek[] = ['SAT', 'SUN'];
+
+const isSameDaySet = (a: DayOfWeek[], b: DayOfWeek[]): boolean =>
+  a.length === b.length && b.every((d) => a.includes(d));
 
 export interface RepeatSettingState {
   isEnabled: boolean;
@@ -16,6 +21,8 @@ type RepeatSettingAction =
   | { type: 'toggle'; enabled: boolean; startDate: Date }
   | { type: 'toggleDay'; day: DayOfWeek }
   | { type: 'toggleAllDays' }
+  | { type: 'toggleWeekdays' }
+  | { type: 'toggleWeekends' }
   | { type: 'setEndDate'; date: Date }
   | { type: 'clearEndDate' };
 
@@ -52,6 +59,14 @@ export const repeatSettingReducer = (
       ...state,
       selectedDays: state.selectedDays.length === 7 ? [] : [...ALL_DAYS],
     }))
+    .with({ type: 'toggleWeekdays' }, () => ({
+      ...state,
+      selectedDays: isSameDaySet(state.selectedDays, WEEKDAYS) ? [] : [...WEEKDAYS],
+    }))
+    .with({ type: 'toggleWeekends' }, () => ({
+      ...state,
+      selectedDays: isSameDaySet(state.selectedDays, WEEKEND_DAYS) ? [] : [...WEEKEND_DAYS],
+    }))
     .with({ type: 'setEndDate' }, ({ date }) => ({
       ...state,
       endDate: date,
@@ -80,9 +95,13 @@ export const useRepeatSetting = ({ isEnabled, selectedDays, endDate }: UseRepeat
     selectedDays: state.selectedDays,
     endDate: state.endDate,
     isAllDaysSelected: state.selectedDays.length === 7,
+    isWeekdaysSelected: isSameDaySet(state.selectedDays, WEEKDAYS),
+    isWeekendsSelected: isSameDaySet(state.selectedDays, WEEKEND_DAYS),
     toggle: (enabled: boolean, startDate: Date) => dispatch({ type: 'toggle', enabled, startDate }),
     toggleDay: (day: DayOfWeek) => dispatch({ type: 'toggleDay', day }),
     toggleAllDays: () => dispatch({ type: 'toggleAllDays' }),
+    toggleWeekdays: () => dispatch({ type: 'toggleWeekdays' }),
+    toggleWeekends: () => dispatch({ type: 'toggleWeekends' }),
     setEndDate: (date: Date) => dispatch({ type: 'setEndDate', date }),
     clearEndDate: () => dispatch({ type: 'clearEndDate' }),
   };


### PR DESCRIPTION
## 📋 개요

할일 반복 설정 바텀시트의 요일 선택 UX를 개선한다. '매일'뿐이던 프리셋 칩에 '주중'과 '주말'을
추가하고, 프리셋이 먼저 노출되도록 칩 순서를 재배치했다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

- `useRepeatSetting`에 `toggleWeekdays`/`toggleWeekends` 액션과
  `isWeekdaysSelected`/`isWeekendsSelected` 셀렉터 추가
  (기존 `toggleAllDays`와 동일한 "현재 상태와 일치하면 해제, 아니면 덮어쓰기" 토글 패턴)
- `DayOfWeekSelector` 칩 배치를 `[매일][주중][주말][월][화][수][목][금][토][일]` 순으로 변경
- 하단 요약 문구에 '주중 반복'/'주말 반복' 케이스 추가
- `DayOfWeekSelector`의 8개 props를 `RepeatSetting` 객체 하나로 단순화해 prop drilling 제거

## 🧪 테스트

### 테스트 방법

```bash
pnpm --filter @aido/mobile test -- useRepeatSetting
pnpm --filter @aido/mobile typecheck
```

### 테스트 결과

- [x] 단위 테스트 통과 (`toggleWeekdays`/`toggleWeekends` 케이스 4건 추가)
- [x] 수동 테스트 완료

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] \`pnpm check\` (Biome) 검사를 통과했습니다
- [x] 변경사항에 대한 테스트를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다 (\`pnpm test\`)
- [x] 빌드가 성공합니다 (\`pnpm build\`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 \`type:*\` 1개와 필요한 \`scope:*\`로 정리되어 있습니다

## 🔗 관련 이슈

Closes #562

## 📸 스크린샷 (UI 변경 시)

|          Before           |           After           |
| :-----------------------: | :-----------------------: |
|<img width="320" height="600" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-04-18 at 21 36 49" src="https://github.com/user-attachments/assets/bd18a017-e6c1-4095-a0ca-b75b5d0e3114" />|<img width="320" height="600" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2026-04-18 at 21 48 26" src="https://github.com/user-attachments/assets/b6325537-288e-44ed-96d9-3e8b8c24bbe3" />
|