### PR TITLE
feat(api): 서버 푸시알림 문구 전면 리프레시 및 날씨 알림 판정 버그 수정

### DIFF
--- a/apps/api/src/modules/notification/templates/notification-templates.spec.ts
+++ b/apps/api/src/modules/notification/templates/notification-templates.spec.ts
@@ -9,12 +9,14 @@
  * pnpm --filter @aido/api test notification-templates
  * ```
  */
+import type { WeatherForecast } from "@/modules/weather/providers/weather-provider.interface";
 import {
 	fillTemplate,
 	NotificationMessageBuilder,
 	pickVariant,
 	SCHEDULER_TEMPLATES,
 	SYSTEM_TEMPLATES,
+	WEATHER_TEMPLATES,
 } from "./notification-templates";
 
 describe("notification-templates", () => {
@@ -96,6 +98,24 @@ describe("notification-templates", () => {
 			);
 			expect(fillTemplate("{item:을/를} 완료", { item: "운동" })).toBe(
 				"운동을 완료",
+			);
+		});
+
+		it("{key:와/과} 구문도 정상 동작한다", () => {
+			expect(fillTemplate("{name:와/과} 연결", { name: "민지" })).toBe(
+				"민지와 연결",
+			);
+			expect(fillTemplate("{name:와/과} 연결", { name: "길동" })).toBe(
+				"길동과 연결",
+			);
+		});
+
+		it("{key:은/는} 구문도 정상 동작한다", () => {
+			expect(fillTemplate("{name:은/는} 끝냈어", { name: "민지" })).toBe(
+				"민지는 끝냈어",
+			);
+			expect(fillTemplate("{name:은/는} 끝냈어", { name: "길동" })).toBe(
+				"길동은 끝냈어",
 			);
 		});
 
@@ -232,7 +252,7 @@ describe("notification-templates", () => {
 				);
 
 				// Then — 첫 번째 variant
-				expect(result.title).toBe("홍길동이 '밥먹기' 콕 찔렀어!");
+				expect(result.title).toBe("👉 홍길동이 '밥먹기' 콕!");
 			});
 
 			it("title에 이름(조사) + todoTitle이 포함된다 (받침 없음)", () => {
@@ -243,7 +263,7 @@ describe("notification-templates", () => {
 				);
 
 				// Then
-				expect(result.title).toBe("철수가 '운동하기' 콕 찔렀어!");
+				expect(result.title).toBe("👉 철수가 '운동하기' 콕!");
 			});
 
 			it("message가 없으면 body는 variants 풀 내의 값을 반환한다", () => {
@@ -254,7 +274,7 @@ describe("notification-templates", () => {
 				);
 
 				// Then — 첫 번째 variant body
-				expect(result.body).toBe("아직도 안 했어?");
+				expect(result.body).toBe("아직도 안 했어? 😏");
 			});
 
 			it("message가 있으면 body에 메시지만 표시한다", () => {
@@ -266,7 +286,7 @@ describe("notification-templates", () => {
 				);
 
 				// Then — WITH_MESSAGE 템플릿은 variants 없음, 고정 포맷
-				expect(result.body).toBe("'같이 먹자'");
+				expect(result.body).toBe("💬 '같이 먹자'");
 			});
 		});
 
@@ -304,8 +324,8 @@ describe("notification-templates", () => {
 				const result = NotificationMessageBuilder.eveningReminder(5, 5, 7);
 
 				// Then — 고정 (variants 없음)
-				expect(result.title).toBe("7일 연속! 일주일 내내 해냈어");
-				expect(result.body).toBe("이거 실화냐");
+				expect(result.title).toBe(SCHEDULER_TEMPLATES.EVENING_STREAK_7.title);
+				expect(result.body).toBe(SCHEDULER_TEMPLATES.EVENING_STREAK_7.body);
 			});
 
 			it("스트릭 14일이면 고정 메시지를 반환한다", () => {
@@ -313,15 +333,20 @@ describe("notification-templates", () => {
 				const result = NotificationMessageBuilder.eveningReminder(5, 5, 14);
 
 				// Then
-				expect(result.title).toBe("2주 연속이다. 진심이구나");
+				expect(result.title).toBe(SCHEDULER_TEMPLATES.EVENING_STREAK_14.title);
 			});
 
-			it("스트릭 30일 이상이면 고정 메시지를 반환한다", () => {
+			it("스트릭 30일 이상이면 streak이 치환된 고정 메시지를 반환한다", () => {
 				// When
 				const result = NotificationMessageBuilder.eveningReminder(5, 5, 30);
 
 				// Then
-				expect(result.title).toBe("30일째. 전설이 되고 있어");
+				expect(result.title).toBe(
+					fillTemplate(SCHEDULER_TEMPLATES.EVENING_STREAK_30.title, {
+						streak: 30,
+					}),
+				);
+				expect(result.title).toContain("30");
 			});
 
 			it("스트릭 2~6일이면 EVENING_STREAK variants 내의 값을 반환한다", () => {
@@ -365,7 +390,7 @@ describe("notification-templates", () => {
 				const result = NotificationMessageBuilder.billingIssue();
 
 				// Then
-				expect(result.title).toBe("결제 문제가 발생했어요");
+				expect(result.title).toBe(SYSTEM_TEMPLATES.BILLING_ISSUE.title);
 			});
 
 			it("결제 문제 알림 body를 반환한다", () => {
@@ -373,9 +398,7 @@ describe("notification-templates", () => {
 				const result = NotificationMessageBuilder.billingIssue();
 
 				// Then
-				expect(result.body).toBe(
-					"결제 수단을 확인해주세요. 구독이 중단될 수 있습니다.",
-				);
+				expect(result.body).toBe(SYSTEM_TEMPLATES.BILLING_ISSUE.body);
 			});
 		});
 
@@ -445,13 +468,13 @@ describe("notification-templates", () => {
 			it("Day 0이면 첫 할일 만들기 메시지를 반환한다", () => {
 				const result = NotificationMessageBuilder.onboarding(0);
 				expect(result).not.toBeNull();
-				expect(result?.title).toBe("첫 할일을 만들어볼까?");
+				expect(result?.title).toBe(SYSTEM_TEMPLATES.ONBOARDING_DAY0.title);
 			});
 
 			it("Day 5이면 completedCount가 치환된다", () => {
 				const result = NotificationMessageBuilder.onboarding(5, 8);
 				expect(result).not.toBeNull();
-				expect(result?.title).toBe("벌써 8개 완료!");
+				expect(result?.title).toBe("벌써 8개 완료! 🔥");
 			});
 
 			it("Day 4이면 null을 반환한다 (발송 없는 날)", () => {
@@ -468,18 +491,24 @@ describe("notification-templates", () => {
 		describe("milestone", () => {
 			it("FIRST_COMPLETE 마일스톤 메시지를 반환한다", () => {
 				const result = NotificationMessageBuilder.milestone("FIRST_COMPLETE");
-				expect(result.title).toBe("첫 번째 완료!");
-				expect(result.body).toBe("시작이 반이야");
+				expect(result.title).toBe(
+					SYSTEM_TEMPLATES.MILESTONE_FIRST_COMPLETE.title,
+				);
+				expect(result.body).toBe(
+					SYSTEM_TEMPLATES.MILESTONE_FIRST_COMPLETE.body,
+				);
 			});
 
 			it("COUNT_100 마일스톤 메시지를 반환한다", () => {
 				const result = NotificationMessageBuilder.milestone("COUNT_100");
-				expect(result.title).toBe("100개 달성!");
+				expect(result.title).toBe(SYSTEM_TEMPLATES.MILESTONE_100.title);
 			});
 
 			it("FIRST_FRIEND 마일스톤 메시지를 반환한다", () => {
 				const result = NotificationMessageBuilder.milestone("FIRST_FRIEND");
-				expect(result.title).toBe("첫 친구가 생겼어!");
+				expect(result.title).toBe(
+					SYSTEM_TEMPLATES.MILESTONE_FIRST_FRIEND.title,
+				);
 			});
 		});
 
@@ -508,6 +537,101 @@ describe("notification-templates", () => {
 			it("2명 이상이면 MULTI variants 내의 값을 반환한다", () => {
 				const result = NotificationMessageBuilder.socialDigest(3);
 				expect(result.title).toContain("3");
+			});
+		});
+
+		describe("weatherMorning / weatherEvening — 템플릿 선택", () => {
+			const makeForecast = (
+				overrides: Partial<WeatherForecast>,
+			): WeatherForecast => ({
+				date: new Date("2026-07-05T00:00:00Z"),
+				skyCondition: "CLEAR",
+				precipitationType: "NONE",
+				precipitationProbability: 0,
+				temperatureMin: 20,
+				temperatureMax: 28,
+				humidity: 50,
+				windSpeed: 2,
+				hourlyForecasts: [],
+				dailyForecasts: [],
+				...overrides,
+			});
+
+			// Math.random=0 → 항상 첫 번째 variant
+			const firstTitle = (
+				template: (typeof WEATHER_TEMPLATES)[keyof typeof WEATHER_TEMPLATES],
+			) => template.variants[0]?.title ?? template.title;
+
+			it("비 예보면 강수확률 40% 미만이어도 비 템플릿을 선택한다", () => {
+				const result = NotificationMessageBuilder.weatherMorning(
+					makeForecast({
+						precipitationType: "RAIN",
+						precipitationProbability: 30,
+					}),
+				);
+				expect(result.title).toBe(
+					fillTemplate(firstTitle(WEATHER_TEMPLATES.MORNING_RAIN), {
+						precipProb: 30,
+					}),
+				);
+			});
+
+			it("소나기 예보도 비 템플릿을 선택한다", () => {
+				const result = NotificationMessageBuilder.weatherMorning(
+					makeForecast({
+						precipitationType: "SHOWER",
+						precipitationProbability: 20,
+					}),
+				);
+				expect(result.title).toBe(
+					fillTemplate(firstTitle(WEATHER_TEMPLATES.MORNING_RAIN), {
+						precipProb: 20,
+					}),
+				);
+			});
+
+			it("진눈깨비 예보는 눈 템플릿을 선택한다", () => {
+				const result = NotificationMessageBuilder.weatherMorning(
+					makeForecast({
+						precipitationType: "RAIN_SNOW",
+						precipitationProbability: 60,
+					}),
+				);
+				expect(result.title).toBe(
+					fillTemplate(firstTitle(WEATHER_TEMPLATES.MORNING_SNOW), {
+						precipProb: 60,
+					}),
+				);
+			});
+
+			it("강수형태가 없어도 확률 40% 이상이면 비 템플릿을 선택한다", () => {
+				const result = NotificationMessageBuilder.weatherEvening(
+					makeForecast({
+						precipitationType: "NONE",
+						precipitationProbability: 50,
+					}),
+				);
+				expect(result.title).toBe(
+					fillTemplate(firstTitle(WEATHER_TEMPLATES.EVENING_RAIN), {
+						precipProb: 50,
+					}),
+				);
+			});
+
+			it("강수형태 없음 + 확률 40% 미만이면 맑음 템플릿을 선택한다", () => {
+				const result = NotificationMessageBuilder.weatherEvening(
+					makeForecast({
+						precipitationType: "NONE",
+						precipitationProbability: 10,
+					}),
+				);
+				expect(result.title).toBe(
+					fillTemplate(firstTitle(WEATHER_TEMPLATES.EVENING_CLEAR), {
+						skyLabel: "맑음",
+						tempMin: 20,
+						tempMax: 28,
+					}),
+				);
 			});
 		});
 	});

--- a/apps/api/src/modules/notification/templates/notification-templates.ts
+++ b/apps/api/src/modules/notification/templates/notification-templates.ts
@@ -27,230 +27,263 @@ export interface NotificationTemplate {
 
 export const SCHEDULER_TEMPLATES = {
 	TODO_REMINDER: {
-		title: "{todoTitle}, 1시간 남았어",
-		body: "미리 시작하면 여유롭게 끝나",
+		title: "⏰ {todoTitle}, 1시간 뒤 시작!",
+		body: "미리 해두면 마음이 편해져",
 		type: "TODO_REMINDER",
 		defaultRoute: "/todos/{todoId}",
 		variants: [
 			{
-				title: "{todoTitle}, 1시간 남았어",
-				body: "미리 시작하면 여유롭게 끝나",
+				title: "⏰ {todoTitle}, 1시간 뒤 시작!",
+				body: "미리 해두면 마음이 편해져",
 			},
-			{ title: "{todoTitle}까지 1시간", body: "슬슬 준비해볼까?" },
-			{ title: "1시간 후 {todoTitle}", body: "지금 시작하면 칼퇴 가능" },
+			{ title: "{todoTitle}까지 1시간 ⏳", body: "슬슬 몸 풀어볼까?" },
+			{
+				title: "1시간 뒤에 {todoTitle} 있어 👀",
+				body: "지금 시작하면 여유롭게 끝나",
+			},
 		],
 	} satisfies NotificationTemplate,
 	TODO_REMINDER_60MIN: {
-		title: "{todoTitle}, 1시간 남았어",
-		body: "미리 시작하면 여유롭게 끝나",
+		title: "⏰ {todoTitle}, 1시간 뒤 시작!",
+		body: "미리 해두면 마음이 편해져",
 		type: "TODO_REMINDER",
 		defaultRoute: "/todos/{todoId}",
 		variants: [
 			{
-				title: "{todoTitle}, 1시간 남았어",
-				body: "미리 시작하면 여유롭게 끝나",
+				title: "⏰ {todoTitle}, 1시간 뒤 시작!",
+				body: "미리 해두면 마음이 편해져",
 			},
-			{ title: "{todoTitle}까지 1시간", body: "슬슬 준비해볼까?" },
-			{ title: "1시간 후 {todoTitle}", body: "지금 시작하면 칼퇴 가능" },
+			{ title: "{todoTitle}까지 1시간 ⏳", body: "슬슬 몸 풀어볼까?" },
+			{
+				title: "1시간 뒤에 {todoTitle} 있어 👀",
+				body: "지금 시작하면 여유롭게 끝나",
+			},
 		],
 	} satisfies NotificationTemplate,
 	TODO_REMINDER_10MIN: {
-		title: "{todoTitle}, 10분 남았어",
-		body: "지금 시작하면 딱 맞아",
+		title: "⏰ {todoTitle}, 10분 전!",
+		body: "딱 좋은 타이밍이야, 가보자",
 		type: "TODO_REMINDER",
 		defaultRoute: "/todos/{todoId}",
 		variants: [
-			{ title: "{todoTitle}, 10분 남았어", body: "지금 시작하면 딱 맞아" },
-			{ title: "{todoTitle}까지 10분!", body: "준비 됐지?" },
-			{ title: "10분 남았어, {todoTitle}", body: "지금이 골든타임" },
+			{ title: "⏰ {todoTitle}, 10분 전!", body: "딱 좋은 타이밍이야, 가보자" },
+			{ title: "{todoTitle}까지 10분 🔥", body: "준비됐지?" },
+			{ title: "10분 뒤 {todoTitle} 시작이야", body: "지금이 골든타임 ✨" },
 		],
 	} satisfies NotificationTemplate,
 	TODO_REMINDER_IMMEDIATE: {
-		title: "{todoTitle}, 시작할 시간이야",
-		body: "바로 해보자!",
+		title: "🚀 {todoTitle}, 지금 시작!",
+		body: "시작이 반이야",
 		type: "TODO_REMINDER",
 		defaultRoute: "/todos/{todoId}",
 		variants: [
-			{ title: "{todoTitle}, 시작할 시간이야", body: "바로 해보자!" },
-			{ title: "{todoTitle} 시간이다!", body: "가보자" },
-			{ title: "지금이야, {todoTitle}", body: "시작이 반이야" },
+			{ title: "🚀 {todoTitle}, 지금 시작!", body: "시작이 반이야" },
+			{ title: "{todoTitle} 할 시간이야 ⏰", body: "바로 가보자!" },
+			{
+				title: "딱 지금이야, {todoTitle} ✨",
+				body: "5분만 해봐, 몸이 풀릴 거야",
+			},
 		],
 	} satisfies NotificationTemplate,
 	MORNING_REMINDER: {
-		title: "오늘 할일 {count}개",
-		body: "하나씩 쓸어버리자",
+		title: "☀️ 오늘 할 일 {count}개",
+		body: "가장 쉬운 것부터 하나씩 가보자",
 		type: "MORNING_REMINDER",
 		defaultRoute: "/todos",
 		variants: [
-			{ title: "오늘 할일 {count}개", body: "하나씩 쓸어버리자" },
 			{
-				title: "{count}개가 널 기다리고 있어",
-				body: "먼저 해치우면 저녁이 편해",
+				title: "☀️ 오늘 할 일 {count}개",
+				body: "가장 쉬운 것부터 하나씩 가보자",
 			},
-			{ title: "오늘의 미션 {count}개", body: "하나만 끝내면 나머지도 쉬워" },
-			{ title: "할일 {count}개 출근했다", body: "순서대로 보내버리자" },
-			{ title: "{count}개 남았어", body: "안 하면 저녁의 내가 운다" },
+			{ title: "오늘의 미션 {count}개 🎯", body: "하나만 끝내도 흐름 탄다" },
+			{
+				title: "{count}개가 널 기다리고 있어 👋",
+				body: "아침에 해치우면 저녁이 한가해져",
+			},
+			{
+				title: "좋은 아침! 오늘은 {count}개야 ☀️",
+				body: "커피 한 잔 하고 바로 시작해볼까?",
+			},
+			{
+				title: "할 일 {count}개 도착 📬",
+				body: "순서대로 하나씩 접수해 주세요~",
+			},
 		],
 	} satisfies NotificationTemplate,
 	EVENING_COMPLETE: {
-		title: "올클리어!",
-		body: "오늘 너 좀 멋있었어",
+		title: "🎉 올클리어!",
+		body: "오늘 너 진짜 멋있었어",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/",
 		variants: [
-			{ title: "올클리어!", body: "오늘 너 좀 멋있었어" },
-			{ title: "다 해버렸네", body: "오늘의 나한테 박수" },
-			{ title: "오늘치 전부 완료", body: "이런 날이 쌓이면 인생 바뀜" },
-			{ title: "끝냈다! 진짜 대단한데?", body: "편하게 쉬어, 자격 있어" },
-			{ title: "완료 도장 꽝", body: "내일도 이러면 전설임" },
+			{ title: "🎉 올클리어!", body: "오늘 너 진짜 멋있었어" },
+			{ title: "오늘 치 전부 완료 ✅", body: "이런 날이 쌓이면 인생이 바뀐다" },
+			{ title: "다 해버렸네? 😎", body: "오늘의 나에게 박수 짝짝짝" },
+			{ title: "완료 도장 꽝! 🏆", body: "이제 편하게 쉬어, 자격 충분해" },
+			{ title: "퍼펙트한 하루 ✨", body: "내일의 너도 오늘만 같아라" },
 		],
 	} satisfies NotificationTemplate,
 	EVENING_PARTIAL: {
-		title: "{remaining}개만 더 하면 올클리어",
-		body: "거의 다 왔잖아",
+		title: "올클리어까지 {remaining}개 🔥",
+		body: "거의 다 왔잖아, 여기서 끝내자",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/todos",
 		variants: [
-			{ title: "{remaining}개만 더 하면 올클리어", body: "거의 다 왔잖아" },
-			{ title: "{remaining}개 남았어", body: "여기서 끝내면 기분 좋을걸" },
-			{ title: "오늘 잘 했어, 근데 {remaining}개 남음", body: "마무리 각?" },
 			{
-				title: "올클리어까지 {remaining}개",
-				body: "자기 전에 해치울 수 있잖아",
+				title: "올클리어까지 {remaining}개 🔥",
+				body: "거의 다 왔잖아, 여기서 끝내자",
+			},
+			{ title: "{remaining}개만 더! 💪", body: "자기 전에 해치우면 꿀잠 각" },
+			{
+				title: "오늘 잘했어, 근데 {remaining}개 남았어 👀",
+				body: "마무리 한 번 가볼까?",
+			},
+			{
+				title: "딱 {remaining}개 남았다 ✨",
+				body: "끝내고 자면 기분이 다를걸",
 			},
 		],
 	} satisfies NotificationTemplate,
 	EVENING_NONE: {
-		title: "오늘 아직 시작 전이야",
-		body: "딱 한 개만 해보자, 그걸로 충분해",
+		title: "오늘 아직 0개야 🥲",
+		body: "딱 하나만 해보자, 그거면 충분해",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/todos",
 		variants: [
 			{
-				title: "오늘 아직 시작 전이야",
-				body: "딱 한 개만 해보자, 그걸로 충분해",
+				title: "오늘 아직 0개야 🥲",
+				body: "딱 하나만 해보자, 그거면 충분해",
 			},
-			{ title: "0개인데... 괜찮아?", body: "하나만 끝내고 자면 기분이 다를걸" },
-			{ title: "오늘 바빴구나", body: "작은 거 하나만, 그게 내일의 시작이야" },
-			{ title: "할일들이 삐져있어", body: "한 개만 해주면 얘들이 좋아할걸" },
+			{
+				title: "할 일들이 기다리다 지쳤대 😢",
+				body: "하나만 완료해 주고 자자",
+			},
+			{ title: "오늘 바빴구나 💦", body: "작은 것 하나가 내일의 시작이야" },
+			{ title: "이대로 자면 아쉽잖아 🌙", body: "5분짜리 하나만 끝내볼까?" },
 		],
 	} satisfies NotificationTemplate,
 	MORNING_NO_TODO: {
-		title: "오늘은 텅 비어있어",
-		body: "뭐라도 하나 적어보면 하루가 달라져",
+		title: "오늘 할 일이 텅 비었어 📭",
+		body: "하나만 적어도 하루가 달라져",
 		type: "MORNING_REMINDER",
 		defaultRoute: "/todos",
 		variants: [
 			{
-				title: "오늘은 텅 비어있어",
-				body: "뭐라도 하나 적어보면 하루가 달라져",
+				title: "오늘 할 일이 텅 비었어 📭",
+				body: "하나만 적어도 하루가 달라져",
 			},
-			{ title: "할일 0개, 진짜야?", body: "한가한 거야 도피하는 거야?" },
-			{ title: "백지 상태", body: "작은 거 하나만 적어봐" },
+			{ title: "오늘은 백지 상태 📝", body: "제일 하고 싶은 것부터 적어볼까?" },
+			{ title: "할 일 0개, 진짜야? 👀", body: "여유로운 거야, 미루는 거야?" },
 		],
 	} satisfies NotificationTemplate,
 	// 스트릭 축하 (전체 완료 + 스트릭 2일+)
 	EVENING_STREAK: {
-		title: "{streak}일 연속 올클리어!",
-		body: "내일이면 {next}일째, 끊지 마",
+		title: "🔥 {streak}일 연속 올클리어!",
+		body: "내일이면 {next}일째, 이 불꽃 꺼뜨리지 마",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/",
 		variants: [
 			{
-				title: "{streak}일 연속 올클리어!",
-				body: "내일이면 {next}일째, 끊지 마",
+				title: "🔥 {streak}일 연속 올클리어!",
+				body: "내일이면 {next}일째, 이 불꽃 꺼뜨리지 마",
 			},
-			{ title: "{streak}일째 달리는 중!", body: "{next}일 가보자" },
-			{ title: "{streak}일 연속! 미쳤다", body: "이 흐름 멈추면 안 돼" },
+			{
+				title: "{streak}일째 달리는 중 🏃",
+				body: "이대로 {next}일 찍으러 가보자",
+			},
+			{ title: "{streak}일 연속?! 미쳤다 🔥", body: "이 흐름 그대로 쭉 가자" },
 		],
 	} satisfies NotificationTemplate,
 	EVENING_STREAK_7: {
-		title: "7일 연속! 일주일 내내 해냈어",
-		body: "이거 실화냐",
+		title: "🎉 7일 연속! 일주일 올클리어",
+		body: "이거 실화야? 진짜 대단해",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/",
 	} satisfies NotificationTemplate,
 	EVENING_STREAK_14: {
-		title: "2주 연속이다. 진심이구나",
-		body: "이쯤 되면 습관이야",
+		title: "🏆 2주 연속 달성!",
+		body: "이쯤 되면 그냥 습관이야",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/",
 	} satisfies NotificationTemplate,
 	EVENING_STREAK_30: {
-		title: "{streak}일째. 전설이 되고 있어",
-		body: "멈추지 마",
+		title: "👑 {streak}일째, 전설이 되는 중",
+		body: "여기서 멈추면 반칙이야",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/",
 	} satisfies NotificationTemplate,
 	// 스트릭 위기 (일부 완료 + 스트릭 2일+)
 	EVENING_STREAK_RISK_PARTIAL: {
-		title: "{streak}일 기록 이어갈 수 있어",
-		body: "{remaining}개만 끝내면 돼!",
+		title: "🚨 {streak}일 기록이 위험해",
+		body: "{remaining}개만 끝내면 지킬 수 있어!",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/todos",
 		variants: [
 			{
-				title: "{streak}일 기록 이어갈 수 있어",
-				body: "{remaining}개만 끝내면 돼!",
+				title: "🚨 {streak}일 기록이 위험해",
+				body: "{remaining}개만 끝내면 지킬 수 있어!",
 			},
 			{
-				title: "{streak}일째인데 여기서 끊기면 아까워",
-				body: "{remaining}개만 더!",
+				title: "{streak}일째인데 여기서 끊기면 아깝잖아 😱",
+				body: "딱 {remaining}개 남았어",
 			},
-			{ title: "아직 기회 있어", body: "{remaining}개 남았어, 지금이야" },
+			{ title: "아직 기회 있어 ⏳", body: "{remaining}개만 하면 기록 세이브!" },
 		],
 	} satisfies NotificationTemplate,
 	// 스트릭 위기 (하나도 안 함 + 스트릭 2일+)
 	EVENING_STREAK_RISK_NONE: {
-		title: "{streak}일 기록, 아직 늦지 않았어",
-		body: "한 개만 끝내면 살릴 수 있어",
+		title: "🚨 {streak}일 기록, 아직 살릴 수 있어",
+		body: "하나만 끝내면 세이브 성공",
 		type: "EVENING_REMINDER",
 		defaultRoute: "/todos",
 		variants: [
 			{
-				title: "{streak}일 기록, 아직 늦지 않았어",
-				body: "한 개만 끝내면 살릴 수 있어",
+				title: "🚨 {streak}일 기록, 아직 살릴 수 있어",
+				body: "하나만 끝내면 세이브 성공",
 			},
 			{
-				title: "{streak}일째인데 오늘 쉴 거야?",
-				body: "하나만 해도 기록은 이어가",
+				title: "{streak}일 불꽃이 꺼지기 직전이야 🕯️",
+				body: "오늘 하나면 다시 활활 타올라",
 			},
 			{
-				title: "{streak}일 기록이 흔들리고 있어",
-				body: "지금 하나 끝내면 세이브",
+				title: "{streak}일이나 쌓았잖아 😢",
+				body: "하나만 해도 기록은 이어져",
 			},
 		],
 	} satisfies NotificationTemplate,
 	// 점심 넛지 (12:30, 오늘 완료 0개)
 	LUNCH_NUDGE: {
-		title: "점심 먹었으면 하나만 해볼까?",
-		body: "오후의 시작은 할일 하나로",
+		title: "🍚 밥 먹었으면 하나 해볼까?",
+		body: "오후의 시작은 할 일 하나부터",
 		type: "LUNCH_NUDGE",
 		defaultRoute: "/feed",
 		variants: [
 			{
-				title: "점심 먹었으면 하나만 해볼까?",
-				body: "오후의 시작은 할일 하나로",
+				title: "🍚 밥 먹었으면 하나 해볼까?",
+				body: "오후의 시작은 할 일 하나부터",
 			},
-			{ title: "아직 0개야", body: "점심값은 했으니 할일값도 하자" },
-			{ title: "밥 먹고 하나만", body: "작은 거부터 시작하면 돼" },
-			{ title: "오후 시작!", body: "하나만 끝내면 탄력 붙어" },
+			{ title: "아직 0개야 👀", body: "점심값 했으니 할일값도 하자" },
+			{ title: "오후 출발! 🏃", body: "하나만 끝내면 탄력 붙는다" },
+			{
+				title: "식곤증엔 완료 체크가 특효약 💊",
+				body: "제일 쉬운 것부터 가보자",
+			},
 		],
 	} satisfies NotificationTemplate,
 	// 스트릭 위기 전용 알림 (21:00, 스트릭 3일+ & 미완료)
 	STREAK_AT_RISK: {
-		title: "{streak}일 기록, 오늘도 이어가자",
+		title: "🚨 {streak}일 기록이 오늘에 달렸어",
 		body: "하나만 끝내면 계속 달릴 수 있어",
 		type: "STREAK_AT_RISK",
 		defaultRoute: "/feed",
 		variants: [
 			{
-				title: "{streak}일 기록, 오늘도 이어가자",
+				title: "🚨 {streak}일 기록이 오늘에 달렸어",
 				body: "하나만 끝내면 계속 달릴 수 있어",
 			},
-			{ title: "{streak}일째인데 여기서 멈출 거야?", body: "딱 하나만!" },
+			{ title: "{streak}일째인데 여기서 멈출 거야? 😱", body: "딱 하나만!" },
 			{
-				title: "{streak}일 기록 깨지기 직전",
+				title: "{streak}일 불꽃 꺼지기 직전 🔥",
 				body: "지금 하나 끝내면 세이브 완료",
 			},
 		],
@@ -263,74 +296,94 @@ export const SCHEDULER_TEMPLATES = {
 
 export const WEATHER_TEMPLATES = {
 	MORNING_CLEAR: {
-		title: "오늘 {skyLabel} {tempMin}~{tempMax}°C",
+		title: "☀️ 오늘 {skyLabel}, {tempMin}~{tempMax}°C",
 		body: "할 일 해치우기 딱 좋은 날씨야",
 		type: "WEATHER_MORNING" as NotificationType,
 		variants: [
 			{
-				title: "오늘 {skyLabel} {tempMin}~{tempMax}°C",
+				title: "☀️ 오늘 {skyLabel}, {tempMin}~{tempMax}°C",
 				body: "할 일 해치우기 딱 좋은 날씨야",
 			},
 			{
-				title: "{tempMin}~{tempMax}°C, 오늘 {skyLabel}",
-				body: "밖에서 할 일 있으면 오늘이 찬스!",
+				title: "오늘 {skyLabel} {tempMin}~{tempMax}°C 🌤️",
+				body: "밖에서 할 일 있으면 오늘이 기회!",
 			},
 		],
 	} satisfies NotificationTemplate,
 	MORNING_RAIN: {
-		title: "☂ 오늘 비 올 확률 {precipProb}%",
-		body: "우산 챙기고 할 일 하러 가자! {tempMin}~{tempMax}°C",
+		title: "☔ 오늘 비 소식, 확률 {precipProb}%",
+		body: "우산 꼭 챙기자! {tempMin}~{tempMax}°C",
 		type: "WEATHER_MORNING" as NotificationType,
 		variants: [
 			{
-				title: "☂ 오늘 비 올 확률 {precipProb}%",
-				body: "우산 챙기고 할 일 하러 가자! {tempMin}~{tempMax}°C",
+				title: "☔ 오늘 비 소식, 확률 {precipProb}%",
+				body: "우산 꼭 챙기자! {tempMin}~{tempMax}°C",
 			},
 			{
-				title: "오늘 비 소식이야 ({precipProb}%)",
-				body: "실내 할 일부터 먼저 해치우는 건 어때? {tempMin}~{tempMax}°C",
+				title: "🌧️ 오늘 비 올 확률 {precipProb}%",
+				body: "실내 할 일부터 해치우기 좋은 날이야 ({tempMin}~{tempMax}°C)",
 			},
 		],
 	} satisfies NotificationTemplate,
 	MORNING_SNOW: {
-		title: "❄ 오늘 눈 올 확률 {precipProb}%",
-		body: "따뜻하게 입고 할 일 시작하자! {tempMin}~{tempMax}°C",
+		title: "❄️ 오늘 눈 소식, 확률 {precipProb}%",
+		body: "따뜻하게 입고 나가자! {tempMin}~{tempMax}°C",
 		type: "WEATHER_MORNING" as NotificationType,
+		variants: [
+			{
+				title: "❄️ 오늘 눈 소식, 확률 {precipProb}%",
+				body: "따뜻하게 입고 나가자! {tempMin}~{tempMax}°C",
+			},
+			{
+				title: "☃️ 오늘 눈 올지도 몰라 ({precipProb}%)",
+				body: "길 미끄러우니 여유 있게 움직이자 {tempMin}~{tempMax}°C",
+			},
+		],
 	} satisfies NotificationTemplate,
 	EVENING_CLEAR: {
-		title: "내일 {skyLabel} {tempMin}~{tempMax}°C",
+		title: "🌙 내일 {skyLabel}, {tempMin}~{tempMax}°C",
 		body: "내일 할 일 미리 정해두면 아침이 편해",
 		type: "WEATHER_EVENING" as NotificationType,
 		variants: [
 			{
-				title: "내일 {skyLabel} {tempMin}~{tempMax}°C",
+				title: "🌙 내일 {skyLabel}, {tempMin}~{tempMax}°C",
 				body: "내일 할 일 미리 정해두면 아침이 편해",
 			},
 			{
-				title: "내일 날씨: {skyLabel} {tempMin}~{tempMax}°C",
-				body: "내일도 해치울 거 많지? 날씨는 도와줄게",
+				title: "내일 날씨 {skyLabel} {tempMin}~{tempMax}°C ✨",
+				body: "지금 계획 세워두면 내일의 내가 고마워할걸",
 			},
 		],
 	} satisfies NotificationTemplate,
 	EVENING_RAIN: {
-		title: "☂ 내일 비 올 확률 {precipProb}%",
-		body: "우산 미리 챙겨두고, 내일 할 일도 정리해둬! {tempMin}~{tempMax}°C",
+		title: "☔ 내일 비 올 확률 {precipProb}%",
+		body: "우산 미리 챙겨두자! {tempMin}~{tempMax}°C",
 		type: "WEATHER_EVENING" as NotificationType,
 		variants: [
 			{
-				title: "☂ 내일 비 올 확률 {precipProb}%",
-				body: "우산 미리 챙겨두고, 내일 할 일도 정리해둬! {tempMin}~{tempMax}°C",
+				title: "☔ 내일 비 올 확률 {precipProb}%",
+				body: "우산 미리 챙겨두자! {tempMin}~{tempMax}°C",
 			},
 			{
-				title: "내일 비 소식이야 ({precipProb}%)",
-				body: "비 오면 실내 할 일 몰아서 하기 좋아! {tempMin}~{tempMax}°C",
+				title: "🌧️ 내일 비 소식이야 ({precipProb}%)",
+				body: "실내 할 일 몰아서 하기 좋은 날! {tempMin}~{tempMax}°C",
 			},
 		],
 	} satisfies NotificationTemplate,
 	EVENING_SNOW: {
-		title: "❄ 내일 눈 올 확률 {precipProb}%",
-		body: "내일 추우니까 실내 할 일 위주로 계획 세워봐! {tempMin}~{tempMax}°C",
+		title: "❄️ 내일 눈 올 확률 {precipProb}%",
+		body: "포근하게 입고, 할 일은 실내 위주로! {tempMin}~{tempMax}°C",
 		type: "WEATHER_EVENING" as NotificationType,
+		variants: [
+			{
+				title: "❄️ 내일 눈 올 확률 {precipProb}%",
+				body: "포근하게 입고, 할 일은 실내 위주로! {tempMin}~{tempMax}°C",
+			},
+			{
+				title: "☃️ 내일 눈 소식이야 ({precipProb}%)",
+				body: "미리 계획 세워두면 걱정 없어 {tempMin}~{tempMax}°C",
+			},
+		],
 	} satisfies NotificationTemplate,
 } as const;
 
@@ -340,155 +393,188 @@ export const WEATHER_TEMPLATES = {
 
 export const SOCIAL_TEMPLATES = {
 	FOLLOW_NEW: {
-		title: "{senderName}의 친구 요청",
-		body: "수락하면 서로 감시 시작",
+		title: "👋 {senderName}의 친구 신청",
+		body: "수락하면 서로의 할 일이 보여. 각오해",
 		type: "FOLLOW_NEW",
 		defaultRoute: "/friends/requests",
 		variants: [
-			{ title: "{senderName}의 친구 요청", body: "수락하면 서로 감시 시작" },
 			{
-				title: "{senderName:이/가} 같이 하자고 해!",
-				body: "친구가 있으면 더 잘하게 돼",
+				title: "👋 {senderName}의 친구 신청",
+				body: "수락하면 서로의 할 일이 보여. 각오해",
 			},
 			{
-				title: "새 친구 요청이 왔어",
+				title: "{senderName:이/가} 같이 하재! 🤝",
+				body: "친구랑 하면 진짜 더 잘하게 돼",
+			},
+			{
+				title: "새 친구 신청 도착 💌",
 				body: "{senderName:이/가} 기다리고 있어",
 			},
 		],
 	} satisfies NotificationTemplate,
 	FOLLOW_ACCEPTED: {
-		title: "{senderName}, 이제 친구다",
-		body: "서로 할일이 다 보여. 각오해",
+		title: "🎉 {senderName}, 이제 친구!",
+		body: "서로 할 일이 다 보여. 각오해",
 		type: "FOLLOW_ACCEPTED",
 		defaultRoute: "/feed/friend/{friendId}",
 		variants: [
 			{
-				title: "{senderName}, 이제 친구다",
-				body: "서로 할일이 다 보여. 각오해",
+				title: "🎉 {senderName}, 이제 친구!",
+				body: "서로 할 일이 다 보여. 각오해",
 			},
-			{ title: "{senderName}과 연결됐어!", body: "이제부터 같이 가는 거야" },
 			{
-				title: "{senderName}, 이제 같은 편이야",
-				body: "서로 응원하면서 달려보자",
+				title: "{senderName:와/과} 연결 완료 🤝",
+				body: "이제부터 같이 달리는 거야",
+			},
+			{
+				title: "{senderName:이/가} 수락했어! ✅",
+				body: "서로 응원하면서 가보자",
 			},
 		],
 	} satisfies NotificationTemplate,
 	NUDGE_RECEIVED: {
-		title: "{senderName:이/가} '{todoTitle}' 콕 찔렀어!",
-		body: "아직도 안 했어?",
+		title: "👉 {senderName:이/가} '{todoTitle}' 콕!",
+		body: "아직도 안 했어? 😏",
 		type: "NUDGE_RECEIVED",
 		defaultRoute: "/feed/friend/{friendId}",
 		variants: [
 			{
-				title: "{senderName:이/가} '{todoTitle}' 콕 찔렀어!",
-				body: "아직도 안 했어?",
+				title: "👉 {senderName:이/가} '{todoTitle}' 콕!",
+				body: "아직도 안 했어? 😏",
 			},
 			{
-				title: "{senderName:이/가} '{todoTitle}' 찔렀어!",
+				title: "{senderName:이/가} '{todoTitle}' 찔렀어 👀",
+				body: "얼른 하라는 뜻이야",
+			},
+			{
+				title: "콕콕! {senderName:이/가} '{todoTitle}' 재촉 중",
 				body: "기다리고 있대",
-			},
-			{
-				title: "{senderName:이/가} '{todoTitle}' 콕!",
-				body: "뭐 하고 있었어?",
 			},
 		],
 	} satisfies NotificationTemplate,
 	NUDGE_RECEIVED_WITH_MESSAGE: {
-		title: "{senderName:이/가} '{todoTitle}' 콕 찔렀어!",
-		body: "'{message}'",
+		title: "👉 {senderName:이/가} '{todoTitle}' 콕!",
+		body: "💬 '{message}'",
 		type: "NUDGE_RECEIVED",
 		defaultRoute: "/feed/friend/{friendId}",
 	} satisfies NotificationTemplate,
 	REMIND_NUDGE_RECEIVED: {
-		title: "{senderName:이/가} 콕 찔렀어!",
-		body: "할일 좀 만들어!",
+		title: "👉 {senderName:이/가} 콕 찔렀어!",
+		body: "할 일 좀 만들라는데? 😆",
 		type: "NUDGE_RECEIVED",
 		defaultRoute: "/feed",
 		variants: [
-			{ title: "{senderName:이/가} 콕 찔렀어!", body: "할일 좀 만들어!" },
-			{ title: "{senderName:이/가} 찾고 있어!", body: "뭐라도 하나 적어볼까?" },
 			{
-				title: "{senderName:이/가} 안부를 물어",
-				body: "오늘 뭐 할지 적어볼까?",
+				title: "👉 {senderName:이/가} 콕 찔렀어!",
+				body: "할 일 좀 만들라는데? 😆",
+			},
+			{
+				title: "{senderName:이/가} 널 찾고 있어 👀",
+				body: "뭐라도 하나 적어볼까?",
+			},
+			{
+				title: "콕! {senderName:이/가} 안부 물었어 💌",
+				body: "오늘 뭐 할지 하나만 적어보자",
 			},
 		],
 	} satisfies NotificationTemplate,
 	REMIND_NUDGE_RECEIVED_WITH_MESSAGE: {
-		title: "{senderName:이/가} 콕 찔렀어!",
-		body: "'{message}'",
+		title: "👉 {senderName:이/가} 콕 찔렀어!",
+		body: "💬 '{message}'",
 		type: "NUDGE_RECEIVED",
 		defaultRoute: "/feed",
 	} satisfies NotificationTemplate,
 	CHEER_RECEIVED: {
-		title: "{senderName}의 한마디",
+		title: "💌 {senderName}의 한마디",
 		body: "{message}",
 		type: "CHEER_RECEIVED",
 		defaultRoute: "/feed/friend/{friendId}",
 	} satisfies NotificationTemplate,
 	CHEER_RECEIVED_NO_MESSAGE: {
-		title: "{senderName}, 보고 있다",
-		body: "네가 잘하는 거 알고 있어",
+		title: "📣 {senderName:이/가} 응원 보냈어",
+		body: "잘하고 있는 거 다 알고 있대",
 		type: "CHEER_RECEIVED",
 		defaultRoute: "/feed/friend/{friendId}",
 		variants: [
-			{ title: "{senderName}, 보고 있다", body: "네가 잘하는 거 알고 있어" },
-			{ title: "{senderName:이/가} 응원 보냈어", body: "힘내, 잘 하고 있어" },
-			{ title: "{senderName}의 응원이 도착", body: "너라면 할 수 있어" },
+			{
+				title: "📣 {senderName:이/가} 응원 보냈어",
+				body: "잘하고 있는 거 다 알고 있대",
+			},
+			{
+				title: "{senderName:이/가} 널 응원해 💪",
+				body: "힘내, 오늘도 할 수 있어",
+			},
+			{
+				title: "{senderName}의 응원 도착 💌",
+				body: "너라면 충분히 할 수 있어",
+			},
 		],
 	} satisfies NotificationTemplate,
 	FRIEND_COMPLETED: {
-		title: "{friendName}, 오늘 다 끝냈대",
-		body: "너는?",
+		title: "✅ {friendName:이/가} 오늘 다 끝냈대",
+		body: "너는? 👀",
 		type: "FRIEND_COMPLETED",
 		defaultRoute: "/feed/friend/{friendId}",
 		variants: [
-			{ title: "{friendName}, 오늘 다 끝냈대", body: "너는?" },
-			{ title: "{friendName:이/가} 올클리어!", body: "이대로 질 수 없잖아" },
-			{ title: "{friendName:이/가} 다 해냈대", body: "우리도 가자" },
+			{ title: "✅ {friendName:이/가} 오늘 다 끝냈대", body: "너는? 👀" },
+			{ title: "{friendName:이/가} 올클리어! 🎉", body: "이대로 질 순 없잖아" },
+			{ title: "{friendName:이/가} 벌써 다 했대 🔥", body: "우리도 가보자" },
 		],
 	} satisfies NotificationTemplate,
 	// 친구 활동 요약 (Social Digest)
 	SOCIAL_DIGEST_MULTI: {
-		title: "친구 {completedFriendCount}명이 오늘 다 끝냈어",
-		body: "너만 남았다",
+		title: "🔥 친구 {completedFriendCount}명이 오늘 다 끝냈어",
+		body: "이제 너만 남았다",
 		type: "SOCIAL_DIGEST",
 		defaultRoute: "/feed",
 		variants: [
 			{
-				title: "친구 {completedFriendCount}명이 오늘 다 끝냈어",
-				body: "너만 남았다",
+				title: "🔥 친구 {completedFriendCount}명이 오늘 다 끝냈어",
+				body: "이제 너만 남았다",
 			},
 			{
-				title: "{completedFriendCount}명이나 올클리어!",
-				body: "나만 빼고 다 했어?",
+				title: "{completedFriendCount}명이나 올클리어! 👀",
+				body: "나만 빼고 다 한 거야?",
 			},
-			{ title: "친구들이 앞서가고 있어", body: "지금이라도 따라잡자" },
+			{ title: "친구들이 앞서가는 중 🏃", body: "지금 시작해도 안 늦었어" },
 		],
 	} satisfies NotificationTemplate,
 	SOCIAL_DIGEST_SINGLE: {
-		title: "{friendName}은 오늘 다 끝냈대",
-		body: "너는 아직이잖아",
+		title: "✅ {friendName:은/는} 오늘 다 끝냈대",
+		body: "너도 할 수 있잖아",
 		type: "SOCIAL_DIGEST",
 		defaultRoute: "/feed",
 		variants: [
-			{ title: "{friendName}은 오늘 다 끝냈대", body: "너는 아직이잖아" },
-			{ title: "{friendName:이/가} 올클리어 했대!", body: "이대로 있을 거야?" },
-			{ title: "{friendName}은 끝냈어", body: "너도 할 수 있잖아" },
+			{
+				title: "✅ {friendName:은/는} 오늘 다 끝냈대",
+				body: "너도 할 수 있잖아",
+			},
+			{
+				title: "{friendName:이/가} 올클리어 했대! 🎉",
+				body: "이대로 보고만 있을 거야?",
+			},
+			{ title: "{friendName:은/는} 벌써 끝냈어 👀", body: "이제 네 차례야" },
 		],
 	} satisfies NotificationTemplate,
 	// 콕 찌르기 유도 (Nudge Suggest)
 	NUDGE_SUGGEST: {
-		title: "{friendName:이/가} {days}일째 조용해",
-		body: "콕 찔러볼래?",
+		title: "👀 {friendName:이/가} {days}일째 조용해",
+		body: "콕 찔러서 깨워볼까?",
 		type: "NUDGE_SUGGEST",
 		defaultRoute: "/feed/friend/{friendId}",
 		variants: [
-			{ title: "{friendName:이/가} {days}일째 조용해", body: "콕 찔러볼래?" },
 			{
-				title: "{friendName:이/가} {days}일째 안 보여",
-				body: "한 번 찔러볼까?",
+				title: "👀 {friendName:이/가} {days}일째 조용해",
+				body: "콕 찔러서 깨워볼까?",
 			},
-			{ title: "{friendName:이/가} 요즘 뜸해", body: "안부 한 번 물어볼래?" },
+			{
+				title: "{friendName:이/가} {days}일째 안 보여 🫥",
+				body: "안부 한 번 물어보자",
+			},
+			{
+				title: "{friendName:이/가} 요즘 잠수 중 🤿",
+				body: "콕 한 번이면 돌아올지도?",
+			},
 		],
 	} satisfies NotificationTemplate,
 } as const;
@@ -500,115 +586,130 @@ export const SOCIAL_TEMPLATES = {
 export const SYSTEM_TEMPLATES = {
 	// Win-back (비활성 유저 재방문 유도)
 	WINBACK_DAY3: {
-		title: "3일째 잠수야?",
-		body: "할일들이 기다리고 있을걸",
+		title: "👀 3일째 안 보여서 와봤어",
+		body: "할 일들이 기다리고 있대",
 		type: "WINBACK",
 		defaultRoute: "/feed",
 		variants: [
-			{ title: "3일째 잠수야?", body: "할일들이 기다리고 있을걸" },
-			{ title: "3일 만이야", body: "오늘 하나만 해보자" },
-			{ title: "3일이나 비웠네", body: "가볍게 하나만 시작해볼까?" },
+			{ title: "👀 3일째 안 보여서 와봤어", body: "할 일들이 기다리고 있대" },
+			{ title: "3일 만이야!", body: "가볍게 하나만 해볼까?" },
+			{ title: "어디 갔어~ 🥺", body: "오늘 딱 하나만 같이 하자" },
 		],
 	} satisfies NotificationTemplate,
 	WINBACK_DAY7: {
-		title: "일주일이나 안 왔잖아",
-		body: "한 개만. 딱 한 개만 해보자",
+		title: "일주일 만이야 🥲",
+		body: "딱 한 개만, 그걸로 충분해",
 		type: "WINBACK",
 		defaultRoute: "/feed",
 		variants: [
-			{ title: "일주일이나 안 왔잖아", body: "한 개만. 딱 한 개만 해보자" },
-			{ title: "7일 만이야", body: "다시 시작해도 늦지 않았어" },
-			{ title: "일주일째 조용한데", body: "할일 하나만 만들어볼까?" },
+			{ title: "일주일 만이야 🥲", body: "딱 한 개만, 그걸로 충분해" },
+			{ title: "7일째 조용하네 👀", body: "다시 시작해도 하나도 안 늦었어" },
+			{ title: "일주일 동안 보고 싶었어 💌", body: "할 일 하나만 만들어볼까?" },
 		],
 	} satisfies NotificationTemplate,
 	WINBACK_DAY14: {
-		title: "거의 잊혀질 뻔했어",
-		body: "다시 시작해도 괜찮아",
+		title: "2주 만이야, 반갑다! 👋",
+		body: "오늘이 새로운 Day 1이야",
 		type: "WINBACK",
 		defaultRoute: "/feed",
 		variants: [
-			{ title: "거의 잊혀질 뻔했어", body: "다시 시작해도 괜찮아" },
-			{ title: "2주 만이야", body: "오늘이 새로운 Day 1이야" },
-			{ title: "오래 쉬었네", body: "언제든 돌아올 수 있어" },
+			{ title: "2주 만이야, 반갑다! 👋", body: "오늘이 새로운 Day 1이야" },
+			{ title: "거의 잊혀질 뻔했잖아 🥲", body: "다시 시작해도 괜찮아" },
+			{ title: "오래 쉬었네 🌱", body: "언제든 돌아올 수 있어, 지금처럼" },
 		],
 	} satisfies NotificationTemplate,
 	WINBACK_DAY21: {
-		title: "3주 만이야",
-		body: "할일 하나만 만들어볼까?",
+		title: "3주 만이야! 🎈",
+		body: "작은 것부터 다시 시작해보자",
 		type: "WINBACK",
 		defaultRoute: "/feed",
 		variants: [
-			{ title: "3주 만이야", body: "할일 하나만 만들어볼까?" },
-			{ title: "기다리고 있었어", body: "작은 것부터 다시 시작해보자" },
-			{ title: "오래 쉬었다", body: "오늘이 새 출발이야" },
+			{ title: "3주 만이야! 🎈", body: "작은 것부터 다시 시작해보자" },
+			{ title: "계속 기다리고 있었어 🥺", body: "할 일 하나면 다시 시작이야" },
+			{
+				title: "슬슬 돌아올 때 됐잖아 😎",
+				body: "오늘이 새 출발 하기 딱 좋은 날",
+			},
 		],
 	} satisfies NotificationTemplate,
 	WINBACK_DAY30: {
-		title: "한 달 만이야",
+		title: "한 달 만이야, 보고 싶었어 💌",
 		body: "언제든 다시 시작할 수 있어",
 		type: "WINBACK",
 		defaultRoute: "/feed",
 		variants: [
-			{ title: "한 달 만이야", body: "언제든 다시 시작할 수 있어" },
-			{ title: "돌아올 거라고 믿었어", body: "오늘이 새로운 Day 1이야" },
-			{ title: "오랜만이야", body: "하나만 해보자, 다시" },
+			{
+				title: "한 달 만이야, 보고 싶었어 💌",
+				body: "언제든 다시 시작할 수 있어",
+			},
+			{ title: "돌아올 거라고 믿었어 🌱", body: "오늘이 새로운 Day 1이야" },
+			{ title: "오랜만이야! 👋", body: "하나만 해보자, 처음처럼" },
 		],
 	} satisfies NotificationTemplate,
 	// 주간 달성 배지
 	WEEKLY_ACHIEVEMENT: {
-		title: "이번 주 {completedCount}개 클리어",
-		body: "다음 주엔 더 할 수 있잖아",
+		title: "📊 이번 주 {completedCount}개 클리어",
+		body: "꾸준함이 곧 실력이야",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 		variants: [
 			{
-				title: "이번 주 {completedCount}개 클리어",
-				body: "다음 주엔 더 할 수 있잖아",
+				title: "📊 이번 주 {completedCount}개 클리어",
+				body: "꾸준함이 곧 실력이야",
 			},
-			{ title: "{completedCount}개 완료!", body: "꾸준히 하고 있네" },
 			{
-				title: "이번 주 {completedCount}개 해냈어",
-				body: "조금씩 늘어가고 있어",
+				title: "이번 주 {completedCount}개 완료! ✅",
+				body: "다음 주엔 더 갈 수 있겠는데?",
+			},
+			{
+				title: "한 주 동안 {completedCount}개 해냈어 💪",
+				body: "조금씩 계속 늘고 있어",
 			},
 		],
 	} satisfies NotificationTemplate,
 	WEEKLY_ACHIEVEMENT_PERFECT: {
-		title: "이번 주 전부 다 해냈어",
-		body: "완벽한 한 주였다",
+		title: "🏆 이번 주 100% 올클리어!",
+		body: "완벽한 한 주였어",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 		variants: [
-			{ title: "이번 주 전부 다 해냈어", body: "완벽한 한 주였다" },
-			{ title: "올클리어!", body: "이런 주가 계속되면 전설임" },
-			{ title: "100% 완료!", body: "진짜 대단해" },
+			{ title: "🏆 이번 주 100% 올클리어!", body: "완벽한 한 주였어" },
+			{
+				title: "이번 주 전부 다 해냈어 🎉",
+				body: "이런 주가 쌓이면 전설이 된다",
+			},
+			{ title: "퍼펙트 위크 달성 ✨", body: "진짜 대단해, 박수!" },
 		],
 	} satisfies NotificationTemplate,
 	WEEKLY_ACHIEVEMENT_ALMOST: {
-		title: "이번 주 완료율 {rate}%",
-		body: "거의 다 했는데 아쉽다",
+		title: "이번 주 완료율 {rate}% 🔥",
+		body: "아깝다! 다음 주엔 100% 가보자",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 		variants: [
-			{ title: "이번 주 완료율 {rate}%", body: "거의 다 했는데 아쉽다" },
-			{ title: "{rate}% 달성!", body: "다음 주 100% 가보자" },
-			{ title: "이번 주 {rate}%!", body: "아깝지만 충분히 잘 했어" },
+			{
+				title: "이번 주 완료율 {rate}% 🔥",
+				body: "아깝다! 다음 주엔 100% 가보자",
+			},
+			{ title: "{rate}% 달성! 💪", body: "거의 다 왔어, 마지막 한 조각만" },
+			{ title: "이번 주 {rate}%! ✨", body: "충분히 잘했어, 다음 주가 기대돼" },
 		],
 	} satisfies NotificationTemplate,
 	WEEKLY_REPORT: {
-		title: "주간 리포트가 도착했다냥!",
-		body: "이번 주 성적표를 확인해보라냥",
+		title: "📊 주간 리포트 도착!",
+		body: "이번 주 어땠는지 같이 볼까?",
 		type: "WEEKLY_REPORT",
 		defaultRoute: "/reports",
 	} satisfies NotificationTemplate,
 	MONTHLY_REPORT: {
-		title: "월간 리포트 왔다냥!",
-		body: "한 달 동안 얼마나 했는지 볼까냥",
+		title: "📈 월간 리포트 도착!",
+		body: "한 달 동안 얼마나 해냈는지 확인해봐",
 		type: "MONTHLY_REPORT",
 		defaultRoute: "/reports",
 	} satisfies NotificationTemplate,
 	AI_SUGGESTION: {
-		title: "반복 패턴을 발견했다냥!",
-		body: "자동으로 만들어줄까냥?",
+		title: "✨ 반복 패턴 발견!",
+		body: "매번 만들기 귀찮지? 자동으로 만들어줄게",
 		type: "AI_SUGGESTION",
 		defaultRoute: "/suggestions",
 	} satisfies NotificationTemplate,
@@ -619,82 +720,82 @@ export const SYSTEM_TEMPLATES = {
 		defaultRoute: null,
 	} satisfies NotificationTemplate,
 	BILLING_ISSUE: {
-		title: "결제 문제가 발생했어요",
-		body: "결제 수단을 확인해주세요. 구독이 중단될 수 있습니다.",
+		title: "💳 결제에 문제가 생겼어",
+		body: "결제 수단을 확인해줘. 이대로면 구독이 멈출 수 있어",
 		type: "SYSTEM_NOTICE",
 		defaultRoute: null,
 	} satisfies NotificationTemplate,
 	// 온보딩 시퀀스 (신규 유저 7일)
 	ONBOARDING_DAY0: {
-		title: "첫 할일을 만들어볼까?",
+		title: "🌱 첫 할 일을 만들어볼까?",
 		body: "작은 거 하나면 충분해",
 		type: "SYSTEM_NOTICE",
 		defaultRoute: "/create-todo",
 	} satisfies NotificationTemplate,
 	ONBOARDING_DAY1: {
-		title: "어제 만든 할일, 해봤어?",
-		body: "완료 체크하면 기분 좋을걸",
+		title: "어제 만든 할 일, 해봤어? ✅",
+		body: "완료 체크 한 번이면 기분 좋아질걸",
 		type: "SYSTEM_NOTICE",
 		defaultRoute: null,
 	} satisfies NotificationTemplate,
 	ONBOARDING_DAY2: {
-		title: "혼자보다 같이가 낫잖아",
+		title: "혼자보다 같이가 낫잖아 🤝",
 		body: "친구 추가하고 서로 응원해보자",
 		type: "SYSTEM_NOTICE",
 		defaultRoute: "/friends",
 	} satisfies NotificationTemplate,
 	ONBOARDING_DAY3: {
-		title: "알림 시간 맞춰놨어?",
-		body: "원하는 시간에 알려줄게",
+		title: "⏰ 알림 시간 맞춰놨어?",
+		body: "원하는 시간에 딱 맞춰 알려줄게",
 		type: "SYSTEM_NOTICE",
 		defaultRoute: "/settings",
 	} satisfies NotificationTemplate,
 	ONBOARDING_DAY5: {
-		title: "벌써 {completedCount}개 완료!",
-		body: "이 속도면 금방 습관 됨",
+		title: "벌써 {completedCount}개 완료! 🔥",
+		body: "이 속도면 금방 습관 된다",
 		type: "SYSTEM_NOTICE",
 		defaultRoute: null,
 	} satisfies NotificationTemplate,
 	ONBOARDING_DAY7: {
-		title: "첫 주 끝!",
-		body: "{completedCount}개 해냈어, 다음 주도 가보자",
+		title: "🎉 첫 주 완주!",
+		body: "{completedCount}개나 해냈어. 다음 주도 가보자",
 		type: "SYSTEM_NOTICE",
 		defaultRoute: null,
 	} satisfies NotificationTemplate,
 	// 마일스톤 축하
 	MILESTONE_FIRST_COMPLETE: {
-		title: "첫 번째 완료!",
-		body: "시작이 반이야",
+		title: "🎉 첫 번째 완료!",
+		body: "시작이 반이야, 벌써 반 왔네",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 	} satisfies NotificationTemplate,
 	MILESTONE_10: {
-		title: "벌써 10개째!",
-		body: "꾸준히 하고 있네",
+		title: "벌써 10개 달성! ✨",
+		body: "꾸준함이 쌓이는 중",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 	} satisfies NotificationTemplate,
 	MILESTONE_50: {
-		title: "50개 돌파!",
-		body: "이쯤 되면 프로야",
+		title: "🔥 50개 돌파!",
+		body: "이쯤 되면 프로 인정",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 	} satisfies NotificationTemplate,
 	MILESTONE_100: {
-		title: "100개 달성!",
-		body: "진짜 대단해",
+		title: "👑 100개 달성!",
+		body: "세 자릿수라니, 진짜 대단해",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 	} satisfies NotificationTemplate,
 	MILESTONE_STREAK_3: {
-		title: "3일 연속!",
-		body: "습관의 시작이야",
+		title: "🔥 3일 연속!",
+		body: "습관은 이렇게 시작되는 거야",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/stats",
 	} satisfies NotificationTemplate,
 	MILESTONE_FIRST_FRIEND: {
-		title: "첫 친구가 생겼어!",
-		body: "같이 하면 더 잘 돼",
+		title: "🎉 첫 친구가 생겼어!",
+		body: "같이 하면 두 배로 잘 돼",
 		type: "WEEKLY_ACHIEVEMENT",
 		defaultRoute: "/friends",
 	} satisfies NotificationTemplate,
@@ -1210,12 +1311,12 @@ export class NotificationMessageBuilder {
 			precipProb: forecast.precipitationProbability,
 		};
 
-		const template =
-			forecast.precipitationType === "SNOW"
-				? WEATHER_TEMPLATES.MORNING_SNOW
-				: forecast.precipitationProbability >= 40
-					? WEATHER_TEMPLATES.MORNING_RAIN
-					: WEATHER_TEMPLATES.MORNING_CLEAR;
+		const template = selectWeatherTemplate(
+			forecast,
+			WEATHER_TEMPLATES.MORNING_SNOW,
+			WEATHER_TEMPLATES.MORNING_RAIN,
+			WEATHER_TEMPLATES.MORNING_CLEAR,
+		);
 
 		const { title, body } = pickVariant(template);
 		return {
@@ -1236,12 +1337,12 @@ export class NotificationMessageBuilder {
 			precipProb: tomorrowForecast.precipitationProbability,
 		};
 
-		const template =
-			tomorrowForecast.precipitationType === "SNOW"
-				? WEATHER_TEMPLATES.EVENING_SNOW
-				: tomorrowForecast.precipitationProbability >= 40
-					? WEATHER_TEMPLATES.EVENING_RAIN
-					: WEATHER_TEMPLATES.EVENING_CLEAR;
+		const template = selectWeatherTemplate(
+			tomorrowForecast,
+			WEATHER_TEMPLATES.EVENING_SNOW,
+			WEATHER_TEMPLATES.EVENING_RAIN,
+			WEATHER_TEMPLATES.EVENING_CLEAR,
+		);
 
 		const { title, body } = pickVariant(template);
 		return {
@@ -1255,8 +1356,8 @@ export class NotificationMessageBuilder {
 	 */
 	static weatherMorningFallback(): { title: string; body: string } {
 		return {
-			title: "오늘 날씨 어떨까?",
-			body: "위치 설정하면 날씨에 맞는 할 일 팁도 알려줄게",
+			title: "오늘 날씨 궁금하지 않아? ☀️",
+			body: "위치만 설정하면 매일 아침 날씨도 같이 알려줄게",
 		};
 	}
 
@@ -1265,10 +1366,40 @@ export class NotificationMessageBuilder {
 	 */
 	static weatherEveningFallback(): { title: string; body: string } {
 		return {
-			title: "내일 날씨 궁금하지 않아?",
-			body: "위치 설정하면 내일 계획 세울 때 날씨도 같이 알려줄게",
+			title: "내일 날씨 미리 알려줄까? 🌙",
+			body: "위치 설정하면 내일 계획 세우기 훨씬 편해져",
 		};
 	}
+}
+
+/**
+ * 강수형태 우선으로 날씨 템플릿을 선택합니다.
+ *
+ * - 눈/진눈깨비 예보 → 눈 템플릿
+ * - 비/소나기 예보 or 강수확률 40% 이상 → 비 템플릿
+ * - 그 외 → 맑음 템플릿
+ *
+ * (강수확률만 보면 확률 40% 미만의 비 예보에 "맑음" 문구가 나가는 문제가 있어
+ * 강수형태를 먼저 판정한다)
+ */
+function selectWeatherTemplate(
+	forecast: WeatherForecast,
+	snow: NotificationTemplate,
+	rain: NotificationTemplate,
+	clear: NotificationTemplate,
+): NotificationTemplate {
+	const type = forecast.precipitationType;
+	if (type === "SNOW" || type === "RAIN_SNOW") {
+		return snow;
+	}
+	if (
+		type === "RAIN" ||
+		type === "SHOWER" ||
+		forecast.precipitationProbability >= 40
+	) {
+		return rain;
+	}
+	return clear;
 }
 
 const SKY_LABEL_MAP: Record<string, string> = {

--- a/apps/api/src/modules/scheduler/reminder/processors/todo-reminder.processor.spec.ts
+++ b/apps/api/src/modules/scheduler/reminder/processors/todo-reminder.processor.spec.ts
@@ -177,8 +177,8 @@ describe("TodoReminderProcessor — 할 일 리마인더 프로세서", () => {
 			// Then — DB의 최신 제목이 알림에 사용됨
 			expect(notificationService.createAndSend).toHaveBeenCalledWith(
 				expect.objectContaining({
-					title: "밥먹고 약먹기, 1시간 남았어",
-					body: "미리 시작하면 여유롭게 끝나",
+					title: "⏰ 밥먹고 약먹기, 1시간 뒤 시작!",
+					body: "미리 해두면 마음이 편해져",
 				}),
 			);
 

--- a/apps/api/src/modules/weather/providers/kma/kma-response-parser.ts
+++ b/apps/api/src/modules/weather/providers/kma/kma-response-parser.ts
@@ -38,6 +38,21 @@ function formatDateString(yyyymmdd: string): string {
 }
 
 /**
+ * non-zero PTY 코드 중 가장 빈도 높은 코드를 반환 (없으면 "0")
+ */
+function mostFrequentPty(ptyCounts: Map<string, number>): string {
+	let dominantPty = "0";
+	let maxCount = 0;
+	for (const [code, count] of ptyCounts) {
+		if (count > maxCount) {
+			maxCount = count;
+			dominantPty = code;
+		}
+	}
+	return dominantPty;
+}
+
+/**
  * 특정 날짜의 아이템들로부터 DailyForecast를 생성
  */
 function buildDailyForecast(
@@ -48,8 +63,7 @@ function buildDailyForecast(
 	let tempMax = Number.NEGATIVE_INFINITY;
 	let maxPrecipProb = 0;
 	const skyCounts = new Map<string, number>();
-	let hasNonNonePty = false;
-	let dominantPty = "0";
+	const ptyCounts = new Map<string, number>();
 
 	for (const item of dateItems) {
 		const value = item.fcstValue;
@@ -86,8 +100,7 @@ function buildDailyForecast(
 			}
 			case KMA_CATEGORY.PTY: {
 				if (value !== "0") {
-					hasNonNonePty = true;
-					dominantPty = value;
+					ptyCounts.set(value, (ptyCounts.get(value) ?? 0) + 1);
 				}
 				break;
 			}
@@ -107,9 +120,7 @@ function buildDailyForecast(
 	return {
 		date: formatDateString(dateStr),
 		skyCondition: SKY_CODE_MAP[mostCommonSky] ?? "CLEAR",
-		precipitationType: hasNonNonePty
-			? (PTY_CODE_MAP[dominantPty] ?? "NONE")
-			: "NONE",
+		precipitationType: PTY_CODE_MAP[mostFrequentPty(ptyCounts)] ?? "NONE",
 		precipitationProbability: maxPrecipProb,
 		temperatureMin: tempMin === Number.POSITIVE_INFINITY ? 0 : tempMin,
 		temperatureMax: tempMax === Number.NEGATIVE_INFINITY ? 0 : tempMax,
@@ -145,7 +156,7 @@ export function parseKmaResponse(
 	let tempMax = Number.NEGATIVE_INFINITY;
 	let maxPrecipProb = 0;
 	let dominantSky = "1"; // 기본: 맑음
-	let dominantPty = "0"; // 기본: 없음
+	const ptyCounts = new Map<string, number>(); // non-zero PTY 빈도
 	let avgHumidity = 0;
 	let avgWindSpeed = 0;
 	let humidityCount = 0;
@@ -230,7 +241,9 @@ export function parseKmaResponse(
 				break;
 			}
 			case KMA_CATEGORY.PTY: {
-				if (!isNextDay && value !== "0") dominantPty = value;
+				if (!isNextDay && value !== "0") {
+					ptyCounts.set(value, (ptyCounts.get(value) ?? 0) + 1);
+				}
 				break;
 			}
 			case KMA_CATEGORY.REH: {
@@ -300,7 +313,7 @@ export function parseKmaResponse(
 	return {
 		date: targetDate,
 		skyCondition: SKY_CODE_MAP[dominantSky] ?? "CLEAR",
-		precipitationType: PTY_CODE_MAP[dominantPty] ?? "NONE",
+		precipitationType: PTY_CODE_MAP[mostFrequentPty(ptyCounts)] ?? "NONE",
 		precipitationProbability: maxPrecipProb,
 		temperatureMin: tempMin === Number.POSITIVE_INFINITY ? 0 : tempMin,
 		temperatureMax: tempMax === Number.NEGATIVE_INFINITY ? 0 : tempMax,

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -217,6 +217,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     // Plugins
     plugins: [
       './plugins/withJitpackFilter',
+      './plugins/withGradleJvmArgs',
       '@react-native-firebase/app',
       '@react-native-firebase/crashlytics',
       '@react-native-community/datetimepicker',

--- a/apps/mobile/plugins/withGradleJvmArgs.js
+++ b/apps/mobile/plugins/withGradleJvmArgs.js
@@ -1,0 +1,29 @@
+const { withGradleProperties } = require('expo/config-plugins');
+
+/**
+ * Gradle JVM 메모리 상향으로 릴리즈 빌드 OOM(Metaspace)을 방지합니다.
+ *
+ * prebuild 기본값(-Xmx2048m -XX:MaxMetaspaceSize=512m)은 SDK 57 규모의
+ * 릴리즈 빌드(Kotlin 컴파일 + lintVitalAnalyzeRelease 병렬 실행)에서
+ * Metaspace가 고갈되어 `OutOfMemoryError: Metaspace`로 실패합니다.
+ */
+const JVM_ARGS = '-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError';
+
+const withGradleJvmArgs = (config) => {
+  return withGradleProperties(config, (config) => {
+    const properties = config.modResults.filter(
+      (item) => !(item.type === 'property' && item.key === 'org.gradle.jvmargs'),
+    );
+
+    properties.push({
+      type: 'property',
+      key: 'org.gradle.jvmargs',
+      value: JVM_ARGS,
+    });
+
+    config.modResults = properties;
+    return config;
+  });
+};
+
+module.exports = withGradleJvmArgs;


### PR DESCRIPTION
## 📋 개요

서버 푸시알림 문구 전체(~40종 템플릿, variants 포함 약 120개 문구)를 "친근한 반말 + 이모지" 톤으로 리프레시하고, 함께 발견된 날씨 알림 판정 버그를 수정합니다.

**클라이언트 영향 0**: 클라는 `title`/`body`를 표시만 하고 라우팅은 `data.type`/`data.context`로 처리합니다. `data` 페이로드, placeholder 키, `defaultRoute`, Prisma 스키마는 일절 변경하지 않았습니다. 기존 DB 알림 행도 그대로 유지되고 신규 발송분부터 새 문구가 적용됩니다.

## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가
- [x] 🐛 `fix` - 버그 수정
- [ ] 📝 `docs` - 문서 수정
- [ ] ♻️ `refactor` - 코드 리팩토링
- [ ] ⚡ `perf` - 성능 개선
- [x] ✅ `test` - 테스트 추가/수정
- [ ] 👷 `ci` - CI/CD 설정 및 스크립트 변경
- [ ] 🔨 `chore` - 기타 변경사항 (빌드 프로세스, 도구 설정 등)

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [x] `apps/mobile` - Expo 모바일 앱
- [ ] `packages/validators` - Zod 스키마
- [ ] `packages/utils` - 공유 유틸리티
- [ ] `packages/errors` - 에러 정의
- [ ] `tooling/*` - 개발 도구 설정 (biome, jest, typescript)
- [ ] multiple - 여러 영역 동시 변경

## 📝 변경 내용

### 1. 문구 전면 리프레시 (`notification-templates.ts`)

전 템플릿 그룹(할일 리마인더 · 아침/저녁 리마인더 · 스트릭 · 점심 넛지 · 날씨 · 소셜 · 윈백 · 주간 달성 · 리포트 · 온보딩 · 마일스톤 · 결제)을 새 톤으로 교체. 대표 Before → After:

| 상황 | Before | After |
|---|---|---|
| 할일 1시간 전 | {todoTitle}, 1시간 남았어 / 미리 시작하면 여유롭게 끝나 | ⏰ {todoTitle}, 1시간 뒤 시작! / 미리 해두면 마음이 편해져 |
| 아침 리마인더 | 오늘 할일 {count}개 / 하나씩 쓸어버리자 | ☀️ 오늘 할 일 {count}개 / 가장 쉬운 것부터 하나씩 가보자 |
| 저녁 전체완료 | 올클리어! / 오늘 너 좀 멋있었어 | 🎉 올클리어! / 오늘 너 진짜 멋있었어 |
| 스트릭 위기 | {streak}일 기록, 오늘도 이어가자 | 🚨 {streak}일 기록이 오늘에 달렸어 |
| 콕 찌르기 | {senderName:이/가} '{todoTitle}' 콕 찔렀어! / 아직도 안 했어? | 👉 {senderName:이/가} '{todoTitle}' 콕! / 아직도 안 했어? 😏 |
| 주간 리포트 | 주간 리포트가 도착했다냥! | 📊 주간 리포트 도착! |
| 결제 문제 | 결제 문제가 발생했어요 (존댓말) | 💳 결제에 문제가 생겼어 (앱 톤 통일) |

- 리포트 3종의 "~냥" 말투 제거 (앱 어디에도 고양이 페르소나 없음 → 고아 페르소나 정리)
- 결제 알림 존댓말 → 앱 기본 반말 톤으로 통일
- 전체 문구 Before/After 목록은 이슈 #584 및 diff 참고

### 2. 날씨 알림 판정 버그 수정

- **템플릿 선택을 강수형태 우선으로 변경** (`selectWeatherTemplate` 신설): 기존엔 `강수확률 >= 40%`만 판정해서 비 예보(`RAIN`/`SHOWER`)라도 확률 40% 미만이면 "할 일 해치우기 딱 좋은 날씨야"가 발송됨. 진눈깨비(`RAIN_SNOW`)는 눈 문구를 타지 못함 → 눈/진눈깨비 → 눈, 비/소나기 or 확률 40%+ → 비, 그 외 → 맑음
- **KMA 파서 `dominantPty` 최빈값 집계** (`kma-response-parser.ts`): 마지막 non-zero PTY로 덮어써지던 것을 SKY와 동일한 빈도 집계 방식으로 수정 (2곳: `buildDailyForecast`, `parseKmaResponse`)

### 3. 조사 하드코딩 수정

- `"{senderName}과 연결됐어!"` → `{senderName:와/과}`, `"{friendName}은 …"` → `{friendName:은/는}` — 받침 없는 이름에서 조사가 틀리던 문제 (예: "민지과" → "민지와")

### 4. (동승) 안드로이드 릴리즈 빌드 OOM 해결 (`apps/mobile`)

- `withGradleJvmArgs` config plugin 추가: prebuild 기본 JVM 설정(-Xmx2048m, MaxMetaspaceSize 512m)으로는 SDK 57 릴리즈 빌드에서 `OutOfMemoryError: Metaspace` 발생 → -Xmx4096m, MaxMetaspaceSize 1024m으로 상향

### 5. 테스트

- 문구 하드코딩 단언 spec 갱신 (고정 템플릿은 상수 참조 방식으로 전환)
- 날씨 템플릿 선택 5개 케이스 신규 추가 (비+30%, 소나기, 진눈깨비, NONE+50%, NONE+10%)
- `fillTemplate` 조사 `와/과`, `은/는` 케이스 추가

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck && pnpm lint   # apps/api
pnpm test                     # apps/api 전체 단위 테스트
```

### 테스트 결과

- [x] 단위 테스트 통과 (191 suites / 2,265 passed)
- [ ] 통합 테스트 통과
- [x] 수동 테스트 완료 (typecheck·lint·build 통과)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 변경사항에 대한 테스트를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [ ] 필요한 경우 문서를 업데이트했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

### 리뷰어 확인

- [ ] 코드 로직이 올바릅니다
- [ ] 에러 처리가 적절합니다
- [ ] 보안 취약점이 없습니다
- [ ] 성능 이슈가 없습니다

## 🔗 관련 이슈

Closes #584

## 💬 추가 정보

- `Notification.title/body`는 DB `VarChar(200)/(500)` 제약 내로 모두 여유 있음
- `SYSTEM_NOTICE`("Aido" / `{message}`)는 관리자 임의 발송용이라 유지
- `notification.service.spec.ts`의 "친구가 콕 찔렀어요"는 임의 테스트 입력이라 미변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)

