### PR TITLE
fix(mobile): 재설치 시 키체인 잔존 토큰으로 인한 즉시 로그아웃 수정 (v1.3.5)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -15,7 +15,7 @@ interface EnvironmentConfig {
 
 const PROJECT_SLUG = 'aido';
 const OWNER = 'aido-team';
-const VERSION = '1.3.4';
+const VERSION = '1.3.5';
 
 const APP_NAME = 'Aido';
 const BUNDLE_IDENTIFIER = 'com.aido.mobile';

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aido/mobile",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/apps/mobile/src/bootstrap/providers/auth-boot.test.ts
+++ b/apps/mobile/src/bootstrap/providers/auth-boot.test.ts
@@ -1,0 +1,70 @@
+import { createMockStorage, createMockSyncStorage } from '@src/shared/__tests__';
+import {
+  clearStaleTokensOnFreshInstall,
+  FIRST_RUN_FLAG,
+  resolveInitialAuthStatus,
+} from './auth-boot';
+
+describe('앱 부팅 인증 처리 — 재설치 잔존 토큰 가드', () => {
+  let secureStorage: ReturnType<typeof createMockStorage>;
+  let flags: ReturnType<typeof createMockSyncStorage>;
+
+  beforeEach(() => {
+    secureStorage = createMockStorage();
+    flags = createMockSyncStorage();
+  });
+
+  it('재설치: 첫 실행(플래그 없음)인데 키체인에 이전 토큰이 남아있으면 → 토큰을 제거하고 미인증으로 시작한다', async () => {
+    // Given — iOS 키체인은 앱 삭제 후에도 잔존, MMKV 플래그는 소멸(첫 실행)
+    flags.getString.mockReturnValue(undefined);
+    secureStorage.get.mockResolvedValue('stale-access-token');
+
+    // When
+    const status = await resolveInitialAuthStatus(secureStorage, flags);
+
+    // Then — 잔존 토큰 제거 + 플래그 심기 + 미인증 시작(즉시 로그아웃 루프 방지)
+    expect(secureStorage.remove).toHaveBeenCalledWith('accessToken');
+    expect(secureStorage.remove).toHaveBeenCalledWith('refreshToken');
+    expect(flags.set).toHaveBeenCalledWith(FIRST_RUN_FLAG, '1');
+    expect(status).toBe('unauthenticated');
+  });
+
+  it('정상 재실행: 플래그가 있으면 토큰을 보존하고 인증 상태를 유지한다', async () => {
+    // Given — 이미 실행된 적 있는 설치(플래그 존재) + 유효 토큰
+    flags.getString.mockReturnValue('1');
+    secureStorage.get.mockResolvedValue('valid-access-token');
+
+    // When
+    const status = await resolveInitialAuthStatus(secureStorage, flags);
+
+    // Then — 토큰을 건드리지 않고 인증 유지
+    expect(secureStorage.remove).not.toHaveBeenCalled();
+    expect(status).toBe('authenticated');
+  });
+
+  it('신규 설치: 플래그도 토큰도 없으면 플래그만 심고 미인증으로 시작한다', async () => {
+    // Given
+    flags.getString.mockReturnValue(undefined);
+    secureStorage.get.mockResolvedValue(null);
+
+    // When
+    const status = await resolveInitialAuthStatus(secureStorage, flags);
+
+    // Then
+    expect(flags.set).toHaveBeenCalledWith(FIRST_RUN_FLAG, '1');
+    expect(status).toBe('unauthenticated');
+  });
+
+  it('clearStaleTokensOnFreshInstall: 플래그가 있으면 아무것도 지우지 않고 false를 반환한다', async () => {
+    // Given
+    flags.getString.mockReturnValue('1');
+
+    // When
+    const cleared = await clearStaleTokensOnFreshInstall(secureStorage, flags);
+
+    // Then
+    expect(cleared).toBe(false);
+    expect(secureStorage.remove).not.toHaveBeenCalled();
+    expect(flags.set).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/bootstrap/providers/auth-boot.ts
+++ b/apps/mobile/src/bootstrap/providers/auth-boot.ts
@@ -1,0 +1,45 @@
+import type { Storage } from '@src/core/ports/storage';
+import type { SyncStorage } from '@src/core/ports/sync-storage';
+import { STORAGE_KEYS } from '@src/shared/constants/storage-keys.constant';
+
+/** MMKV(앱 삭제 시 함께 소멸)에 심는 "이 설치에서 실행된 적 있음" 플래그 키. */
+export const FIRST_RUN_FLAG = 'aido.hasLaunchedBefore';
+
+export type InitialAuthStatus = 'authenticated' | 'unauthenticated';
+
+/**
+ * 재설치 시 키체인에 잔존한 토큰으로 인한 즉시 로그아웃을 방지한다.
+ *
+ * iOS 키체인(SecureStore)은 앱을 삭제해도 남지만, MMKV(SyncStorage)는 삭제 시 함께 지워진다.
+ * 따라서 MMKV 플래그가 없으면 "이 설치에서의 첫 실행"(신규 설치 또는 재설치)이므로,
+ * 키체인에 남아있을 수 있는 이전 설치의 토큰을 선제 제거한다.
+ *
+ * @returns 잔존 토큰 정리를 수행했으면 true (= 미인증으로 시작해야 함)
+ */
+export const clearStaleTokensOnFreshInstall = async (
+  secureStorage: Storage,
+  flags: SyncStorage,
+): Promise<boolean> => {
+  if (flags.getString(FIRST_RUN_FLAG) === '1') {
+    return false;
+  }
+  await Promise.all([
+    secureStorage.remove(STORAGE_KEYS.ACCESS_TOKEN),
+    secureStorage.remove(STORAGE_KEYS.REFRESH_TOKEN),
+  ]);
+  flags.set(FIRST_RUN_FLAG, '1');
+  return true;
+};
+
+/** 앱 부팅 시 초기 인증 상태를 결정한다(재설치 잔존 토큰 가드 포함). */
+export const resolveInitialAuthStatus = async (
+  secureStorage: Storage,
+  flags: SyncStorage,
+): Promise<InitialAuthStatus> => {
+  const cleared = await clearStaleTokensOnFreshInstall(secureStorage, flags);
+  if (cleared) {
+    return 'unauthenticated';
+  }
+  const token = await secureStorage.get<string>(STORAGE_KEYS.ACCESS_TOKEN);
+  return token ? 'authenticated' : 'unauthenticated';
+};

--- a/apps/mobile/src/bootstrap/providers/auth-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/auth-provider.tsx
@@ -34,11 +34,20 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
   // 앱 시작 시 초기 인증 상태 결정 (재설치 잔존 토큰 가드 포함)
   useEffect(() => {
     const checkAuth = async () => {
-      const initialStatus = await resolveInitialAuthStatus(storage, mmkvSyncStorage);
-      setStatusState(initialStatus);
+      try {
+        const initialStatus = await resolveInitialAuthStatus(storage, mmkvSyncStorage);
+        setStatusState(initialStatus);
+      } catch (error) {
+        // 키체인 접근 실패(기기 잠김 등)로 throw되어도 'loading'에 영구히 갇히지 않도록
+        // 미인증으로 폴백하고 관측 리포팅한다.
+        errorReporter.captureException(error instanceof Error ? error : new Error(String(error)), {
+          feature: 'auth',
+        });
+        setStatusState('unauthenticated');
+      }
     };
     checkAuth();
-  }, [storage]);
+  }, [storage, errorReporter]);
 
   // 토큰 갱신 최종 실패(세션 만료 확정) 시 로그아웃과 동일한 순서로 정리 + 관측 리포팅
   useEffect(() => {

--- a/apps/mobile/src/bootstrap/providers/auth-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/auth-provider.tsx
@@ -2,6 +2,7 @@ import { subscribeSessionExpired } from '@src/core/events/session-expired';
 import { sessionExpiredSeverity } from '@src/core/ports/telemetry-event';
 import { track } from '@src/shared/analytics';
 import { resetAuthClient } from '@src/shared/infra/http/auth-client';
+import { mmkvSyncStorage } from '@src/shared/infra/storage/mmkv-storage';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   createContext,
@@ -11,6 +12,7 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { resolveInitialAuthStatus } from './auth-boot';
 import { useAnalytics, useErrorReporter, useStorage } from './di-provider';
 
 type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
@@ -29,11 +31,11 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
   const queryClient = useQueryClient();
   const [status, setStatusState] = useState<AuthStatus>('loading');
 
-  // 앱 시작 시 토큰 확인
+  // 앱 시작 시 초기 인증 상태 결정 (재설치 잔존 토큰 가드 포함)
   useEffect(() => {
     const checkAuth = async () => {
-      const token = await storage.get<string>('accessToken');
-      setStatusState(token ? 'authenticated' : 'unauthenticated');
+      const initialStatus = await resolveInitialAuthStatus(storage, mmkvSyncStorage);
+      setStatusState(initialStatus);
     };
     checkAuth();
   }, [storage]);

--- a/apps/mobile/src/features/auth/services/auth.service.ts
+++ b/apps/mobile/src/features/auth/services/auth.service.ts
@@ -37,6 +37,7 @@ import {
 import type { HttpClient } from '@src/core/ports/http';
 import type { Storage } from '@src/core/ports/storage';
 import { ENV } from '@src/shared/config/env';
+import { STORAGE_KEYS } from '@src/shared/constants/storage-keys.constant';
 import type { ApiError } from '@src/shared/errors/api-error';
 import { ParseError } from '@src/shared/errors/infra-error';
 import { err, ok, type Result } from '@src/shared/errors/result';
@@ -199,13 +200,16 @@ export class AuthService {
 
   #saveTokens = async (accessToken: string, refreshToken: string): Promise<void> => {
     await Promise.all([
-      this.#storage.set('accessToken', accessToken),
-      this.#storage.set('refreshToken', refreshToken),
+      this.#storage.set(STORAGE_KEYS.ACCESS_TOKEN, accessToken),
+      this.#storage.set(STORAGE_KEYS.REFRESH_TOKEN, refreshToken),
     ]);
   };
 
   #clearTokens = async (): Promise<void> => {
-    await Promise.all([this.#storage.remove('accessToken'), this.#storage.remove('refreshToken')]);
+    await Promise.all([
+      this.#storage.remove(STORAGE_KEYS.ACCESS_TOKEN),
+      this.#storage.remove(STORAGE_KEYS.REFRESH_TOKEN),
+    ]);
   };
 
   #parseAuthTokens = (result: { ok: true; value: AuthTokensDTO }): AuthTokens => {

--- a/apps/mobile/src/shared/constants/storage-keys.constant.ts
+++ b/apps/mobile/src/shared/constants/storage-keys.constant.ts
@@ -1,0 +1,8 @@
+/**
+ * SecureStore(키체인)에 저장하는 인증 토큰 키.
+ * 앱 전역에서 이 상수만 사용해 오타·불일치를 방지한다.
+ */
+export const STORAGE_KEYS = {
+  ACCESS_TOKEN: 'accessToken',
+  REFRESH_TOKEN: 'refreshToken',
+} as const;

--- a/apps/mobile/src/shared/infra/http/auth-client.ts
+++ b/apps/mobile/src/shared/infra/http/auth-client.ts
@@ -1,5 +1,6 @@
 import type { Storage } from '@src/core/ports/storage';
 import { ENV } from '@src/shared/config/env';
+import { STORAGE_KEYS } from '@src/shared/constants/storage-keys.constant';
 import { getDeviceTimezone } from '@src/shared/utils/timezone';
 import ky, { type AfterResponseHook, type KyInstance } from 'ky';
 import { handleApiErrors } from './error-handler';
@@ -42,7 +43,7 @@ export const createTokenRefreshHook = (deps: TokenRefreshHookDeps): AfterRespons
       return response;
     }
 
-    const storedAccessToken = await storage.get<string>('accessToken');
+    const storedAccessToken = await storage.get<string>(STORAGE_KEYS.ACCESS_TOKEN);
     const sentAuthorization = request.headers.get('Authorization');
     if (storedAccessToken && sentAuthorization !== `Bearer ${storedAccessToken}`) {
       return retryWithMarker(request);
@@ -74,7 +75,7 @@ export const createAuthClient = (storage: Storage): KyInstance => {
     hooks: {
       beforeRequest: [
         async (request) => {
-          const accessToken = await storage.get<string>('accessToken');
+          const accessToken = await storage.get<string>(STORAGE_KEYS.ACCESS_TOKEN);
           if (accessToken) {
             request.headers.set('Authorization', `Bearer ${accessToken}`);
           }

--- a/apps/mobile/src/shared/infra/http/token-refresher.ts
+++ b/apps/mobile/src/shared/infra/http/token-refresher.ts
@@ -3,6 +3,7 @@ import { emitSessionExpired } from '@src/core/events/session-expired';
 import type { Storage } from '@src/core/ports/storage';
 import type { SessionExpiredReason } from '@src/core/ports/telemetry-event';
 import { ENV } from '@src/shared/config/env';
+import { STORAGE_KEYS } from '@src/shared/constants/storage-keys.constant';
 import { logger } from '@src/shared/infra/logger/global-logger';
 import ky from 'ky';
 import { z } from 'zod';
@@ -26,13 +27,16 @@ export const createTokenRefresher = (storage: Storage): TokenRefresher => {
 
   const expireSession = async (reason: SessionExpiredReason): Promise<false> => {
     logger.warn('[TokenRefresher] 세션 만료 확정', { reason });
-    await Promise.all([storage.remove('accessToken'), storage.remove('refreshToken')]);
+    await Promise.all([
+      storage.remove(STORAGE_KEYS.ACCESS_TOKEN),
+      storage.remove(STORAGE_KEYS.REFRESH_TOKEN),
+    ]);
     emitSessionExpired(reason);
     return false;
   };
 
   const refresh = async (): Promise<boolean> => {
-    const refreshToken = await storage.get<string>('refreshToken');
+    const refreshToken = await storage.get<string>(STORAGE_KEYS.REFRESH_TOKEN);
     if (!refreshToken) {
       return expireSession('no-refresh-token');
     }
@@ -65,8 +69,8 @@ export const createTokenRefresher = (storage: Storage): TokenRefresher => {
       }
       const { accessToken, refreshToken: nextRefreshToken } = parsed.data.data;
       await Promise.all([
-        storage.set('accessToken', accessToken),
-        storage.set('refreshToken', nextRefreshToken),
+        storage.set(STORAGE_KEYS.ACCESS_TOKEN, accessToken),
+        storage.set(STORAGE_KEYS.REFRESH_TOKEN, nextRefreshToken),
       ]);
       return true;
     }


### PR DESCRIPTION
## 📋 개요

**재설치 시 키체인 잔존 토큰으로 인한 즉시 로그아웃**을 수정합니다. iOS 키체인은 앱 삭제 후에도 남는데, 부팅 시 이 잔존 토큰을 걸러내는 first-run 가드가 없어 stale 토큰으로 자동 로그인→401→즉시 로그아웃 루프가 발생했습니다. (1.3.3 이하부터 존재, 1.3.4에서 Sentry 붙어 관측됨 — 회귀 아님)

> 릴리스 버전: `@aido/mobile` **1.3.4 → 1.3.5** (`app.config.ts` · `package.json`)

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정 (재설치 즉시 로그아웃)
- [x] ♻️ `refactor` - 토큰 키 상수화

## 📦 영향 범위

- [x] `apps/mobile` - Expo 모바일 앱

## 📝 변경 내용

**1) 재설치 잔존 토큰 가드 (핵심 수정)**
- `auth-boot.ts` 신규: `clearStaleTokensOnFreshInstall` — **MMKV 플래그**(앱 삭제 시 함께 소멸, 키체인과 반대)가 없으면 = 이 설치 첫 실행(신규/재설치) → 키체인의 `accessToken`/`refreshToken` 선제 제거 후 플래그 심기.
- `auth-provider.tsx`: 인라인 `checkAuth`("토큰 존재?"만 판정) → `resolveInitialAuthStatus`(가드 포함)로 교체.
- 기존 `SyncStorage` 포트(MMKV) 재사용 — 새 네이티브 의존성 0.

**2) 토큰 키 상수화 (드리프트 방지)**
- 흩어진 `'accessToken'`/`'refreshToken'` 리터럴 11곳 → `STORAGE_KEYS` 상수(`shared/constants/storage-keys.constant.ts`)로 통일. 프로덕션 코드 잔여 리터럴 0.

## 🧪 테스트 (TDD — RED → GREEN)

먼저 버그를 재현하는 실패 테스트를 작성한 뒤 수정했습니다.

```bash
pnpm turbo run typecheck check test --filter=@aido/mobile
```

- **RED**(수정 전): "재설치+잔존 토큰 → 미인증으로 시작" 테스트가 실패(현재 코드는 stale 토큰으로 `authenticated` 진입 = 버그 재현).
- **GREEN**(수정 후): `auth-boot.test` 4건 통과 —
  - [x] 재설치: 잔존 토큰 제거 + 미인증 시작
  - [x] 정상 재실행: 플래그 있으면 토큰 보존 + 인증 유지
  - [x] 신규 설치: 플래그 심고 미인증
  - [x] 플래그 있으면 아무것도 안 지움
- [x] `@aido/mobile` **644 / 644 ✅** (61 suites) · typecheck ✅ · biome ✅ · expo export(iOS/Android) 빌드 ✅

## ✅ 체크리스트

- [x] 코딩 컨벤션 준수 / `pnpm check` 통과
- [x] 테스트 작성(TDD) 및 전체 통과
- [x] 빌드 성공(expo export)
- [x] 커밋 메시지 Conventional Commits
- [x] 라벨 `type:*` + `scope:*`

## 🔗 관련 이슈

Closes #590

## 💬 추가 정보

**⚠️ 배포 주의**
- **가드 도입 1회 재로그인**: 이 버전 첫 실행 시 기존 로그인 유저는 플래그가 없어 **1회 재로그인** 필요(재설치와 구분 불가능한 표준 트레이드오프).
- 네이티브 의존성 변화 없음 → OTA 가능(단, 1.3.4가 Sentry로 네이티브 재빌드를 이미 요구하므로 1.3.4 이후 배포 흐름에 맞춰 진행).

**🔀 머지 순서 주의**
- 이 PR은 버전을 **1.3.5**로 올립니다. `develop`엔 아직 미배포된 **1.3.4(#589)** 가 있습니다.
- 이 PR을 develop에 머지하면 develop = 1.3.5가 되어, 열려있는 **Release v1.3.4(#589)** 는 실제로 1.3.5 내용을 담게 됩니다.
- 권장: **#589(1.3.4)를 먼저 main에 릴리스**한 뒤 이 PR을 develop에 머지 → 이후 Release v1.3.5. (또는 #589를 v1.3.5로 재라벨해 통합 — 팀 결정)
