### PR TITLE
Release v1.4.3 (살아있는 세션 401 컨테인먼트)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -15,7 +15,7 @@ interface EnvironmentConfig {
 
 const PROJECT_SLUG = 'aido';
 const OWNER = 'aido-team';
-const VERSION = '1.4.2';
+const VERSION = '1.4.3';
 
 const APP_NAME = 'Aido';
 const BUNDLE_IDENTIFIER = 'com.aido.mobile';

--- a/apps/mobile/app/(app)/(tabs)/memo/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/memo/index.tsx
@@ -12,6 +12,7 @@ import {
   HStack,
   PlusIcon,
   QueryErrorBoundary,
+  RefreshIcon,
   ScrollProgressWidget,
 } from '@src/shared/ui';
 import { cn } from '@src/shared/utils/cn';
@@ -51,9 +52,11 @@ export default function MemoScreen() {
 
   return (
     <Box className="flex-1">
-      <Suspense fallback={<Header.Loading />}>
-        <Header />
-      </Suspense>
+      <QueryErrorBoundary fallback={(props) => <Header.Error {...props} />}>
+        <Suspense fallback={<Header.Loading />}>
+          <Header />
+        </Suspense>
+      </QueryErrorBoundary>
 
       <Animated.ScrollView
         ref={scrollRef}
@@ -119,4 +122,24 @@ function Header() {
 
 Header.Loading = function Loading() {
   return <Box px={16} mb={16} style={{ height: 44 }} />;
+};
+
+// 살아있는 세션의 일시적 401 등으로 Header 쿼리가 실패해도 앱 레벨로 새지 않게 로컬에 담는다.
+// 제목은 유지하고 생성 버튼 자리를 재시도(reset)로 바꿔 레이아웃을 흔들지 않는다.
+Header.Error = function ErrorFallback({ reset }: { error: unknown; reset: () => void }) {
+  const { t } = useTranslation('memo');
+  return (
+    <HStack align="center" px={16} mb={16}>
+      <Box flex={1}>
+        <H3 shade={7}>{t('tab.addMemo')}</H3>
+      </Box>
+      <PressableFeedback
+        onPress={reset}
+        style={{ width: fontScaledSize(36), height: fontScaledSize(36) }}
+        className="items-center justify-center rounded-full bg-gray-8"
+      >
+        <RefreshIcon width={20} height={20} colorClassName="text-white" />
+      </PressableFeedback>
+    </HStack>
+  );
 };

--- a/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/mypage/index.tsx
@@ -110,9 +110,11 @@ const MyPageScreen = () => {
 
         <Spacing size={32} />
 
-        <Suspense fallback={null}>
-          <AccountActionButtons />
-        </Suspense>
+        <QueryErrorBoundary>
+          <Suspense fallback={null}>
+            <AccountActionButtons />
+          </Suspense>
+        </QueryErrorBoundary>
       </ScrollView>
     </StyledSafeAreaView>
   );

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from '@src/bootstrap/providers/auth-provider';
 import { useErrorReporter } from '@src/bootstrap/providers/di-context';
-import { isApiError } from '@src/shared/errors';
+import { classifyBoundaryError } from '@src/shared/errors';
 import { useTranslation } from '@src/shared/i18n';
 import { HStack, Result, StyledSafeAreaView } from '@src/shared/ui';
 import { Stack } from 'expo-router';
@@ -48,10 +48,10 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   const errorReporter = useErrorReporter();
   const { t } = useTranslation();
 
-  // 세션이 끝난 뒤 도착한 401은 장애가 아니라 인증 전환이다. 라우트 게이트가 곧 로그인 화면으로
-  // 바꾸므로, 재시도 UI를 보여주지도 리포팅하지도 않는다.
-  // (세션이 살아있는데 401이면 진짜 문제이므로 아래 에러 화면을 그대로 보여준다.)
-  const isAuthTransition = isApiError(error) && error.status === 401 && status !== 'authenticated';
+  // 세션이 끝난 뒤 도착한 401만 조용히 로그인으로 넘긴다. 세션이 살아있는데 401이 여기까지
+  // 새어왔다면 컨테인먼트 구멍이므로, null 빈 화면 대신 재시도 UI를 보여주고 리포트한다.
+  const isAuthTransition =
+    status !== 'authenticated' && classifyBoundaryError(error) === 'auth-transition';
 
   // 렌더 중 부수효과 금지 — 리렌더마다 중복 캡처된다.
   useEffect(() => {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aido/mobile",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,7 @@
     "format": "biome format --write .",
     "ios": "expo run:ios",
     "lint": "biome lint . && pnpm lint:cycles",
+    "lint:cycles": "node scripts/check-import-cycles.mjs",
     "native:prebuild": "expo prebuild --clean",
     "submit:production": "eas submit --profile production --platform all --latest",
     "submit:production:android": "eas submit --profile production --platform android --latest",
@@ -33,8 +34,7 @@
     "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit",
     "update:preview": "eas update --branch preview",
-    "update:production": "eas update --branch production",
-    "lint:cycles": "node scripts/check-import-cycles.mjs"
+    "update:production": "eas update --branch production"
   },
   "dependencies": {
     "@aido/errors": "workspace:^",

--- a/apps/mobile/src/bootstrap/providers/query-provider.tsx
+++ b/apps/mobile/src/bootstrap/providers/query-provider.tsx
@@ -1,8 +1,8 @@
-import { isApiError, isBusinessError } from '@src/shared/errors';
 import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { PropsWithChildren } from 'react';
 import type { AppStateStatus } from 'react-native';
 import { AppState, Platform } from 'react-native';
+import { shouldRetryQuery } from './query-retry';
 
 /**
  * React Native에서는 브라우저의 `visibilitychange` 이벤트가 없으므로,
@@ -29,17 +29,7 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: MIN_STALE_TIME,
       gcTime: MIN_GC_TIME,
-      retry: (failureCount, error) => {
-        if (isApiError(error) && [401, 403].includes(error.status)) {
-          return false;
-        }
-
-        if (isBusinessError(error)) {
-          return false;
-        }
-
-        return failureCount < 3;
-      },
+      retry: shouldRetryQuery,
     },
     mutations: {
       retry: false,

--- a/apps/mobile/src/bootstrap/providers/query-retry.test.ts
+++ b/apps/mobile/src/bootstrap/providers/query-retry.test.ts
@@ -1,0 +1,32 @@
+import { ApiError, NetworkError } from '@src/shared/errors';
+import { shouldRetryQuery } from './query-retry';
+
+describe('shouldRetryQuery', () => {
+  it('401/403 ApiError는 재시도하지 않는다 (세션 종료·권한 없음 → QueryErrorBoundary가 담음)', () => {
+    // Given
+    const unauthorized = new ApiError('AUTH_0105', '다시 로그인', 401);
+    const forbidden = new ApiError('AUTH_0108', '권한 없음', 403);
+
+    // When / Then
+    expect(shouldRetryQuery(0, unauthorized)).toBe(false);
+    expect(shouldRetryQuery(0, forbidden)).toBe(false);
+  });
+
+  it('그 외 BusinessError(예측 가능한 4xx)는 재시도하지 않는다', () => {
+    // Given — 호출부가 onError에서 처리한다
+    const businessError = new ApiError('MEMO_0301', '한도 초과', 409);
+
+    // When / Then
+    expect(shouldRetryQuery(0, businessError)).toBe(false);
+  });
+
+  it('네트워크·5xx 등은 상한(3)까지 재시도한다', () => {
+    // Given
+    const error = new NetworkError();
+
+    // When / Then
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(2, error)).toBe(true);
+    expect(shouldRetryQuery(3, error)).toBe(false);
+  });
+});

--- a/apps/mobile/src/bootstrap/providers/query-retry.ts
+++ b/apps/mobile/src/bootstrap/providers/query-retry.ts
@@ -1,0 +1,24 @@
+import { isApiError, isBusinessError } from '@src/shared/errors';
+
+/** 재시도 상한. */
+const MAX_RETRIES = 3;
+
+/**
+ * React Query 쿼리 재시도 술어.
+ *
+ * - `ApiError` 401/403(세션 종료·권한 없음): 재시도하지 않는다. 401은 인터셉터가 이미 한 번
+ *   갱신·재시도했고, 남은 401은 화면별 `QueryErrorBoundary`가 로컬 재시도로 담는다.
+ * - 그 외 `BusinessError`(예측 가능한 4xx): 재시도하지 않는다 — 호출부가 처리한다.
+ * - 나머지(네트워크·5xx 등): 상한까지 재시도한다.
+ */
+export const shouldRetryQuery = (failureCount: number, error: unknown): boolean => {
+  if (isApiError(error) && [401, 403].includes(error.status)) {
+    return false;
+  }
+
+  if (isBusinessError(error)) {
+    return false;
+  }
+
+  return failureCount < MAX_RETRIES;
+};

--- a/apps/mobile/src/shared/errors/classify-boundary-error.test.ts
+++ b/apps/mobile/src/shared/errors/classify-boundary-error.test.ts
@@ -1,0 +1,29 @@
+import { ApiError } from './api-error';
+import { classifyBoundaryError } from './classify-boundary-error';
+import { ServerError } from './infra-error';
+
+describe('classifyBoundaryError', () => {
+  it('401 ApiError는 auth-transition으로 분류한다 (인증 상태와 무관 — 순수 함수)', () => {
+    // Given — status 결합 판단은 호출부(앱 레벨 바운더리)의 몫이고, 이 함수는 에러 종류만 본다.
+    const error = new ApiError('AUTH_0105', '다시 로그인', 401);
+
+    // When / Then
+    expect(classifyBoundaryError(error)).toBe('auth-transition');
+  });
+
+  it('403 ApiError는 error로 분류한다 (권한 없음은 인증 전환이 아니다)', () => {
+    // Given
+    const error = new ApiError('AUTH_0108', '권한 없음', 403);
+
+    // When / Then
+    expect(classifyBoundaryError(error)).toBe('error');
+  });
+
+  it('5xx·기타 인프라 에러는 error로 분류한다', () => {
+    // Given
+    const error = new ServerError(500);
+
+    // When / Then
+    expect(classifyBoundaryError(error)).toBe('error');
+  });
+});

--- a/apps/mobile/src/shared/errors/classify-boundary-error.ts
+++ b/apps/mobile/src/shared/errors/classify-boundary-error.ts
@@ -1,0 +1,27 @@
+import { isApiError } from './api-error';
+
+/**
+ * ErrorBoundary가 잡은 에러의 처리 종류.
+ *
+ * - `auth-transition`: 세션이 끝난 뒤 도착한 401. 라우트 게이트가 곧 로그인 화면으로 바꾸므로
+ *   화면·리포트 없이 조용히 넘긴다.
+ * - `error`: 진짜 장애(5xx·네트워크·파싱 등). 에러 화면 + 리포트.
+ */
+export type BoundaryErrorKind = 'auth-transition' | 'error';
+
+/**
+ * 던져진 에러가 "401(인증 계열)"인지 "진짜 장애"인지만 판정하는 순수 함수.
+ *
+ * **의도적으로 인증 상태(`status`)를 보지 않는다** — 레이스 프리하게 유지하기 위해서다.
+ * 401을 실제 세션 종료(→로그인 게이트, 조용히 넘김)로 볼지, 컨테인먼트 구멍으로 새어온
+ * 살아있는 세션의 401(→재시도 UI + 리포트)로 볼지의 **최종 판단은 호출부(앱 레벨 바운더리)**
+ * 가 `status`와 결합해 내린다(`app/(app)/_layout.tsx` 안전망 참조). 이 함수는 그 판단의
+ * 한 축(에러 종류)만 제공한다.
+ */
+export const classifyBoundaryError = (error: unknown): BoundaryErrorKind => {
+  if (isApiError(error) && error.status === 401) {
+    return 'auth-transition';
+  }
+
+  return 'error';
+};

--- a/apps/mobile/src/shared/errors/index.ts
+++ b/apps/mobile/src/shared/errors/index.ts
@@ -1,6 +1,9 @@
 // Base Classes
 export { ApiError, isApiError } from './api-error';
 
+// Boundary 에러 분류 (라우트 ErrorBoundary 처리 분기)
+export { type BoundaryErrorKind, classifyBoundaryError } from './classify-boundary-error';
+
 // Infrastructure Errors
 export {
   InfraError,

--- a/apps/mobile/src/shared/infra/http/auth-client.test.ts
+++ b/apps/mobile/src/shared/infra/http/auth-client.test.ts
@@ -1,0 +1,169 @@
+import type { AuthTokenPair, TokenStore } from '@src/core/ports/token-store';
+import { ApiError } from '@src/shared/errors';
+import ky, { type KyInstance } from 'ky';
+import { handleApiErrors } from './error-handler';
+import { KyHttpClient } from './ky-client';
+import { createTokenRefreshHook, RETRY_MARKER_HEADER } from './token-refresh-hook';
+import { createTokenRefresher, type RefreshTokensRequest } from './token-refresher';
+
+/**
+ * 인증 파이프라인 통합 테스트.
+ *
+ * `createAuthClient`와 **동일한 훅 배선**(beforeRequest 토큰 주입 + [handleApiErrors,
+ * createTokenRefreshHook] + retry:0)을 조립하되, env(expo-constants) 결합을 피하려
+ * prefixUrl만 테스트용으로 둔다. 네트워크 경계(`global.fetch`)만 fake하고 나머지는 실제 코드다.
+ *
+ * 검증하려는 핵심 계약: 401 → 갱신 → 재시도의 결과가 (a) 성공 시 값 반환, (b) 재시도도
+ * 401이면 로그아웃 없이 `Result.err(ApiError)`로 담김(화면 QueryErrorBoundary가 흡수),
+ * (c) 서버가 리프레시 거부 시에만 `endSession` + `ApiError`. ky는 자체 재시도하지 않는다(retry:0).
+ */
+
+// ── 서버 응답 빌더 (실제 Response) ──────────────────────────────────────────
+const successBody = <T>(data: T) =>
+  new Response(JSON.stringify({ success: true, data, timestamp: 0 }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const errorBody = (status: number, code: string, message = 'error') =>
+  new Response(JSON.stringify({ error: { code, message } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+// ── 회전을 실제로 반영하는 상태형 토큰 저장소 (모킹 대신 진짜 fake) ──────────
+const createStatefulTokenStore = (initial: AuthTokenPair): TokenStore => {
+  let tokens: { accessToken: string | null; refreshToken: string | null } = { ...initial };
+  return {
+    readAccessToken: async () => tokens.accessToken,
+    readRefreshToken: async () => tokens.refreshToken,
+    save: async (next) => {
+      tokens = next;
+    },
+    clear: async () => {
+      tokens = { accessToken: null, refreshToken: null };
+    },
+  };
+};
+
+describe('인증 클라이언트 통합 (401 → refresh → retry)', () => {
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+  let tokenStore: TokenStore;
+  let requestRefresh: jest.MockedFunction<RefreshTokensRequest>;
+  let endSession: jest.MockedFunction<(details: unknown) => Promise<void>>;
+  let http: KyHttpClient;
+
+  const buildClient = (): KyInstance => {
+    const clientRef: { current: KyInstance | null } = { current: null };
+    const refresh = createTokenRefresher({ tokenStore, requestRefresh });
+
+    clientRef.current = ky.create({
+      prefixUrl: 'https://api.test',
+      retry: 0, // 재시도는 훅/React Query가 소유 — ky 자체 재시도 없음 (createAuthClient와 동일)
+      hooks: {
+        beforeRequest: [
+          async (request) => {
+            const accessToken = await tokenStore.readAccessToken();
+            if (accessToken) {
+              request.headers.set('Authorization', `Bearer ${accessToken}`);
+            }
+          },
+        ],
+        afterResponse: [
+          handleApiErrors,
+          createTokenRefreshHook({
+            tokenStore,
+            refresh,
+            endSession,
+            retry: (request) => {
+              const client = clientRef.current;
+              if (!client) throw new Error('client not initialized');
+              return client(request);
+            },
+          }),
+        ],
+      },
+    });
+
+    return clientRef.current;
+  };
+
+  beforeEach(() => {
+    fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+    global.fetch = fetchMock;
+    tokenStore = createStatefulTokenStore({ accessToken: 'access-1', refreshToken: 'refresh-1' });
+    requestRefresh = jest.fn();
+    endSession = jest.fn().mockResolvedValue(undefined);
+    http = new KyHttpClient(buildClient());
+  });
+
+  it('갱신에 성공하면 원 요청을 재시도해 데이터를 반환한다', async () => {
+    // Given — 첫 요청은 401, 갱신 성공(토큰 회전), 마커 붙은 재시도는 200
+    fetchMock.mockImplementation(async (input) => {
+      const request = input as Request;
+      if (request.headers.get(RETRY_MARKER_HEADER) === '1') {
+        return successBody({ id: 'todo-1' });
+      }
+      return errorBody(401, 'AUTH_0102', 'access token expired');
+    });
+    requestRefresh.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { accessToken: 'access-2', refreshToken: 'refresh-2' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    // When
+    const result = await http.get<{ id: string }>('todos');
+
+    // Then
+    expect(result).toEqual({ ok: true, value: { id: 'todo-1' } });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 원 요청 1 + 재시도 1 (ky 자체 재시도 없음)
+    expect(endSession).not.toHaveBeenCalled();
+  });
+
+  it('갱신 후 재시도가 다시 401이면 Result.err(ApiError)로 담긴다 (세션 유지 — 화면 QEB가 로컬 재시도)', async () => {
+    // Given — 회전 레이스: 갱신은 성공하지만 재시도도 401
+    fetchMock.mockResolvedValue(errorBody(401, 'AUTH_0102', 'access token expired'));
+    requestRefresh.mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { accessToken: 'access-2', refreshToken: 'refresh-2' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    // When
+    const result = await http.get('todos');
+
+    // Then — 로그아웃(endSession) 없이 ApiError로 담긴다. 세션 종료가 아니므로 화면별
+    // QueryErrorBoundary가 로컬 재시도로 흡수한다(앱 레벨로 새지 않음).
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ApiError);
+      expect(result.error.status).toBe(401);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 원 요청 1 + 재시도 1 — ky가 이중 재시도하지 않음
+    expect(endSession).not.toHaveBeenCalled();
+  });
+
+  it('서버가 리프레시 토큰을 거부하면 세션을 종료하고 ApiError를 반환한다', async () => {
+    // Given — 갱신 요청이 401(SESSION_0704: 토큰 재사용 감지)
+    fetchMock.mockResolvedValue(errorBody(401, 'AUTH_0105', 're-login required'));
+    requestRefresh.mockResolvedValue(errorBody(401, 'SESSION_0704', 'reuse detected'));
+
+    // When
+    const result = await http.get('todos');
+
+    // Then — 진짜 세션 종료: endSession 호출 + Result.err(ApiError)
+    expect(endSession).toHaveBeenCalledWith({
+      reason: 'refresh-rejected',
+      serverErrorCode: 'SESSION_0704',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ApiError);
+      expect(result.error.status).toBe(401);
+      expect(result.error.code).toBe('AUTH_0105');
+    }
+  });
+});

--- a/apps/mobile/src/shared/infra/http/auth-client.ts
+++ b/apps/mobile/src/shared/infra/http/auth-client.ts
@@ -31,6 +31,9 @@ export const createAuthClient = ({
   clientRef.current = ky.create({
     prefixUrl: ENV.API_URL,
     timeout: 10_000,
+    // 재시도 정책은 React Query가 소유한다(`shouldRetryQuery`). ky가 401 훅 throw나 5xx를
+    // 자체 재시도하면 갱신 훅과 겹쳐 토큰 패밀리를 소모하고 재시도 횟수가 이중 계산된다.
+    retry: 0,
     headers: {
       'Content-Type': 'application/json',
       'X-Timezone': getDeviceTimezone(),

--- a/apps/mobile/src/shared/infra/http/token-refresh-hook.test.ts
+++ b/apps/mobile/src/shared/infra/http/token-refresh-hook.test.ts
@@ -55,7 +55,8 @@ describe('createTokenRefreshHook', () => {
   });
 
   it('재시도 마커가 있으면 갱신 없이 응답을 반환한다 (루프 가드)', async () => {
-    // Given
+    // Given — 갱신 성공 후 재시도가 다시 401. 다시 갱신하면 무한 루프이므로 원 401을 반환하고,
+    // 화면별 QueryErrorBoundary가 로컬 재시도로 담는다.
     const response = createFakeResponse(401);
     const request = createFakeRequest({ [RETRY_MARKER_HEADER]: '1' });
 
@@ -66,6 +67,7 @@ describe('createTokenRefreshHook', () => {
     expect(result).toBe(response);
     expect(refresh).not.toHaveBeenCalled();
     expect(retry).not.toHaveBeenCalled();
+    expect(endSession).not.toHaveBeenCalled();
   });
 
   it('보낸 토큰이 저장된 토큰과 다르면(이미 회전됨) 갱신 없이 재시도한다', async () => {
@@ -148,7 +150,7 @@ describe('createTokenRefreshHook', () => {
     // When
     const result = await invokeHook(request, response);
 
-    // Then
+    // Then — 원 401을 반환(로컬 QueryErrorBoundary가 담음), 세션 종료 없음
     expect(endSession).not.toHaveBeenCalled();
     expect(retry).not.toHaveBeenCalled();
     expect(result).toBe(response);
@@ -163,7 +165,7 @@ describe('createTokenRefreshHook', () => {
     // When
     const result = await invokeHook(createFakeRequest(), response);
 
-    // Then
+    // Then — 갱신 경로로 넘어가 일시 실패로 판정되고, 세션은 끝나지 않는다
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(endSession).not.toHaveBeenCalled();
     expect(result).toBe(response);

--- a/apps/mobile/src/shared/infra/http/token-refresh-hook.ts
+++ b/apps/mobile/src/shared/infra/http/token-refresh-hook.ts
@@ -24,6 +24,7 @@ export interface TokenRefreshHookDeps {
  * - 이미 다른 flight가 토큰을 회전한 뒤 도착한 401(stale token)은 갱신 없이
  *   바로 재시도한다 — 불필요한 갱신은 서버의 토큰 패밀리를 소모시킨다.
  * - 갱신 실패 시 원 401 응답을 그대로 반환해 ky-client가 ApiError로 일관 번역하게 한다.
+ *   이 ApiError는 화면별 `QueryErrorBoundary`가 로컬 재시도로 담는다(앱 레벨로 새지 않음).
  *
  * 세션 종료 여부는 갱신 결과(`RefreshOutcome`)만 보고 판단한다.
  * `transient-failure`(네트워크·5xx·잠긴 키체인)에서는 절대 세션을 끝내지 않는다.

--- a/apps/mobile/src/shared/ui/QueryErrorBoundary/QueryErrorBoundary.tsx
+++ b/apps/mobile/src/shared/ui/QueryErrorBoundary/QueryErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { useErrorReporter } from '@src/bootstrap/providers/di-context';
-import { toError } from '@src/shared/errors';
+import { classifyBoundaryError, toError } from '@src/shared/errors';
 import { useTranslation } from '@src/shared/i18n';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -26,6 +26,10 @@ export function QueryErrorBoundary({ children, fallback }: QueryErrorBoundaryPro
         <ErrorBoundary
           onReset={reset}
           onError={(error) => {
+            // 로컬에 담기는 일시적 401은 리포트하지 않는다 — 콜드스타트마다 Sentry가 울린다.
+            if (classifyBoundaryError(error) === 'auth-transition') {
+              return;
+            }
             errorReporter.captureException(toError(error), { feature: 'error_boundary' });
           }}
           fallbackRender={({ error, resetErrorBoundary }) =>

--- a/apps/mobile/src/shared/ui/index.ts
+++ b/apps/mobile/src/shared/ui/index.ts
@@ -64,6 +64,7 @@ export {
   PinFilledIcon,
   PinIcon,
   PlusIcon,
+  RefreshIcon,
   RepeatIcon,
   RobotIcon,
   RobotPixelIcon,


### PR DESCRIPTION
# Release v1.4.3

> `905c08a5` → `4c423205` | `develop` → `main`

살아있는 세션에서 발생한 401이 앱 레벨 `ErrorBoundary`까지 새어 **"인증 정보가 올바르지 않아요. 다시 로그인해주세요."** 전체화면이 뜨던 문제를 고칩니다(로그아웃이 아닌데 로그아웃처럼 보임). 콜드스타트/업데이트 직후 병렬 401 다발이 회전 레이스로 앱 레벨까지 도달하던 회귀(1.3.4~1.4.2)입니다. **`apps/api` 변경 없음. DB 마이그레이션 없음. 사용자 노출 문자열 변경 없음.**

---

## 🐛 Fixes

**살아있는 세션의 401이 앱 레벨로 새어 "다시 로그인" 화면을 띄웠다**
일부 suspense 쿼리가 `QueryErrorBoundary` 없이 `<Suspense>`만 감싸져 있어, 회전 레이스/일시적 401이 앱 레벨 라우트 바운더리까지 도달했습니다. 화면별 `QueryErrorBoundary` **컨테인먼트**로 그 구역 로컬 재시도에 담아, 앱 레벨로 새지 않게 했습니다(crabit/1.3.x 검증 모델). 메운 구멍: `memo`의 `Header`(→ `Header.Error` 폴백), `mypage`의 `AccountActionButtons`.

**로컬 QEB가 일시적 401까지 Sentry로 리포트해 노이즈가 쌓였다**
컨테인먼트로 로컬에 담아도 `QueryErrorBoundary.onError`가 잡은 401을 무조건 리포트해, 콜드스타트마다 `AIDO-MOBILE-PRODUCTION-3`가 계속 울렸습니다. `classifyBoundaryError`가 `auth-transition`(401)으로 판정하면 리포트를 건너뜁니다. 로컬 재시도 폴백은 그대로 유지됩니다.

**컨테인먼트 구멍이 있으면 흰 화면(null)으로 굳을 수 있었다**
앱 레벨 바운더리가 401을 무조건 조용히 넘기면, 살아있는 세션의 401이 QEB 구멍으로 새어왔을 때 아무것도 안 그리고 로그인 게이트도 안 뜨는 먹통 화면이 됩니다. `status !== 'authenticated'` 안전망을 두어, 세션이 살아있는데 새어온 401은 **빈 화면 대신 재시도 UI + 리포트**로 처리합니다(구멍을 관측 가능하게).

**재시도 버튼이 `+`로 보여 무슨 동작인지 헷갈렸다**
`memo` `Header.Error`의 폴백 버튼이 생성 아이콘(`PlusIcon`) 그대로라 재시도임을 알기 어려웠습니다. `RefreshIcon`으로 바꾸고, 리터럴 `color="white"` 대신 `colorClassName` 토큰 + `gray-8`/`white` 고대비 짝으로 **다크/라이트 모두 또렷하게** 대응했습니다.

## 🏗️ 구조 변경

- `classifyBoundaryError`는 **순수 함수**로 유지 — 던져진 게 401(인증 계열)인지 진짜 장애인지만 판정하고, 의도적으로 `status`를 보지 않습니다(레이스 프리). `status`와 결합한 최종 판단은 호출부(앱 레벨 바운더리)의 몫입니다.
- 재시도 정책은 **React Query가 단독 소유**합니다(`query-retry.ts`의 `shouldRetryQuery`: 401/403·비즈니스 에러는 no-retry). `auth-client`에 `retry: 0`을 두어 ky 자체 재시도가 갱신 훅과 겹쳐 토큰 패밀리를 소모하지 않도록 했습니다.
- 세션 종료는 여전히 **이벤트 구동**입니다: `SessionManager.end → emitSessionExpired → auth-provider status flip → 로그인`. QEB가 401을 로컬에 담아도, 진짜 만료면 status flip으로 앱 전체가 로그인으로 재게이트됩니다.

## 🧪 검증

| 항목 | 결과 |
|------|------|
| `pnpm typecheck` | pass |
| `pnpm lint` | clean (+ 순환 참조 0) |
| mobile 테스트 | **76 suites / 857 tests** |
| Metro 번들 (`expo export --platform ios·android`) | 성공 |
| CI (Build · Lint & Type Check · Test) | 3/3 pass |

**대조군으로 확인한 것** (통과만으로는 증명되지 않는 것들):

- **통합 테스트** `auth-client.test.ts`: 실제 ky 인스턴스 + 실제 갱신 훅을 `createAuthClient`와 동일 배선으로 조립하고 `global.fetch`만 스텁. 계약 3종 고정 — (a) 갱신 성공 시 재시도로 데이터 반환, (b) **재시도도 401이면 로그아웃 없이 `Result.err(ApiError)`로 담김**(화면 QEB가 흡수), (c) 서버가 리프레시 거부(`session-invalid`) 시에만 `endSession`.
- **시뮬레이터 콜드스타트**: 401 다발이 앱 레벨 에러 화면 없이 로컬에 담기고, 피드 정상 로드(계측으로 `refresh() → refreshed` 확인).
- **Gemini 리뷰 2건 반영·resolve**: `status !== 'authenticated'` 안전망(HIGH), 재시도 아이콘 `RefreshIcon`(MEDIUM).

## 📦 영향

**기존 유저 영향 없음.** 토큰 삭제 경로 불변식 유지 — 삭제는 여전히 `SessionManager.end()`와 명시적 로그아웃 두 경로뿐입니다. 업데이트/재실행/알림 진입 어느 경로에서도 살아있는 세션의 401이 강제 로그아웃처럼 보이지 않습니다.

> `chore`: Sentry MCP 서버 설정(`.mcp.json`)이 함께 포함됩니다 — 개발 도구 설정일 뿐 런타임/사용자 영향 없음(시크릿 없음).

## 📱 버전

`1.4.2` → **`1.4.3`** (`app.config.ts`, `apps/mobile/package.json`)
