### PR TITLE
fix(mobile): 잠금이 아닌 키체인 오류를 locked로 뭉개 무한 로딩에 갇히는 문제 수정

### DIFF
--- a/apps/mobile/src/bootstrap/providers/auth-boot.test.ts
+++ b/apps/mobile/src/bootstrap/providers/auth-boot.test.ts
@@ -1,3 +1,4 @@
+import { KeychainLockedError } from '@src/core/ports/storage';
 import { createMockTokenStore } from '@src/shared/__tests__';
 import { resolveInitialAuthStatus } from './auth-boot';
 
@@ -30,15 +31,28 @@ describe('앱 부팅 인증 판정 — 클라이언트는 세션을 먼저 끊�
     expect(status).toBe('unauthenticated');
   });
 
-  it('키체인을 읽을 수 없으면 미인증이 아니라 locked로 판정을 미룬다', async () => {
+  it('기기 잠금으로 읽지 못하면 미인증이 아니라 locked로 판정을 미룬다', async () => {
     // Given — 기기 잠금 중 콜드 스타트(푸시·백그라운드 실행). iOS는 null이 아니라 throw한다.
-    tokenStore.readRefreshToken.mockRejectedValue(new Error('User interaction is not allowed.'));
+    tokenStore.readRefreshToken.mockRejectedValue(
+      new KeychainLockedError(new Error('User interaction is not allowed.')),
+    );
 
     // When
     const status = await resolveInitialAuthStatus(tokenStore);
 
     // Then — locked를 미인증으로 확정하면 잠긴 키체인이 곧 로그아웃이 된다
     expect(status).toBe('locked');
+  });
+
+  it('잠금이 아닌 읽기 실패는 locked로 뭉개지 않고 그대로 던진다', async () => {
+    // Given — 키체인 손상(Android DecryptException)·entitlement 오설정 등 영구 오류.
+    // locked로 두면 재판정도 계속 실패해 앱이 조용히 무한 로딩에 갇힌다.
+    tokenStore.readRefreshToken.mockRejectedValue(new Error('Could not decrypt the value'));
+
+    // When & Then
+    await expect(resolveInitialAuthStatus(tokenStore)).rejects.toThrow(
+      'Could not decrypt the value',
+    );
   });
 
   it('세션 존재 판단은 리프레시 토큰 기준이다 (액세스 토큰과 무관)', async () => {
@@ -68,12 +82,23 @@ describe('앱 부팅 인증 판정 — 클라이언트는 세션을 먼저 끊�
       expect(tokenStore.clear).not.toHaveBeenCalled();
     });
 
-    it('키체인 읽기 실패 시에도 토큰을 지우지 않는다', async () => {
+    it('기기 잠금으로 읽지 못해도 토큰을 지우지 않는다', async () => {
       // Given
-      tokenStore.readRefreshToken.mockRejectedValue(new Error('keychain locked'));
+      tokenStore.readRefreshToken.mockRejectedValue(new KeychainLockedError(new Error('locked')));
 
       // When
       await resolveInitialAuthStatus(tokenStore);
+
+      // Then
+      expect(tokenStore.clear).not.toHaveBeenCalled();
+    });
+
+    it('잠금이 아닌 읽기 실패로 던질 때도 토큰을 지우지 않는다', async () => {
+      // Given — 폴백은 미인증 표시일 뿐. 원인이 해소되면 다음 실행에 회복되어야 한다.
+      tokenStore.readRefreshToken.mockRejectedValue(new Error('Could not decrypt the value'));
+
+      // When
+      await expect(resolveInitialAuthStatus(tokenStore)).rejects.toThrow();
 
       // Then
       expect(tokenStore.clear).not.toHaveBeenCalled();

--- a/apps/mobile/src/bootstrap/providers/auth-boot.ts
+++ b/apps/mobile/src/bootstrap/providers/auth-boot.ts
@@ -1,3 +1,4 @@
+import { KeychainLockedError } from '@src/core/ports/storage';
 import type { TokenStore } from '@src/core/ports/token-store';
 
 /**
@@ -23,6 +24,10 @@ export type ResolvedAuthStatus = 'authenticated' | 'unauthenticated' | 'locked';
  *   세션 검증은 첫 인증 요청의 401 경로가 알아서 수행한다.
  *
  * 세션 존재의 근거는 **리프레시 토큰**이다 — 액세스 토큰은 만료돼도 재발급된다.
+ *
+ * @throws 잠금이 아닌 읽기 실패(키체인 손상, entitlement 오설정 등)는 그대로 던진다.
+ *   이를 `locked`로 뭉개면 재판정도 계속 실패해 앱이 **조용히 무한 로딩**에 갇힌다.
+ *   호출자가 관측하고 미인증으로 폴백해야 한다(토큰은 지우지 않으므로 다음 실행에 회복 가능).
  */
 export const resolveInitialAuthStatus = async (
   tokenStore: TokenStore,
@@ -30,7 +35,10 @@ export const resolveInitialAuthStatus = async (
   try {
     const refreshToken = await tokenStore.readRefreshToken();
     return refreshToken ? 'authenticated' : 'unauthenticated';
-  } catch {
-    return 'locked';
+  } catch (error) {
+    if (error instanceof KeychainLockedError) {
+      return 'locked';
+    }
+    throw error;
   }
 };

--- a/apps/mobile/src/bootstrap/providers/auth-provider.test.tsx
+++ b/apps/mobile/src/bootstrap/providers/auth-provider.test.tsx
@@ -1,5 +1,6 @@
 import { emitSessionExpired, subscribeSessionExpired } from '@src/core/events/session-expired';
 import type { ErrorReporter } from '@src/core/ports/error-reporter';
+import { KeychainLockedError } from '@src/core/ports/storage';
 import {
   createMockAnalytics,
   createMockDIContainer,
@@ -67,15 +68,57 @@ describe('AuthProvider', () => {
       await expectStatus('authenticated');
     });
 
-    it('키체인을 읽을 수 없으면 locked이며 로그인 화면으로 내려보내지 않는다', async () => {
+    it('기기 잠금으로 읽지 못하면 locked이며 로그인 화면으로 내려보내지 않는다', async () => {
       // Given — 기기 잠금 중 콜드 스타트
-      tokenStore.readRefreshToken.mockRejectedValue(new Error('User interaction is not allowed.'));
+      tokenStore.readRefreshToken.mockRejectedValue(
+        new KeychainLockedError(new Error('User interaction is not allowed.')),
+      );
 
       // When
       renderProvider();
 
       // Then
       await expectStatus('locked');
+      expect(tokenStore.clear).not.toHaveBeenCalled();
+    });
+
+    it('locked 상태에서는 리포팅하지 않는다 (잠금은 오류가 아니라 대기다)', async () => {
+      // Given
+      tokenStore.readRefreshToken.mockRejectedValue(new KeychainLockedError(new Error('locked')));
+
+      // When
+      renderProvider();
+      await expectStatus('locked');
+
+      // Then
+      expect(errorReporter.captureException).not.toHaveBeenCalled();
+    });
+
+    it('잠금이 아닌 판정 실패는 리포팅하고 미인증으로 폴백한다 (무한 로딩 금지)', async () => {
+      // Given — 키체인 손상 등 영구 오류. locked로 두면 재판정도 실패해 앱이 조용히 갇힌다.
+      tokenStore.readRefreshToken.mockRejectedValue(new Error('Could not decrypt the value'));
+
+      // When
+      renderProvider();
+
+      // Then
+      await expectStatus('unauthenticated');
+      expect(errorReporter.captureException).toHaveBeenCalledTimes(1);
+      expect(errorReporter.captureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ feature: 'auth' }),
+      );
+    });
+
+    it('판정 실패로 폴백해도 토큰을 지우지 않는다', async () => {
+      // Given — 원인이 해소되면 다음 실행에 회복되어야 한다
+      tokenStore.readRefreshToken.mockRejectedValue(new Error('boom'));
+
+      // When
+      renderProvider();
+      await expectStatus('unauthenticated');
+
+      // Then
       expect(tokenStore.clear).not.toHaveBeenCalled();
     });
   });

--- a/apps/mobile/src/bootstrap/providers/auth-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/auth-provider.tsx
@@ -47,14 +47,37 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     setStatusState(next);
   }, []);
 
+  /**
+   * 판정 실패를 관측하고 미인증으로 폴백한다.
+   *
+   * `locked`는 잠금 해제를 기다리는 상태다. 잠금이 아닌 영구 오류(키체인 손상 등)까지
+   * `locked`로 두면 재판정도 계속 실패해 **조용히 무한 로딩**에 갇힌다.
+   * 미인증 폴백은 토큰을 지우지 않으므로, 원인이 해소되면 다음 실행에 회복된다.
+   */
+  const fallbackToUnauthenticated = useCallback(
+    (error: unknown) => {
+      errorReporter.captureException(error instanceof Error ? error : new Error(String(error)), {
+        feature: 'auth',
+      });
+      applyStatus('unauthenticated');
+    },
+    [errorReporter, applyStatus],
+  );
+
   // 앱 시작 시 초기 인증 상태 결정 (읽기만 한다 — auth-boot.ts의 불변식 참조)
   useEffect(() => {
     let cancelled = false;
 
     const checkAuth = async () => {
-      const initialStatus = await resolveInitialAuthStatus(tokenStore);
-      if (!cancelled) {
-        applyStatus(initialStatus);
+      try {
+        const initialStatus = await resolveInitialAuthStatus(tokenStore);
+        if (!cancelled) {
+          applyStatus(initialStatus);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          fallbackToUnauthenticated(error);
+        }
       }
     };
     checkAuth();
@@ -62,7 +85,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     return () => {
       cancelled = true;
     };
-  }, [tokenStore, applyStatus]);
+  }, [tokenStore, applyStatus, fallbackToUnauthenticated]);
 
   // 잠긴 키체인으로 판정을 미뤘다면, 잠금 해제(포그라운드 복귀) 후 다시 시도한다.
   // 이 재판정이 없으면 잠금 중 콜드 스타트가 영구 로그인 화면이 된다.
@@ -75,11 +98,15 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
       if (appState !== 'active') {
         return;
       }
-      applyStatus(await resolveInitialAuthStatus(tokenStore));
+      try {
+        applyStatus(await resolveInitialAuthStatus(tokenStore));
+      } catch (error) {
+        fallbackToUnauthenticated(error);
+      }
     });
 
     return () => subscription.remove();
-  }, [status, tokenStore, applyStatus]);
+  }, [status, tokenStore, applyStatus, fallbackToUnauthenticated]);
 
   // 세션 만료 확정 → 미인증으로 전환 + 관측 리포팅.
   useEffect(() => {

--- a/apps/mobile/src/core/ports/storage.ts
+++ b/apps/mobile/src/core/ports/storage.ts
@@ -1,3 +1,21 @@
+/**
+ * 키체인을 **지금** 읽을 수 없다는 신호. "값이 없다"(null)와 구분된다.
+ *
+ * 기기 잠금 중 콜드 스타트(푸시·백그라운드 실행)에서 발생한다.
+ * 이를 "토큰 없음"으로 확정하면 잠긴 키체인이 곧 로그아웃이 된다.
+ *
+ * **일시적 오류만 이 타입으로 승격한다.** 영구 오류(키체인 손상, entitlement 오설정 등)는
+ * 원본 에러 그대로 전파해야 상위에서 관측하고 안전하게 폴백할 수 있다.
+ * 모든 읽기 실패를 "잠김"으로 뭉개면 앱이 조용히 무한 로딩에 갇힌다.
+ */
+export class KeychainLockedError extends Error {
+  override readonly name = 'KeychainLockedError';
+
+  constructor(override readonly cause: unknown) {
+    super('Keychain is temporarily unavailable (device locked).');
+  }
+}
+
 export interface Storage {
   get<T>(key: string): Promise<T | null>;
   set<T>(key: string, value: T): Promise<void>;

--- a/apps/mobile/src/shared/infra/storage/secure-storage.test.ts
+++ b/apps/mobile/src/shared/infra/storage/secure-storage.test.ts
@@ -1,0 +1,83 @@
+import { KeychainLockedError } from '@src/core/ports/storage';
+import * as ExpoSecureStore from 'expo-secure-store';
+import { SecureStorage } from './secure-storage';
+
+// 네이티브 모듈 경계 — 여기서만 jest.mock을 쓴다.
+jest.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'afterFirstUnlock',
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+const getItemAsync = ExpoSecureStore.getItemAsync as jest.MockedFunction<
+  typeof ExpoSecureStore.getItemAsync
+>;
+
+describe('SecureStorage — 벤더 에러 분류', () => {
+  let storage: SecureStorage;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage = new SecureStorage();
+  });
+
+  it('값이 있으면 파싱해서 돌려준다', async () => {
+    // Given
+    getItemAsync.mockResolvedValue(JSON.stringify('token-value'));
+
+    // When & Then
+    await expect(storage.get<string>('key')).resolves.toBe('token-value');
+  });
+
+  it('항목이 없으면 null을 돌려준다', async () => {
+    // Given — errSecItemNotFound는 throw가 아니라 null이다
+    getItemAsync.mockResolvedValue(null);
+
+    // When & Then
+    await expect(storage.get('key')).resolves.toBeNull();
+  });
+
+  it('기기 잠금 오류는 KeychainLockedError로 승격한다', async () => {
+    // Given — iOS errSecInteractionNotAllowed. expo-secure-store는 OSStatus를 메시지로만 노출한다.
+    getItemAsync.mockRejectedValue(new Error('User interaction is not allowed.'));
+
+    // When & Then — "지금 못 읽는다"는 "토큰이 없다"와 다르다
+    await expect(storage.get('key')).rejects.toBeInstanceOf(KeychainLockedError);
+  });
+
+  it('잠금 오류를 승격할 때 원본을 cause로 보존한다', async () => {
+    // Given
+    const original = new Error('User interaction is not allowed.');
+    getItemAsync.mockRejectedValue(original);
+
+    // When
+    const error = await storage.get('key').catch((caught: unknown) => caught);
+
+    // Then — 관측 시 원본 OSStatus 메시지를 잃지 않는다
+    expect((error as KeychainLockedError).cause).toBe(original);
+  });
+
+  it.each([
+    ['Android 키체인 손상', 'Could not decrypt the value for key'],
+    ['알 수 없는 encoding scheme', 'has an unknown encoding scheme'],
+    ['entitlement 오설정', 'A required entitlement is not present.'],
+    ['키스토어 접근 실패', 'An error occurred when accessing the keystore'],
+  ])('영구 오류(%s)는 잠김으로 뭉개지 않고 원본을 그대로 던진다', async (_label, message) => {
+    // Given — 이걸 locked로 승격하면 재판정도 계속 실패해 앱이 조용히 무한 로딩에 갇힌다
+    const original = new Error(message);
+    getItemAsync.mockRejectedValue(original);
+
+    // When & Then
+    await expect(storage.get('key')).rejects.toBe(original);
+    await expect(storage.get('key')).rejects.not.toBeInstanceOf(KeychainLockedError);
+  });
+
+  it('저장된 값이 손상돼 파싱에 실패하면 null로 취급한다 (throw하지 않는다)', async () => {
+    // Given — 손상된 항목 하나가 부팅을 막아선 안 된다
+    getItemAsync.mockResolvedValue('{not-json');
+
+    // When & Then
+    await expect(storage.get('key')).resolves.toBeNull();
+  });
+});

--- a/apps/mobile/src/shared/infra/storage/secure-storage.ts
+++ b/apps/mobile/src/shared/infra/storage/secure-storage.ts
@@ -1,4 +1,4 @@
-import type { Storage } from '@src/core/ports/storage';
+import { KeychainLockedError, type Storage } from '@src/core/ports/storage';
 import * as ExpoSecureStore from 'expo-secure-store';
 
 // AFTER_FIRST_UNLOCK: 첫 잠금해제 후 접근 가능(잠금 중 백그라운드 접근 throw 방지), 재설치해도 유지.
@@ -11,9 +11,34 @@ const SECURE_STORE_OPTIONS: ExpoSecureStore.SecureStoreOptions = {
   keychainAccessible: ExpoSecureStore.AFTER_FIRST_UNLOCK,
 };
 
+/**
+ * iOS `errSecInteractionNotAllowed`의 메시지.
+ *
+ * expo-secure-store의 `KeyChainException`은 OSStatus를 **메시지로만** 노출한다
+ * (`code`는 클래스명에서 파생되므로 잠금과 영구 오류를 구분하지 못한다).
+ * 벤더의 에러 형태를 아는 것은 이 인프라 경계의 책임이다 — 도메인이 문자열을 알아선 안 된다.
+ *
+ * Android에는 잠금 개념이 없다(`requireAuthentication` 미사용). `DecryptException` 등은
+ * 영구 오류이므로 잠김으로 승격하지 않는다.
+ */
+const IOS_LOCKED_KEYCHAIN_MESSAGE = 'User interaction is not allowed.';
+
+const isLockedKeychain = (error: unknown): boolean =>
+  error instanceof Error && error.message.includes(IOS_LOCKED_KEYCHAIN_MESSAGE);
+
 export class SecureStorage implements Storage {
   async get<T>(key: string): Promise<T | null> {
-    const item = await ExpoSecureStore.getItemAsync(key, SECURE_STORE_OPTIONS);
+    let item: string | null;
+    try {
+      item = await ExpoSecureStore.getItemAsync(key, SECURE_STORE_OPTIONS);
+    } catch (error) {
+      // 일시적(잠김)만 타입으로 승격한다. 나머지는 원본 그대로 — 상위에서 리포팅 후 폴백한다.
+      if (isLockedKeychain(error)) {
+        throw new KeychainLockedError(error);
+      }
+      throw error;
+    }
+
     if (!item) return null;
 
     try {


### PR DESCRIPTION
> PR #605 Gemini 코드 리뷰 반영. v1.4.2에 합류시킨다 (버전 유지).

## 📋 개요

`resolveInitialAuthStatus`가 **모든 읽기 실패를 `'locked'`로 반환**했다.

`locked`는 로딩 화면을 유지하고 포그라운드 복귀 시 재판정하는 상태다. 그런데 **영구 오류는 재판정도 실패**하므로 앱이 **조용히 무한 로딩에 갇힌다.** Sentry 리포팅도 없다. 유저는 로그인조차 할 수 없다.

**v1.4.1에는 이 안전망이 있었다.**

```ts
// v1.4.1 auth-provider.tsx
} catch (error) {
  // 키체인 접근 실패(기기 잠김 등)로 throw되어도 'loading'에 영구히 갇히지 않도록
  errorReporter.captureException(...);
  setStatusState('unauthenticated');
}
```

`resolveInitialAuthStatus`를 "절대 throw하지 않는다"로 바꾸면서 함께 사라졌다. **v1.4.2가 만든 회귀다.**

## 🔍 영구 오류는 가설이 아니라 실제 코드 경로다

`expo-secure-store@57.0.0` 소스를 확인했다.

**Android** — `SecureStoreModule.kt`
- `DecryptException`을 **던지고** 해당 항목을 **지우지 않는다** (JSON 파싱 실패, 알 수 없는 encoding scheme). 손상된 항목이 있으면 **매 실행마다 재현**된다.
- `KeyPermanentlyInvalidatedException`만 `return null`이라 자가 치유된다.

**iOS** — `SecureStoreModule.swift:168`
- `searchKeyChain`은 `errSecItemNotFound`를 뺀 **모든 OSStatus**에 `KeyChainException`을 던진다.
- 잠금(`errSecInteractionNotAllowed`)뿐 아니라 entitlement 오설정, `errSecNotAvailable` 등이 포함된다.

즉 프로비저닝 실수 하나로 **전 유저가 침묵하는 로딩 화면**에 갇힐 수 있었다. v1.4.1이었다면 최소한 Sentry에 잡히고 로그인 화면이 떴다.

## 📝 변경 내용

**벤더 에러의 형태를 아는 것은 인프라 경계의 책임이다.** 도메인이 문자열을 알아선 안 된다.

| 파일 | 변경 |
|---|---|
| `core/ports/storage.ts` | `KeychainLockedError` 도입. **일시적 오류만** 이 타입으로 승격 |
| `shared/infra/storage/secure-storage.ts` | `expo-secure-store` 에러 분류. 원본은 `cause`로 보존 |
| `bootstrap/providers/auth-boot.ts` | `KeychainLockedError`만 `'locked'`. 나머지는 그대로 던진다 |
| `bootstrap/providers/auth-provider.tsx` | 부팅 **과** AppState 재판정 양쪽에서 리포팅 + `'unauthenticated'` 폴백 |

`KeyChainException`은 OSStatus를 **메시지로만** 노출한다 (`code`는 클래스명에서 파생되므로 잠금과 영구 오류를 구분하지 못한다). 메시지 판별이 불가피하지만, 그 지식은 벤더를 import하는 파일 안에 가둔다.

**폴백은 토큰을 지우지 않는다.** 미인증 표시일 뿐이므로 원인이 해소되면 다음 실행에 회복된다. 세션 불변식은 그대로다.

## 🤔 Gemini 제안과 다르게 한 점

Gemini는 `auth-boot.ts`에서 직접 문자열을 매칭하라고 제안했다. 두 가지 이유로 따르지 않았다.

1. **의존성 방향** — `auth-boot`는 도메인 판정 함수다. `expo-secure-store`의 에러 메시지 포맷을 알면 벤더 교체 시 도메인이 깨진다.
2. **테스트 가능성** — 문자열이 도메인에 있으면 `auth-boot.test.ts`가 벤더 메시지를 흉내 내야 한다. 타입으로 바꾸면 도메인 테스트는 `KeychainLockedError`만 알면 되고, 문자열 판별은 벤더 경계 테스트(`secure-storage.test.ts`)가 책임진다.

결론은 같고 배치만 다르다.

## 🧪 테스트

```bash
pnpm typecheck && pnpm lint && pnpm --filter @aido/mobile test
```

- [x] 타입 체크 8/8 ✅ · Biome ✅ · `expo export` 빌드 ✅
- [x] mobile **72 suites / 832 tests 통과** (기존 818 + 신규 14)
- [x] api **195 suites / 2328 tests 통과** (영향 없음 재확인)

**신규 회귀 테스트**

`secure-storage.test.ts` (신규, 벤더 경계 — `jest.mock`이 허용되는 유일한 지점)
- 잠금 오류 → `KeychainLockedError`로 승격, 원본을 `cause`로 보존
- 영구 오류 4종(Android 손상 / 알 수 없는 scheme / entitlement / 키스토어) → **잠김으로 뭉개지 않고 원본 그대로 던짐**
- 항목 없음 → `null`, 파싱 실패 → `null` (throw 아님)

`auth-boot.test.ts`
- `KeychainLockedError` → `'locked'`
- 그 외 → **그대로 throw**
- 두 경우 모두 `tokenStore.clear`를 호출하지 않음 (세션 불변식)

`auth-provider.test.tsx`
- `locked`에서는 **리포팅하지 않는다** (잠금은 오류가 아니라 대기다)
- 잠금이 아닌 실패 → `'unauthenticated'` + `captureException` 1회
- 폴백해도 `tokenStore.clear` 미호출

> 기존 테스트가 일반 `Error`로 `'locked'`를 단언하고 있었다 — 그게 바로 버그였다. 타입 기반으로 교정했다.

## 🙋 사용자 영향

| 상황 | 기존(v1.4.2) | 수정 후 |
|---|---|---|
| 기기 잠금 중 콜드 스타트 | `locked` → 로딩 → 잠금 해제 후 복귀 | **동일** |
| 키체인 영구 손상 | **무한 로딩, Sentry 0건** | Sentry 리포팅 + 로그인 화면 (토큰 보존, 회복 가능) |
| 정상 | 동일 | 동일 |

영속 계약 무변경. 토큰 삭제 경로 무변경.

## 🔗 관련

- PR #605 (Release v1.4.2) 리뷰 지적
- PR #599, 이슈 #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
