### PR TITLE
fix(mobile): 던져진 값 정규화 + TodoList 순환 참조 제거

### DIFF
--- a/apps/mobile/docs/error-handling.md
+++ b/apps/mobile/docs/error-handling.md
@@ -384,6 +384,51 @@ export function QueryErrorBoundary({ children, fallback }: QueryErrorBoundaryPro
 
 ---
 
+## 저장소 에러: KeychainLockedError
+
+`shared/errors/storage-error.ts`. `InfraError`가 **아니다** — ErrorBoundary로 보내지 않는다.
+
+| 상황 | `Storage.get()` 결과 |
+|------|---------------------|
+| 값이 있음 | 파싱된 값 |
+| 값이 없음 (`errSecItemNotFound`) | `null` |
+| **지금 못 읽음** (기기 잠금) | `throw KeychainLockedError` |
+| 영구 오류 (키체인 손상, entitlement 오설정) | **원본 오류 그대로 throw** |
+| 저장된 값 파싱 실패 | `null` (손상된 항목 하나가 부팅을 막지 않는다) |
+
+"지금 못 읽는다"를 "토큰이 없다"로 확정하면 **잠긴 키체인이 곧 로그아웃**이 된다.
+반대로 모든 읽기 실패를 잠김으로 뭉개면 재판정도 계속 실패해 **조용히 무한 로딩**에 갇힌다.
+그래서 일시적 오류만 이 타입으로 승격하고, 영구 오류는 상위(`AuthProvider`)가 관측하고 미인증으로 폴백한다.
+
+벤더 에러 판별(OSStatus 메시지 매칭)은 **인프라 경계**(`secure-storage.ts`)에만 둔다.
+도메인 판정 함수(`auth-boot.ts`)는 `isKeychainLockedError()`만 안다.
+
+---
+
+## 던져진 값 다루기: toError / errorMessageOf
+
+JS는 무엇이든 throw할 수 있다. RN 네이티브 브릿지와 서드파티 SDK는 `Error`가 아닌 값
+(문자열, `{ message }` 객체)을 던지기도 한다. `instanceof Error`를 **관문**으로 쓰면 조용히 무너진다.
+
+```typescript
+// ❌ 평범한 객체가 "[object Object]"가 되어 원인이 사라진다
+new Error(String(error))
+
+// ❌ 더 나쁘다 — 에러를 통째로 버린다
+logger.error('failed', error instanceof Error ? error : undefined)
+
+// ✅ 값의 모양이 아니라 내용으로 판단. 원본은 cause로 보존
+errorReporter.captureException(toError(error), { feature: 'auth' });
+logger.warn('갱신 실패', { error: errorMessageOf(error) });
+```
+
+| 함수 | 용도 |
+|------|------|
+| `toError(value)` | `ErrorReporter.captureException`·`logger.error`처럼 `Error`를 요구하는 곳 |
+| `errorMessageOf(value)` | 로그 필드, 벤더 에러 메시지 판별 |
+
+---
+
 ## UI 에러 처리 패턴
 
 ### 패턴 1: toast.error 기본 처리

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,7 +16,7 @@
     "build:production": "eas build --profile production --platform all",
     "build:production:android": "eas build --profile production --platform android",
     "build:production:ios": "eas build --profile production --platform ios",
-    "check": "biome check .",
+    "check": "biome check . && pnpm lint:cycles",
     "clean": "rm -rf dist .expo android ios node_modules/.cache",
     "dev": "expo start",
     "dev:android": "pnpm adb:reverse || true && expo start --android",
@@ -24,7 +24,7 @@
     "dev:web": "expo start --web",
     "format": "biome format --write .",
     "ios": "expo run:ios",
-    "lint": "biome lint .",
+    "lint": "biome lint . && pnpm lint:cycles",
     "native:prebuild": "expo prebuild --clean",
     "submit:production": "eas submit --profile production --platform all --latest",
     "submit:production:android": "eas submit --profile production --platform android --latest",
@@ -33,7 +33,8 @@
     "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit",
     "update:preview": "eas update --branch preview",
-    "update:production": "eas update --branch production"
+    "update:production": "eas update --branch production",
+    "lint:cycles": "node scripts/check-import-cycles.mjs"
   },
   "dependencies": {
     "@aido/errors": "workspace:^",

--- a/apps/mobile/scripts/check-import-cycles.mjs
+++ b/apps/mobile/scripts/check-import-cycles.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * 런타임 순환 참조 검사기.
+ *
+ * Metro는 사이클을 허용하되 경고만 남긴다("Require cycle: ..."). 사이클은 모듈 하나가
+ * 아직 초기화되지 않은 값을 보게 만들 수 있고, 그 실패는 런타임에만 드러난다.
+ * 경고를 읽는 사람에게 맡기지 않고 CI에서 막는다.
+ *
+ * Biome의 `suspicious/noImportCycles`를 쓰지 않는 이유(2.4.10 기준):
+ * - 이 모노레포 설정에서 규칙이 사이클을 검출하지 못한다(의도적으로 심은 사이클로 확인)
+ * - 루트 설정에 켜면 project 스캐너가 한글 마크다운에서 패닉한다(biome_markdown_parser)
+ * 업스트림이 해결되면 이 스크립트를 규칙으로 교체한다.
+ *
+ * 타입 전용 import(`import type`)는 컴파일 후 사라지므로 사이클을 만들지 않는다 — 제외한다.
+ */
+import { readFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_DIRS = ['src', 'app'];
+const EXTENSIONS = ['.tsx', '.ts'];
+const ALIASES = { '@src/': 'src/', '@/': 'app/' };
+
+const IMPORT_PATTERN = /(?:from|require\()\s*['"]([^'"]+)['"]/g;
+const TYPE_IMPORT_PATTERN = /import\s+type\s+[^;]*?from\s*['"]([^'"]+)['"]/gs;
+
+const isTestFile = (path) => path.includes('__tests__') || /\.test\.tsx?$/.test(path);
+
+async function collectSourceFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true, recursive: true });
+  return entries
+    .filter((entry) => entry.isFile() && EXTENSIONS.some((ext) => entry.name.endsWith(ext)))
+    .map((entry) => join(entry.parentPath, entry.name))
+    .filter((path) => !isTestFile(path));
+}
+
+/** 임포트 지정자를 실제 파일 경로로 해석한다. 외부 패키지는 null. */
+function resolveSpecifier(specifier, fromFile) {
+  let base;
+  const alias = Object.keys(ALIASES).find((prefix) => specifier.startsWith(prefix));
+
+  if (alias) {
+    base = join(ROOT, ALIASES[alias], specifier.slice(alias.length));
+  } else if (specifier.startsWith('.')) {
+    base = resolve(dirname(fromFile), specifier);
+  } else {
+    return null;
+  }
+
+  const candidates = [
+    ...EXTENSIONS.map((ext) => base + ext),
+    ...EXTENSIONS.map((ext) => join(base, `index${ext}`)),
+  ];
+  return candidates.find((candidate) => {
+    try {
+      readFileSync(candidate);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function buildGraph(files) {
+  const graph = new Map();
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    const typeOnly = new Set(
+      [...source.matchAll(TYPE_IMPORT_PATTERN)].map(([, specifier]) => specifier),
+    );
+
+    const dependencies = new Set();
+    for (const [, specifier] of source.matchAll(IMPORT_PATTERN)) {
+      if (typeOnly.has(specifier)) {
+        continue;
+      }
+      const target = resolveSpecifier(specifier, file);
+      if (target && target !== file) {
+        dependencies.add(target);
+      }
+    }
+    graph.set(file, dependencies);
+  }
+
+  return graph;
+}
+
+/** Tarjan 대신 DFS + 스택 — 사이클 경로를 그대로 보여주기 위해. */
+function findCycles(graph) {
+  const cycles = [];
+  const visited = new Set();
+  const stack = [];
+  const onStack = new Set();
+
+  const visit = (node) => {
+    visited.add(node);
+    stack.push(node);
+    onStack.add(node);
+
+    for (const next of [...(graph.get(node) ?? [])].sort()) {
+      if (!visited.has(next)) {
+        visit(next);
+      } else if (onStack.has(next)) {
+        cycles.push([...stack.slice(stack.indexOf(next)), next]);
+      }
+    }
+
+    stack.pop();
+    onStack.delete(node);
+  };
+
+  for (const node of [...graph.keys()].sort()) {
+    if (!visited.has(node)) {
+      visit(node);
+    }
+  }
+
+  return cycles;
+}
+
+const files = (
+  await Promise.all(SOURCE_DIRS.map((dir) => collectSourceFiles(join(ROOT, dir))))
+).flat();
+const cycles = findCycles(buildGraph(files));
+
+if (cycles.length === 0) {
+  console.log(`✓ 순환 참조 없음 (${files.length}개 파일)`);
+  process.exit(0);
+}
+
+console.error(`✗ 순환 참조 ${cycles.length}건\n`);
+for (const cycle of cycles) {
+  console.error(`  ${cycle.map((path) => path.slice(ROOT.length + 1)).join('\n  → ')}\n`);
+}
+console.error('사이클은 초기화되지 않은 값을 만든다. 임포트가 한 방향만 향하도록 코드를 옮겨라.');
+process.exit(1);

--- a/apps/mobile/scripts/check-import-cycles.mjs
+++ b/apps/mobile/scripts/check-import-cycles.mjs
@@ -11,7 +11,10 @@
  * - 루트 설정에 켜면 project 스캐너가 한글 마크다운에서 패닉한다(biome_markdown_parser)
  * 업스트림이 해결되면 이 스크립트를 규칙으로 교체한다.
  *
- * 타입 전용 import(`import type`)는 컴파일 후 사라지므로 사이클을 만들지 않는다 — 제외한다.
+ * **타입 전용 import는 컴파일 후 사라지므로 런타임 사이클을 만들지 않는다.**
+ * 단, 같은 모듈에서 타입과 값을 함께 가져올 수 있다(`import type {T}` + `import {v}`).
+ * 그래서 모듈 단위가 아니라 **구문 단위**로 판정한다. 모듈 단위로 뭉개면 값 의존성을
+ * 통째로 놓쳐 사이클을 못 잡는다 — 지키는 게 없는 초록불이 된다.
  */
 import { readFileSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
@@ -23,10 +26,93 @@ const SOURCE_DIRS = ['src', 'app'];
 const EXTENSIONS = ['.tsx', '.ts'];
 const ALIASES = { '@src/': 'src/', '@/': 'app/' };
 
-const IMPORT_PATTERN = /(?:from|require\()\s*['"]([^'"]+)['"]/g;
-const TYPE_IMPORT_PATTERN = /import\s+type\s+[^;]*?from\s*['"]([^'"]+)['"]/gs;
+/** `import ... from 'x'` / `export ... from 'x'` — 바인딩 절을 1번 그룹으로 잡는다. */
+const BINDING_STATEMENT = /\b(?:import|export)\s+([^;'"]*?)\s*from\s*['"]([^'"]+)['"]/gs;
+/** `import 'x'`(부수효과)와 `require('x')` — 언제나 런타임 엣지다. */
+const SIDE_EFFECT_STATEMENT = /\bimport\s*['"]([^'"]+)['"]|\brequire\(\s*['"]([^'"]+)['"]\s*\)/g;
 
 const isTestFile = (path) => path.includes('__tests__') || /\.test\.tsx?$/.test(path);
+
+/**
+ * 주석을 제거한다. 문자열·템플릿 리터럴 안의 `//`는 주석이 아니므로 따옴표를 추적한다.
+ *
+ * 이게 없으면 주석에 적어둔 예시 import가 진짜 의존성으로 둔갑해 없는 사이클을 만든다.
+ */
+function stripComments(source) {
+  let output = '';
+  let quote = null;
+  let index = 0;
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (quote) {
+      if (char === '\\') {
+        output += char + (next ?? '');
+        index += 2;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      output += char;
+      index += 1;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      while (index < source.length && source[index] !== '\n') {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      index += 2;
+      while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) {
+        index += 1;
+      }
+      index += 2;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+    }
+    output += char;
+    index += 1;
+  }
+
+  return output;
+}
+
+/**
+ * 이 구문이 컴파일 후 사라지는가?
+ *
+ * - `import type { T } from 'x'`         → 사라진다
+ * - `export type { T } from 'x'`         → 사라진다
+ * - `import { type A, type B } from 'x'` → 지정자가 전부 type이면 사라진다
+ * - `import { type A, b } from 'x'`      → `b`가 남으므로 런타임 엣지다
+ */
+function isTypeOnlyClause(clause) {
+  const trimmed = clause.trim();
+  if (trimmed === 'type' || trimmed.startsWith('type ') || trimmed.startsWith('type{')) {
+    return true;
+  }
+
+  const braces = trimmed.match(/^\{([^}]*)\}$/);
+  if (!braces) {
+    return false;
+  }
+
+  const specifiers = braces[1]
+    .split(',')
+    .map((specifier) => specifier.trim())
+    .filter(Boolean);
+
+  return specifiers.length > 0 && specifiers.every((specifier) => specifier.startsWith('type '));
+}
 
 async function collectSourceFiles(dir) {
   const entries = await readdir(dir, { withFileTypes: true, recursive: true });
@@ -36,23 +122,24 @@ async function collectSourceFiles(dir) {
     .filter((path) => !isTestFile(path));
 }
 
-/** 임포트 지정자를 실제 파일 경로로 해석한다. 외부 패키지는 null. */
+/** 임포트 지정자를 실제 파일 경로로 해석한다. 외부 패키지는 undefined. */
 function resolveSpecifier(specifier, fromFile) {
-  let base;
   const alias = Object.keys(ALIASES).find((prefix) => specifier.startsWith(prefix));
 
+  let base;
   if (alias) {
     base = join(ROOT, ALIASES[alias], specifier.slice(alias.length));
   } else if (specifier.startsWith('.')) {
     base = resolve(dirname(fromFile), specifier);
   } else {
-    return null;
+    return undefined;
   }
 
   const candidates = [
     ...EXTENSIONS.map((ext) => base + ext),
     ...EXTENSIONS.map((ext) => join(base, `index${ext}`)),
   ];
+
   return candidates.find((candidate) => {
     try {
       readFileSync(candidate);
@@ -63,29 +150,30 @@ function resolveSpecifier(specifier, fromFile) {
   });
 }
 
-function buildGraph(files) {
-  const graph = new Map();
+/** 한 파일이 런타임에 실제로 끌어오는 모듈들. */
+function runtimeDependencies(file) {
+  const source = stripComments(readFileSync(file, 'utf8'));
+  const specifiers = new Set();
 
-  for (const file of files) {
-    const source = readFileSync(file, 'utf8');
-    const typeOnly = new Set(
-      [...source.matchAll(TYPE_IMPORT_PATTERN)].map(([, specifier]) => specifier),
-    );
-
-    const dependencies = new Set();
-    for (const [, specifier] of source.matchAll(IMPORT_PATTERN)) {
-      if (typeOnly.has(specifier)) {
-        continue;
-      }
-      const target = resolveSpecifier(specifier, file);
-      if (target && target !== file) {
-        dependencies.add(target);
-      }
+  for (const [, clause, specifier] of source.matchAll(BINDING_STATEMENT)) {
+    if (!isTypeOnlyClause(clause)) {
+      specifiers.add(specifier);
     }
-    graph.set(file, dependencies);
   }
 
-  return graph;
+  for (const [, bare, required] of source.matchAll(SIDE_EFFECT_STATEMENT)) {
+    specifiers.add(bare ?? required);
+  }
+
+  const dependencies = new Set();
+  for (const specifier of specifiers) {
+    const target = resolveSpecifier(specifier, file);
+    if (target && target !== file) {
+      dependencies.add(target);
+    }
+  }
+
+  return dependencies;
 }
 
 /** Tarjan 대신 DFS + 스택 — 사이클 경로를 그대로 보여주기 위해. */
@@ -124,7 +212,9 @@ function findCycles(graph) {
 const files = (
   await Promise.all(SOURCE_DIRS.map((dir) => collectSourceFiles(join(ROOT, dir))))
 ).flat();
-const cycles = findCycles(buildGraph(files));
+
+const graph = new Map(files.map((file) => [file, runtimeDependencies(file)]));
+const cycles = findCycles(graph);
 
 if (cycles.length === 0) {
   console.log(`✓ 순환 참조 없음 (${files.length}개 파일)`);

--- a/apps/mobile/src/bootstrap/providers/auth-boot.test.ts
+++ b/apps/mobile/src/bootstrap/providers/auth-boot.test.ts
@@ -1,5 +1,5 @@
-import { KeychainLockedError } from '@src/core/ports/storage';
 import { createMockTokenStore } from '@src/shared/__tests__';
+import { KeychainLockedError } from '@src/shared/errors';
 import { resolveInitialAuthStatus } from './auth-boot';
 
 describe('앱 부팅 인증 판정 — 클라이언트는 세션을 먼저 끊지 않는다', () => {

--- a/apps/mobile/src/bootstrap/providers/auth-boot.ts
+++ b/apps/mobile/src/bootstrap/providers/auth-boot.ts
@@ -1,5 +1,5 @@
-import { KeychainLockedError } from '@src/core/ports/storage';
 import type { TokenStore } from '@src/core/ports/token-store';
+import { isKeychainLockedError } from '@src/shared/errors';
 
 /**
  * 부팅 판정이 내려진 뒤의 인증 상태.
@@ -36,7 +36,7 @@ export const resolveInitialAuthStatus = async (
     const refreshToken = await tokenStore.readRefreshToken();
     return refreshToken ? 'authenticated' : 'unauthenticated';
   } catch (error) {
-    if (error instanceof KeychainLockedError) {
+    if (isKeychainLockedError(error)) {
       return 'locked';
     }
     throw error;

--- a/apps/mobile/src/bootstrap/providers/auth-provider.test.tsx
+++ b/apps/mobile/src/bootstrap/providers/auth-provider.test.tsx
@@ -1,11 +1,11 @@
 import { emitSessionExpired, subscribeSessionExpired } from '@src/core/events/session-expired';
 import type { ErrorReporter } from '@src/core/ports/error-reporter';
-import { KeychainLockedError } from '@src/core/ports/storage';
 import {
   createMockAnalytics,
   createMockDIContainer,
   createMockTokenStore,
 } from '@src/shared/__tests__';
+import { KeychainLockedError } from '@src/shared/errors';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react-native';
 import { Text } from 'react-native';
@@ -106,6 +106,21 @@ describe('AuthProvider', () => {
       expect(errorReporter.captureException).toHaveBeenCalledTimes(1);
       expect(errorReporter.captureException).toHaveBeenCalledWith(
         expect.any(Error),
+        expect.objectContaining({ feature: 'auth' }),
+      );
+    });
+
+    it('Error가 아닌 값이 던져져도 메시지를 잃지 않고 리포팅한다', async () => {
+      // Given — String(value)로 감싸면 "[object Object]"가 되어 원인을 알 수 없다
+      tokenStore.readRefreshToken.mockRejectedValue({ message: 'native bridge failure' });
+
+      // When
+      renderProvider();
+      await expectStatus('unauthenticated');
+
+      // Then — String(value)였다면 message가 "[object Object]"가 된다
+      expect(errorReporter.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'native bridge failure' }),
         expect.objectContaining({ feature: 'auth' }),
       );
     });

--- a/apps/mobile/src/bootstrap/providers/auth-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/auth-provider.tsx
@@ -1,6 +1,7 @@
 import { subscribeSessionExpired } from '@src/core/events/session-expired';
 import { sessionExpiredSeverity } from '@src/core/ports/telemetry-event';
 import { track } from '@src/shared/analytics';
+import { toError } from '@src/shared/errors';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   createContext,
@@ -56,9 +57,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
    */
   const fallbackToUnauthenticated = useCallback(
     (error: unknown) => {
-      errorReporter.captureException(error instanceof Error ? error : new Error(String(error)), {
-        feature: 'auth',
-      });
+      errorReporter.captureException(toError(error), { feature: 'auth' });
       applyStatus('unauthenticated');
     },
     [errorReporter, applyStatus],

--- a/apps/mobile/src/bootstrap/providers/notification-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/notification-provider.tsx
@@ -1,9 +1,9 @@
 import { useNotificationHandler } from '@src/features/notification/presentations/hooks/use-notification-handler';
+import { toError } from '@src/shared/errors';
 import { i18n } from '@src/shared/i18n';
 import * as Notifications from 'expo-notifications';
 import { createContext, type PropsWithChildren, use, useEffect, useMemo, useRef } from 'react';
 import { Platform } from 'react-native';
-
 import { useAuth } from './auth-provider';
 import { useLogger, useNotificationService } from './di-context';
 
@@ -59,10 +59,7 @@ const NativeNotificationProvider = ({ children }: PropsWithChildren) => {
         lastResponseHandled.current = responseId;
         pendingColdStartResponse.current = null;
         handleNotificationResponse(responseToProcess).catch((e) =>
-          logger.error(
-            '[Notification] Response handling failed',
-            e instanceof Error ? e : undefined,
-          ),
+          logger.error('[Notification] Response handling failed', toError(e)),
         );
       }
     } else if (
@@ -85,7 +82,7 @@ const NativeNotificationProvider = ({ children }: PropsWithChildren) => {
 
     responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
       handleNotificationResponse(response).catch((e) =>
-        logger.error('[Notification] Response handling failed', e instanceof Error ? e : undefined),
+        logger.error('[Notification] Response handling failed', toError(e)),
       );
     });
 
@@ -135,15 +132,11 @@ const NativeNotificationProvider = ({ children }: PropsWithChildren) => {
     if (isAuthenticated) {
       notificationService
         .syncBadgeCount()
-        .catch((e) =>
-          logger.error('[Notification] Badge sync failed', e instanceof Error ? e : undefined),
-        );
+        .catch((e) => logger.error('[Notification] Badge sync failed', toError(e)));
     } else {
       notificationService
         .clearBadge()
-        .catch((e) =>
-          logger.error('[Notification] Badge clear failed', e instanceof Error ? e : undefined),
-        );
+        .catch((e) => logger.error('[Notification] Badge clear failed', toError(e)));
     }
   }, [isAuthenticated, notificationService, logger]);
 

--- a/apps/mobile/src/core/ports/storage.ts
+++ b/apps/mobile/src/core/ports/storage.ts
@@ -1,21 +1,10 @@
 /**
- * 키체인을 **지금** 읽을 수 없다는 신호. "값이 없다"(null)와 구분된다.
+ * 키-값 저장소 포트.
  *
- * 기기 잠금 중 콜드 스타트(푸시·백그라운드 실행)에서 발생한다.
- * 이를 "토큰 없음"으로 확정하면 잠긴 키체인이 곧 로그아웃이 된다.
- *
- * **일시적 오류만 이 타입으로 승격한다.** 영구 오류(키체인 손상, entitlement 오설정 등)는
- * 원본 에러 그대로 전파해야 상위에서 관측하고 안전하게 폴백할 수 있다.
- * 모든 읽기 실패를 "잠김"으로 뭉개면 앱이 조용히 무한 로딩에 갇힌다.
+ * @throws {import('@src/shared/errors').KeychainLockedError}
+ *   `get`은 기기 잠금 등으로 **지금 읽을 수 없을 때** 던진다. `null`(값 없음)과 구분된다.
+ *   그 외 읽기 실패는 원본 오류를 그대로 던진다.
  */
-export class KeychainLockedError extends Error {
-  override readonly name = 'KeychainLockedError';
-
-  constructor(override readonly cause: unknown) {
-    super('Keychain is temporarily unavailable (device locked).');
-  }
-}
-
 export interface Storage {
   get<T>(key: string): Promise<T | null>;
   set<T>(key: string, value: T): Promise<void>;

--- a/apps/mobile/src/features/ai/presentations/queries/use-handle-suggestion-mutation-options.ts
+++ b/apps/mobile/src/features/ai/presentations/queries/use-handle-suggestion-mutation-options.ts
@@ -4,7 +4,7 @@ import type { AiSuggestionActionInput } from '@src/features/ai/models/ai.model';
 import { TODO_CATEGORY_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-category-query-keys.constant';
 import { TODO_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-query-keys.constant';
 import { useTrack } from '@src/shared/analytics';
-import { isApiError } from '@src/shared/errors';
+import { isApiError, toError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { useAppToast } from '@src/shared/hooks/useAppToast';
 import { t } from '@src/shared/i18n';
@@ -74,7 +74,7 @@ export const useHandleSuggestionMutationOptions = () => {
         return;
       }
 
-      logger.error('[AiSuggestion] Unexpected error', error instanceof Error ? error : undefined);
+      logger.error('[AiSuggestion] Unexpected error', toError(error));
       toast.error(undefined, { fallback: t('ai:suggestions.toasts.retryLater') });
     },
   });

--- a/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
+++ b/apps/mobile/src/features/notification/presentations/hooks/use-notification-handler.ts
@@ -4,6 +4,7 @@ import { useLogger, useNotificationService } from '@src/bootstrap/providers/di-c
 import { FRIEND_QUERY_KEYS } from '@src/features/friend/presentations/constants/friend-query-keys.constant';
 import { NOTIFICATION_QUERY_KEYS } from '@src/features/notification/presentations/constants/notification-query-keys.constant';
 import { useTrack } from '@src/shared/analytics';
+import { toError } from '@src/shared/errors';
 import { useQueryClient } from '@tanstack/react-query';
 import * as Linking from 'expo-linking';
 import type * as Notifications from 'expo-notifications';
@@ -123,7 +124,7 @@ export const useNotificationHandler = ({ isAuthenticated }: UseNotificationHandl
         }
 
         Promise.all(invalidations).catch((e) =>
-          logger.error('[Notification] Handler failed', e instanceof Error ? e : undefined),
+          logger.error('[Notification] Handler failed', toError(e)),
         );
       }, 1000);
     },

--- a/apps/mobile/src/features/notification/presentations/queries/use-register-push-token-mutation-options.ts
+++ b/apps/mobile/src/features/notification/presentations/queries/use-register-push-token-mutation-options.ts
@@ -1,7 +1,7 @@
 import { useLogger, useNotificationService } from '@src/bootstrap/providers/di-context';
+import { toError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { mutationOptions } from '@tanstack/react-query';
-
 import {
   isNotificationError,
   isNotPhysicalDeviceError,
@@ -39,10 +39,7 @@ export const useRegisterPushTokenMutationOptions = () => {
         logger.info('[PushNotification] Permission denied by user');
         return;
       }
-      logger.error(
-        '[PushNotification] Failed to register after retries',
-        error instanceof Error ? error : undefined,
-      );
+      logger.error('[PushNotification] Failed to register after retries', toError(error));
     },
   });
 };

--- a/apps/mobile/src/features/notification/presentations/queries/use-unregister-push-token-mutation-options.ts
+++ b/apps/mobile/src/features/notification/presentations/queries/use-unregister-push-token-mutation-options.ts
@@ -1,4 +1,5 @@
 import { useLogger, useNotificationService } from '@src/bootstrap/providers/di-context';
+import { toError } from '@src/shared/errors';
 import { unwrap } from '@src/shared/errors/result';
 import { mutationOptions } from '@tanstack/react-query';
 
@@ -12,10 +13,7 @@ export const useUnregisterPushTokenMutationOptions = () => {
       return unwrap(result);
     },
     onError: (error) => {
-      logger.error(
-        '[PushNotification] Failed to unregister',
-        error instanceof Error ? error : undefined,
-      );
+      logger.error('[PushNotification] Failed to unregister', toError(error));
     },
   });
 };

--- a/apps/mobile/src/features/todo/presentations/components/FriendTodoList.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/FriendTodoList.tsx
@@ -28,7 +28,7 @@ import { useGetTodoNudgeLimitQueryOptions } from '../queries/use-get-todo-nudge-
 import type { TodoItemViewModel } from '../view-models/todo-item.view-model';
 import { NudgeBottomSheet } from './NudgeBottomSheet';
 import { RemindNudgeBottomSheet } from './RemindNudgeBottomSheet';
-import { TodoList } from './TodoList/TodoList';
+import { TodoCheckbox, TodoLabel, TodoProgress, TodoRow } from './TodoRow';
 
 interface FriendTodoListProps {
   friend: FriendUserViewModel;
@@ -157,9 +157,9 @@ function FriendTodoItem({ todo, friend, isLimitReached, date }: FriendTodoItemPr
   };
 
   return (
-    <TodoList.Item
-      left={<TodoList.Checkbox isChecked={todo.completed} />}
-      top={<TodoList.Label isChecked={todo.completed}>{todo.title}</TodoList.Label>}
+    <TodoRow
+      left={<TodoCheckbox isChecked={todo.completed} />}
+      top={<TodoLabel isChecked={todo.completed}>{todo.title}</TodoLabel>}
       middle={
         showDateTime ? (
           <Text size="e1" shade={6}>
@@ -169,7 +169,7 @@ function FriendTodoItem({ todo, friend, isLimitReached, date }: FriendTodoItemPr
       }
       bottom={
         todo.hasSubTodos ? (
-          <TodoList.Progress value={todo.subTodoStats.completed} total={todo.subTodoStats.total} />
+          <TodoProgress value={todo.subTodoStats.completed} total={todo.subTodoStats.total} />
         ) : undefined
       }
       right={
@@ -184,15 +184,15 @@ function FriendTodoItem({ todo, friend, isLimitReached, date }: FriendTodoItemPr
       {isExpanded && (
         <VStack className="ml-8 pl-4 border-l border-gray-2">
           {todo.subTodos.map((subTodo) => (
-            <TodoList.Item
+            <TodoRow
               key={subTodo.id}
-              left={<TodoList.Checkbox isChecked={subTodo.completed} />}
-              top={<TodoList.Label isChecked={subTodo.completed}>{subTodo.title}</TodoList.Label>}
+              left={<TodoCheckbox isChecked={subTodo.completed} />}
+              top={<TodoLabel isChecked={subTodo.completed}>{subTodo.title}</TodoLabel>}
             />
           ))}
         </VStack>
       )}
-    </TodoList.Item>
+    </TodoRow>
   );
 }
 

--- a/apps/mobile/src/features/todo/presentations/components/SubTodoList/SubTodoList.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/SubTodoList/SubTodoList.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from '@src/shared/i18n';
 import { HStack, MoreIcon, PlusIcon, Text, VStack } from '@src/shared/ui';
 import { PressableFeedback } from 'heroui-native';
 import type { ReactNode } from 'react';
-import { TodoList } from '../TodoList/TodoList';
+import { TodoCheckbox, TodoLabel, TodoRow } from '../TodoRow';
 
 interface SubTodoListProps {
   children: ReactNode;
@@ -50,9 +50,9 @@ SubTodoList.Item = function Item({
   isDragDisabled,
 }: SubTodoListItemProps) {
   return (
-    <TodoList.Item
-      left={<TodoList.Checkbox isChecked={isChecked} onCheckedChange={onCheckedChange} />}
-      top={<TodoList.Label isChecked={isChecked}>{label}</TodoList.Label>}
+    <TodoRow
+      left={<TodoCheckbox isChecked={isChecked} onCheckedChange={onCheckedChange} />}
+      top={<TodoLabel isChecked={isChecked}>{label}</TodoLabel>}
       right={
         <PressableFeedback onPress={onMorePress} hitSlop={8}>
           <MoreIcon width={20} height={20} colorClassName="text-gray-5" />

--- a/apps/mobile/src/features/todo/presentations/components/TodoList/TodoItem.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoList/TodoItem.tsx
@@ -15,9 +15,9 @@ import { CategorySelectBottomSheet } from '../CategorySelectBottomSheet';
 import { SubTodoActionsBottomSheet } from '../SubTodoList/SubTodoActionsBottomSheet';
 import { SubTodoList } from '../SubTodoList/SubTodoList';
 import { TodoDatePickerContent } from '../TodoDatePickerContent';
+import { TodoCheckbox, TodoLabel, TodoProgress, TodoRow } from '../TodoRow';
 import { TodoTimePickerContent } from '../TodoTimePickerContent';
 import { TodoActionsBottomSheet } from './TodoActionsBottomSheet';
-import { TodoList } from './TodoList';
 
 interface TodoItemProps {
   todo: TodoItemViewModel;
@@ -222,9 +222,9 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
   };
 
   return (
-    <TodoList.Item
+    <TodoRow
       left={
-        <TodoList.Checkbox
+        <TodoCheckbox
           isChecked={todo.completed}
           onCheckedChange={todoActions.toggle}
           isDisabled={todoActions.isTogglePending || isOptimistic}
@@ -232,7 +232,7 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
       }
       top={
         <HStack gap={4} align="center">
-          <TodoList.Label isChecked={todo.completed}>{todo.title}</TodoList.Label>
+          <TodoLabel isChecked={todo.completed}>{todo.title}</TodoLabel>
           {todo.visibility === 'PRIVATE' && (
             <LockIcon width={14} height={14} colorClassName="text-gray-5" />
           )}
@@ -247,7 +247,7 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
       }
       bottom={
         todo.hasSubTodos ? (
-          <TodoList.Progress value={todo.subTodoStats.completed} total={todo.subTodoStats.total} />
+          <TodoProgress value={todo.subTodoStats.completed} total={todo.subTodoStats.total} />
         ) : undefined
       }
       right={
@@ -282,6 +282,6 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
           />
         </SubTodoList>
       )}
-    </TodoList.Item>
+    </TodoRow>
   );
 }

--- a/apps/mobile/src/features/todo/presentations/components/TodoList/TodoList.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoList/TodoList.tsx
@@ -1,13 +1,11 @@
 import { useGetPreferenceQueryOptions } from '@src/features/auth/presentations/queries/use-get-preference-query-options';
 import { useTranslation } from '@src/shared/i18n';
 import { Box, HStack, PlusIcon, Text, useOverlay, VStack } from '@src/shared/ui';
-import { cn } from '@src/shared/utils/cn';
 import { formatDate } from '@src/shared/utils/date';
 import { fontScaledSize } from '@src/shared/utils/scale';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import times from 'es-toolkit/compat/times';
-import { Checkbox, PressableFeedback, Skeleton } from 'heroui-native';
-import type { ComponentProps, ReactNode } from 'react';
+import { PressableFeedback, Skeleton } from 'heroui-native';
 import { NestableDraggableFlatList, ScaleDecorator } from 'react-native-draggable-flatlist';
 import { useDraggableReorderList } from '../../hooks/use-draggable-reorder-list';
 import { useFeedDate } from '../../hooks/use-feed-date';
@@ -61,116 +59,6 @@ TodoList.Loading = function Loading() {
         </HStack>
       ))}
     </VStack>
-  );
-};
-
-interface TodoListItemProps {
-  left?: ReactNode;
-  top: ReactNode;
-  middle?: ReactNode;
-  bottom?: ReactNode;
-  right?: ReactNode;
-  onPress?: () => void;
-  onLongPress?: () => void;
-  isActive?: boolean;
-  isDisabled?: boolean;
-  children?: ReactNode;
-}
-
-TodoList.Item = function Item({
-  left,
-  top,
-  middle,
-  bottom,
-  right,
-  onPress,
-  onLongPress,
-  isActive,
-  isDisabled,
-  children,
-}: TodoListItemProps) {
-  return (
-    <>
-      <PressableFeedback
-        onPress={onPress}
-        onLongPress={onLongPress}
-        isDisabled={isActive || isDisabled || (!onPress && !onLongPress)}
-        className={cn('py-2 rounded-xl', isActive && 'bg-gray-1', isDisabled && 'opacity-50')}
-      >
-        <HStack gap={12} align="center">
-          {left}
-          <VStack flex={1} gap={2}>
-            {top}
-            {middle}
-            {bottom}
-          </VStack>
-          {right}
-        </HStack>
-      </PressableFeedback>
-      {children}
-    </>
-  );
-};
-
-interface TodoListCheckboxProps
-  extends Omit<ComponentProps<typeof Checkbox>, 'isSelected' | 'onSelectedChange' | 'className'> {
-  isChecked: boolean;
-  onCheckedChange?: (checked: boolean) => void;
-}
-
-TodoList.Checkbox = function TodoCheckbox({
-  isChecked,
-  onCheckedChange,
-  isDisabled,
-  ...props
-}: TodoListCheckboxProps) {
-  return (
-    <Checkbox
-      className="shadow-none border border-main size-5 rounded-md"
-      isSelected={isChecked}
-      onSelectedChange={onCheckedChange ? () => onCheckedChange(!isChecked) : undefined}
-      isDisabled={isDisabled || !onCheckedChange}
-      {...props}
-    />
-  );
-};
-
-interface TodoListLabelProps
-  extends Omit<
-    ComponentProps<typeof Text>,
-    'size' | 'weight' | 'strikethrough' | 'shade' | 'children'
-  > {
-  isChecked: boolean;
-  children: string;
-}
-
-TodoList.Label = function TodoLabel({ isChecked, children, ...props }: TodoListLabelProps) {
-  return (
-    <Text
-      size="b3"
-      weight="medium"
-      strikethrough={isChecked}
-      shade={isChecked ? 5 : undefined}
-      {...props}
-    >
-      {children}
-    </Text>
-  );
-};
-
-TodoList.Progress = function Progress({ value, total }: { value: number; total: number }) {
-  return (
-    <HStack gap={6} align="center">
-      <Box className="h-1 w-10 rounded-full bg-gray-2 overflow-hidden">
-        <Box
-          className="h-full rounded-full bg-main"
-          style={{ width: `${(value / total) * 100}%` }}
-        />
-      </Box>
-      <Text size="e1" shade={6}>
-        {value}/{total}
-      </Text>
-    </HStack>
   );
 };
 

--- a/apps/mobile/src/features/todo/presentations/components/TodoRow.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoRow.tsx
@@ -110,13 +110,14 @@ interface TodoProgressProps {
 }
 
 export function TodoProgress({ value, total }: TodoProgressProps) {
+  // total이 0이면 `NaN%`가 되어 RN 스타일 파서가 레이아웃을 깨뜨린다.
+  // 호출자가 지금은 하위 할 일이 있을 때만 렌더하지만, 이건 공개 프리미티브다.
+  const percentage = total > 0 ? (value / total) * 100 : 0;
+
   return (
     <HStack gap={6} align="center">
       <Box className="h-1 w-10 rounded-full bg-gray-2 overflow-hidden">
-        <Box
-          className="h-full rounded-full bg-main"
-          style={{ width: `${(value / total) * 100}%` }}
-        />
+        <Box className="h-full rounded-full bg-main" style={{ width: `${percentage}%` }} />
       </Box>
       <Text size="e1" shade={6}>
         {value}/{total}

--- a/apps/mobile/src/features/todo/presentations/components/TodoRow.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoRow.tsx
@@ -1,0 +1,126 @@
+import { Box, HStack, Text, VStack } from '@src/shared/ui';
+import { cn } from '@src/shared/utils/cn';
+import { Checkbox, PressableFeedback } from 'heroui-native';
+import type { ComponentProps, ReactNode } from 'react';
+
+/**
+ * 할 일 목록의 행 프리미티브.
+ *
+ * 데이터를 모르는 순수 레이아웃이다. `TodoList`(컨테이너)가 아니라 여기 사는 이유:
+ * 자식(`TodoItem`, `SubTodoList`, `FriendTodoList`)이 컨테이너를 import하면
+ * 순환 참조가 생기고, Metro가 초기화되지 않은 값을 넘길 수 있다.
+ */
+interface TodoRowProps {
+  left?: ReactNode;
+  top: ReactNode;
+  middle?: ReactNode;
+  bottom?: ReactNode;
+  right?: ReactNode;
+  onPress?: () => void;
+  onLongPress?: () => void;
+  isActive?: boolean;
+  isDisabled?: boolean;
+  children?: ReactNode;
+}
+
+export function TodoRow({
+  left,
+  top,
+  middle,
+  bottom,
+  right,
+  onPress,
+  onLongPress,
+  isActive,
+  isDisabled,
+  children,
+}: TodoRowProps) {
+  return (
+    <>
+      <PressableFeedback
+        onPress={onPress}
+        onLongPress={onLongPress}
+        isDisabled={isActive || isDisabled || (!onPress && !onLongPress)}
+        className={cn('py-2 rounded-xl', isActive && 'bg-gray-1', isDisabled && 'opacity-50')}
+      >
+        <HStack gap={12} align="center">
+          {left}
+          <VStack flex={1} gap={2}>
+            {top}
+            {middle}
+            {bottom}
+          </VStack>
+          {right}
+        </HStack>
+      </PressableFeedback>
+      {children}
+    </>
+  );
+}
+
+interface TodoCheckboxProps
+  extends Omit<ComponentProps<typeof Checkbox>, 'isSelected' | 'onSelectedChange' | 'className'> {
+  isChecked: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+export function TodoCheckbox({
+  isChecked,
+  onCheckedChange,
+  isDisabled,
+  ...props
+}: TodoCheckboxProps) {
+  return (
+    <Checkbox
+      className="shadow-none border border-main size-5 rounded-md"
+      isSelected={isChecked}
+      onSelectedChange={onCheckedChange ? () => onCheckedChange(!isChecked) : undefined}
+      isDisabled={isDisabled || !onCheckedChange}
+      {...props}
+    />
+  );
+}
+
+interface TodoLabelProps
+  extends Omit<
+    ComponentProps<typeof Text>,
+    'size' | 'weight' | 'strikethrough' | 'shade' | 'children'
+  > {
+  isChecked: boolean;
+  children: string;
+}
+
+export function TodoLabel({ isChecked, children, ...props }: TodoLabelProps) {
+  return (
+    <Text
+      size="b3"
+      weight="medium"
+      strikethrough={isChecked}
+      shade={isChecked ? 5 : undefined}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+}
+
+interface TodoProgressProps {
+  value: number;
+  total: number;
+}
+
+export function TodoProgress({ value, total }: TodoProgressProps) {
+  return (
+    <HStack gap={6} align="center">
+      <Box className="h-1 w-10 rounded-full bg-gray-2 overflow-hidden">
+        <Box
+          className="h-full rounded-full bg-main"
+          style={{ width: `${(value / total) * 100}%` }}
+        />
+      </Box>
+      <Text size="e1" shade={6}>
+        {value}/{total}
+      </Text>
+    </HStack>
+  );
+}

--- a/apps/mobile/src/shared/errors/index.ts
+++ b/apps/mobile/src/shared/errors/index.ts
@@ -22,3 +22,9 @@ export {
   type Result,
   unwrap,
 } from './result';
+
+// Storage Errors
+export { isKeychainLockedError, KeychainLockedError } from './storage-error';
+
+// 던져진 값 정규화
+export { errorMessageOf, toError } from './to-error';

--- a/apps/mobile/src/shared/errors/storage-error.ts
+++ b/apps/mobile/src/shared/errors/storage-error.ts
@@ -1,0 +1,24 @@
+/**
+ * 키체인을 **지금** 읽을 수 없다는 신호. "값이 없다"(`null`)와 구분된다.
+ *
+ * 기기 잠금 중 콜드 스타트(푸시·백그라운드 실행)에서 발생한다.
+ * 이를 "토큰 없음"으로 확정하면 잠긴 키체인이 곧 로그아웃이 된다.
+ *
+ * **일시적 오류만 이 타입으로 승격한다.** 영구 오류(키체인 손상, entitlement 오설정 등)는
+ * 원본 오류 그대로 전파해야 상위에서 관측하고 안전하게 폴백할 수 있다.
+ * 모든 읽기 실패를 "잠김"으로 뭉개면 앱이 조용히 무한 로딩에 갇힌다.
+ *
+ * `InfraError`를 상속하지 않는다 — 그쪽은 `statusCode`를 갖는 HTTP 계열이고
+ * ErrorBoundary가 처리하는 의미론이다. 잠김은 화면에 띄울 오류가 아니라 재시도할 상태다.
+ */
+export class KeychainLockedError extends Error {
+  override readonly name = 'KeychainLockedError';
+
+  constructor(override readonly cause: unknown) {
+    super('Keychain is temporarily unavailable (device locked).');
+  }
+}
+
+/** `KeychainLockedError` 타입 가드 */
+export const isKeychainLockedError = (error: unknown): error is KeychainLockedError =>
+  error instanceof KeychainLockedError;

--- a/apps/mobile/src/shared/errors/to-error.test.ts
+++ b/apps/mobile/src/shared/errors/to-error.test.ts
@@ -1,0 +1,99 @@
+import { errorMessageOf, toError } from './to-error';
+
+describe('toError — 던져진 값을 Error로 정규화한다', () => {
+  it('Error는 그대로 통과시킨다 (스택 보존)', () => {
+    // Given
+    const original = new Error('boom');
+
+    // When & Then — 감싸면 원본 스택을 잃는다
+    expect(toError(original)).toBe(original);
+  });
+
+  it('Error 서브클래스도 그대로 통과시킨다', () => {
+    // Given
+    class CodedError extends Error {}
+    const original = new CodedError('coded');
+
+    // When & Then
+    expect(toError(original)).toBe(original);
+  });
+
+  it('{ message } 형태의 평범한 객체에서 메시지를 살린다', () => {
+    // Given — RN 네이티브 브릿지가 Error가 아닌 값을 던지는 경우.
+    // String(value)로 감싸면 "[object Object]"가 되어 리포터에 내용이 사라진다.
+    const thrown = { message: 'User interaction is not allowed.', code: 'ERR_KEY_CHAIN' };
+
+    // When
+    const error = toError(thrown);
+
+    // Then
+    expect(error.message).toBe('User interaction is not allowed.');
+    expect(error.message).not.toContain('[object Object]');
+  });
+
+  it('원본을 cause로 보존한다', () => {
+    // Given
+    const thrown = { message: 'native failure', code: 'ERR_X' };
+
+    // When
+    const error = toError(thrown);
+
+    // Then — Sentry 이슈에 껍데기만 남지 않게
+    expect(error.cause).toBe(thrown);
+  });
+
+  it('문자열을 던져도 메시지가 된다', () => {
+    // Given & When & Then
+    expect(toError('plain string').message).toBe('plain string');
+  });
+});
+
+describe('errorMessageOf — 값의 모양이 아니라 내용으로 판단한다', () => {
+  it.each([
+    ['Error', new Error('from error'), 'from error'],
+    ['문자열', 'from string', 'from string'],
+    ['message 객체', { message: 'from object' }, 'from object'],
+  ])('%s에서 메시지를 뽑는다', (_label, value, expected) => {
+    // Given & When & Then
+    expect(errorMessageOf(value)).toBe(expected);
+  });
+
+  it('message가 없는 객체는 JSON으로 직렬화한다 ([object Object] 금지)', () => {
+    // Given
+    const value = { code: 'ERR_X', status: 500 };
+
+    // When
+    const message = errorMessageOf(value);
+
+    // Then
+    expect(message).toBe('{"code":"ERR_X","status":500}');
+    expect(message).not.toBe('[object Object]');
+  });
+
+  it('빈 문자열 message는 무시하고 직렬화로 폴백한다', () => {
+    // Given
+    const value = { message: '', code: 'ERR_X' };
+
+    // When & Then
+    expect(errorMessageOf(value)).toBe('{"message":"","code":"ERR_X"}');
+  });
+
+  it('순환 참조에도 죽지 않는다', () => {
+    // Given
+    const value: Record<string, unknown> = { code: 'ERR_X' };
+    value.self = value;
+
+    // When & Then — JSON.stringify가 던지므로 String()으로 폴백
+    expect(() => errorMessageOf(value)).not.toThrow();
+    expect(errorMessageOf(value)).toBe('[object Object]');
+  });
+
+  it.each([
+    [null, 'null'],
+    [undefined, 'undefined'],
+    [42, '42'],
+  ])('원시값(%p)도 문자열로 만든다', (value, expected) => {
+    // Given & When & Then
+    expect(errorMessageOf(value)).toBe(expected);
+  });
+});

--- a/apps/mobile/src/shared/errors/to-error.ts
+++ b/apps/mobile/src/shared/errors/to-error.ts
@@ -1,0 +1,67 @@
+/**
+ * 던져진 값을 다루는 유틸.
+ *
+ * JS는 무엇이든 throw할 수 있다. RN 네이티브 브릿지와 서드파티 라이브러리는
+ * `Error`가 아닌 값(문자열, `{ message }` 형태의 평범한 객체)을 던지기도 한다.
+ *
+ * 그래서 `instanceof Error`를 관문으로 삼으면 두 가지가 조용히 무너진다:
+ * - `new Error(String(value))` → 객체가 `"[object Object]"`가 되어 리포터에 내용이 사라진다
+ * - `value instanceof Error ? value : undefined` → 에러가 통째로 버려진다
+ *
+ * 값의 **모양**이 아니라 **내용**으로 판단한다.
+ */
+
+/** 순환 참조·getter 예외에도 죽지 않는 최선의 문자열화. */
+const stringify = (value: unknown): string => {
+  try {
+    const json = JSON.stringify(value);
+    if (json !== undefined && json !== '{}') {
+      return json;
+    }
+  } catch {
+    // 순환 참조 등 — String()으로 폴백
+  }
+  return String(value);
+};
+
+/** `{ message: '...' }` 형태에서 메시지를 꺼낸다. */
+const readMessage = (value: unknown): string | undefined => {
+  if (typeof value !== 'object' || value === null || !('message' in value)) {
+    return undefined;
+  }
+
+  const { message } = value as { message: unknown };
+  return typeof message === 'string' && message.length > 0 ? message : undefined;
+};
+
+/**
+ * 던져진 값에서 사람이 읽을 메시지를 뽑는다.
+ *
+ * `Error`가 아니어도 동작해야 한다 — 벤더 에러를 메시지로 판별하는 경계에서 쓴다.
+ */
+export const errorMessageOf = (value: unknown): string => {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return readMessage(value) ?? stringify(value);
+};
+
+/**
+ * 던져진 값을 `Error`로 정규화한다. 원본은 `cause`로 보존한다.
+ *
+ * `ErrorReporter.captureException`은 `Error`를 요구한다. 감싸는 과정에서
+ * 원본을 잃으면 Sentry 이슈에 남는 것이 껍데기뿐이다.
+ */
+export const toError = (value: unknown): Error => {
+  if (value instanceof Error) {
+    return value;
+  }
+
+  const error = new Error(errorMessageOf(value));
+  // `new Error(msg, { cause })`는 Hermes가 무시할 수 있어 직접 대입한다.
+  error.cause = value;
+  return error;
+};

--- a/apps/mobile/src/shared/infra/http/token-refresher.ts
+++ b/apps/mobile/src/shared/infra/http/token-refresher.ts
@@ -1,6 +1,7 @@
 import { refreshTokensSchema } from '@aido/validators';
 import type { SessionExpiredDetails } from '@src/core/ports/telemetry-event';
 import type { TokenStore } from '@src/core/ports/token-store';
+import { errorMessageOf } from '@src/shared/errors';
 import { logger } from '@src/shared/infra/logger/global-logger';
 import { z } from 'zod';
 import { toServerErrorCode } from './server-error-code';
@@ -54,7 +55,7 @@ export const createTokenRefresher = ({
       refreshToken = await tokenStore.readRefreshToken();
     } catch (error) {
       // 키체인 접근 실패(기기 잠김 등)는 "토큰 없음"이 아니다. 세션을 끝내면 안 된다.
-      logger.warn('[TokenRefresher] 토큰 읽기 실패 (세션 보존)', { error: String(error) });
+      logger.warn('[TokenRefresher] 토큰 읽기 실패 (세션 보존)', { error: errorMessageOf(error) });
       return { kind: 'transient-failure' };
     }
 
@@ -67,7 +68,9 @@ export const createTokenRefresher = ({
       response = await requestRefresh(refreshToken);
     } catch (error) {
       // 네트워크/타임아웃 — 서버는 회전하지 않았으므로 보유 토큰은 여전히 유효하다.
-      logger.warn('[TokenRefresher] 일시적 갱신 실패 (토큰 보존)', { error: String(error) });
+      logger.warn('[TokenRefresher] 일시적 갱신 실패 (토큰 보존)', {
+        error: errorMessageOf(error),
+      });
       return { kind: 'transient-failure' };
     }
 
@@ -86,7 +89,7 @@ export const createTokenRefresher = ({
         await tokenStore.save({ accessToken, refreshToken: nextRefreshToken });
       } catch (error) {
         // 저장 실패. 서버는 회전했지만 보유 토큰은 grace(10초) 안에서 아직 통한다.
-        logger.warn('[TokenRefresher] 새 토큰 저장 실패', { error: String(error) });
+        logger.warn('[TokenRefresher] 새 토큰 저장 실패', { error: errorMessageOf(error) });
         return { kind: 'transient-failure' };
       }
       return { kind: 'refreshed' };

--- a/apps/mobile/src/shared/infra/storage/secure-storage.test.ts
+++ b/apps/mobile/src/shared/infra/storage/secure-storage.test.ts
@@ -1,4 +1,4 @@
-import { KeychainLockedError } from '@src/core/ports/storage';
+import { KeychainLockedError } from '@src/shared/errors';
 import * as ExpoSecureStore from 'expo-secure-store';
 import { SecureStorage } from './secure-storage';
 
@@ -43,6 +43,15 @@ describe('SecureStorage — 벤더 에러 분류', () => {
     getItemAsync.mockRejectedValue(new Error('User interaction is not allowed.'));
 
     // When & Then — "지금 못 읽는다"는 "토큰이 없다"와 다르다
+    await expect(storage.get('key')).rejects.toBeInstanceOf(KeychainLockedError);
+  });
+
+  it('Error가 아닌 값으로 던져져도 잠금을 판별한다', async () => {
+    // Given — RN 네이티브 브릿지가 { message } 객체를 던지는 경우.
+    // instanceof Error를 관문으로 두면 판별에 실패해 잠긴 키체인이 곧 로그아웃이 된다.
+    getItemAsync.mockRejectedValue({ message: 'User interaction is not allowed.' });
+
+    // When & Then
     await expect(storage.get('key')).rejects.toBeInstanceOf(KeychainLockedError);
   });
 

--- a/apps/mobile/src/shared/infra/storage/secure-storage.ts
+++ b/apps/mobile/src/shared/infra/storage/secure-storage.ts
@@ -1,4 +1,5 @@
-import { KeychainLockedError, type Storage } from '@src/core/ports/storage';
+import type { Storage } from '@src/core/ports/storage';
+import { errorMessageOf, KeychainLockedError } from '@src/shared/errors';
 import * as ExpoSecureStore from 'expo-secure-store';
 
 // AFTER_FIRST_UNLOCK: 첫 잠금해제 후 접근 가능(잠금 중 백그라운드 접근 throw 방지), 재설치해도 유지.
@@ -20,11 +21,14 @@ const SECURE_STORE_OPTIONS: ExpoSecureStore.SecureStoreOptions = {
  *
  * Android에는 잠금 개념이 없다(`requireAuthentication` 미사용). `DecryptException` 등은
  * 영구 오류이므로 잠김으로 승격하지 않는다.
+ *
+ * `instanceof Error`를 관문으로 두지 않는다 — 네이티브 브릿지가 `{ message }` 형태의
+ * 평범한 객체를 던지면 판별에 실패해 **잠긴 키체인이 곧 로그아웃**이 된다.
  */
 const IOS_LOCKED_KEYCHAIN_MESSAGE = 'User interaction is not allowed.';
 
 const isLockedKeychain = (error: unknown): boolean =>
-  error instanceof Error && error.message.includes(IOS_LOCKED_KEYCHAIN_MESSAGE);
+  errorMessageOf(error).includes(IOS_LOCKED_KEYCHAIN_MESSAGE);
 
 export class SecureStorage implements Storage {
   async get<T>(key: string): Promise<T | null> {

--- a/apps/mobile/src/shared/ui/QueryErrorBoundary/QueryErrorBoundary.tsx
+++ b/apps/mobile/src/shared/ui/QueryErrorBoundary/QueryErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { useErrorReporter } from '@src/bootstrap/providers/di-context';
+import { toError } from '@src/shared/errors';
 import { useTranslation } from '@src/shared/i18n';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -25,10 +26,7 @@ export function QueryErrorBoundary({ children, fallback }: QueryErrorBoundaryPro
         <ErrorBoundary
           onReset={reset}
           onError={(error) => {
-            errorReporter.captureException(
-              error instanceof Error ? error : new Error(String(error)),
-              { feature: 'error_boundary' },
-            );
+            errorReporter.captureException(toError(error), { feature: 'error_boundary' });
           }}
           fallbackRender={({ error, resetErrorBoundary }) =>
             fallback ? (


### PR DESCRIPTION
## 요약

`#606` 리뷰에서 나온 지적을 처리하고, Metro가 경고하던 순환 참조 2건을 제거합니다.
그 과정에서 **`#606`이 남긴 동작 버그 하나**를 발견해 함께 고칩니다.

`apps/api` 변경 없음. DB 마이그레이션 없음. 사용자 노출 문자열 변경 없음.

---

## 1. 동작 버그: 잠긴 키체인이 곧 로그아웃이 될 수 있었다

`#606`이 넣은 잠금 판별기가 `instanceof Error`를 관문으로 삼고 있었습니다.

```ts
// before
error instanceof Error && error.message.includes('User interaction is not allowed.')
```

네이티브 브릿지가 `{ message: '...' }` 형태의 **평범한 객체**를 던지면 판별에 실패합니다.
그러면 원본이 그대로 전파되고 `AuthProvider`가 미인증으로 폴백합니다 — 즉 **잠금 해제를 기다려야 할 상황에서 로그인 화면으로 떨어집니다.**

Gemini가 지적한 `[object Object]`(리포팅 품질)보다 **이쪽이 먼저 터집니다.**

값의 모양이 아니라 **내용**으로 판단하도록 바꿨습니다.

> `expo-modules-core`는 `CodedError extends Error`를 던지므로 오늘 이 경로에서 실제로 발생할 확률은 낮습니다. 그러나 `unknown`을 `instanceof`로 좁히는 관문은 언제든 조용히 무너집니다.

## 2. 리포팅에서 원인이 사라지는 두 경로

```ts
// ❌ 평범한 객체가 "[object Object]"가 된다
new Error(String(error))

// ❌ 더 나쁘다 — 에러를 통째로 버린다
logger.error('failed', error instanceof Error ? error : undefined)
```

후자는 `notification-provider`, 푸시 토큰 등록/해제, `use-notification-handler`, AI 제안 뮤테이션에 있었습니다. `[object Object]`라도 남기는 게 낫습니다. 이건 **아무것도 안 남깁니다.**

`toError` / `errorMessageOf`로 8개 지점을 통일했습니다. 원본은 `cause`로 보존합니다.

## 3. 순환 참조 제거

```
TodoList → TodoItem → SubTodoList → TodoList
TodoList → TodoItem → TodoList
```

원인은 **배치**입니다. 데이터를 페치하는 화면 컨테이너(`TodoList`)에 순수 레이아웃 프리미티브(`Item`/`Checkbox`/`Label`/`Progress`)가 static 프로퍼티로 붙어 있어, 자식이 그것을 쓰려면 부모를 import해야 했습니다.

프리미티브를 `components/TodoRow.tsx`로 분리했습니다. 컨테이너에는 화면 폴백(`Loading`/`Error`)만 남습니다.

## 4. 재발 방지 게이트

`suspicious/noImportCycles`를 먼저 시도했으나 **이 레포에서 쓸 수 없습니다.**

- 의도적으로 심은 2파일 사이클을 **검출하지 못합니다** (독립 최소 재현에서는 검출됨 → 우리 모노레포 설정 표면의 문제)
- 루트 설정에 켜면 project 스캐너가 저장소 전체를 인덱싱하다 **한글 마크다운에서 패닉**합니다
  (`biome_markdown_parser`: `byte index N is not a char boundary`)

지키는 게 없는 초록불 대신 의존성 없는 검사기(`scripts/check-import-cycles.mjs`)를 넣고, `pnpm lint`와 CI가 부르는 `check` 양쪽에 물렸습니다. 업스트림이 해결되면 규칙으로 교체합니다.

---

## 🏗️ 구조 변경

- `KeychainLockedError`를 `core/ports/storage.ts` → `shared/errors/storage-error.ts`로 이동
  `core/ports/`는 아키텍처 문서상 **Port 인터페이스 전용**입니다. `#606`에서 제가 어긴 규약입니다.
- `InfraError`는 상속하지 않습니다 — 그쪽은 `statusCode`를 갖는 HTTP 계열이고 ErrorBoundary가 처리하는 의미론입니다. 잠김은 띄울 오류가 아니라 **재시도할 상태**입니다.
- 벤더 에러 문자열 판별은 인프라 경계(`secure-storage.ts`)에만 둡니다. 도메인(`auth-boot.ts`)은 `isKeychainLockedError()`만 압니다.

## 🧪 검증

| 항목 | 결과 |
|------|------|
| `pnpm typecheck` | 8/8 |
| `pnpm lint` | clean (+ 순환 참조 0) |
| `pnpm turbo run check` (CI 경로) | pass |
| mobile 테스트 | **73 suites / 848 tests** (+15) |
| api 테스트 | 195 suites / 2328 tests (영향 없음) |
| Metro 번들 (`expo export --platform ios`) | 성공, Require cycle 경고 0 |

**대조군으로 검증한 것** (통과만으로는 증명되지 않는 것들):

- 순환 참조 검사기: 심은 사이클 **검출** / 타입 전용 import는 **무시** / 실제 코드 **0건**
  수정 전 트리에 돌려 Metro가 경고한 **바로 그 2건을 재현**했습니다.
- `KeychainLockedError`의 `instanceof`: Metro+Hermes 실제 빌드 경로로 트랜스파일해 실행 확인
  (다운레벨되어도 Babel `_wrapNativeSuper`가 `Reflect.construct`를 써서 프로토타입 체인 유지)

## 📦 영향

**기존 유저 영향 없음.** 미인증 폴백은 토큰을 지우지 않습니다 — 삭제는 여전히 `SessionManager.end()`와 명시적 로그아웃 두 경로뿐입니다.

## 관련

- Closes #606 리뷰 지적
- Refs #599, #605, #607
