### PR TITLE
fix(api): Redis 장애 격리 — 단절 시 API hang 제거 (연결 이원화 + fail-fast + 포트 계약)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ JWT_EXPIRES_IN="7d"
 
 # --- Redis ---
 # REDIS_URL=redis://localhost:6379
+# 명령용 클라이언트 fail-fast 타임아웃 (기본값: 1500 / 5000)
+# REDIS_COMMAND_TIMEOUT_MS=1500
+# REDIS_CONNECT_TIMEOUT_MS=5000
 
 # --- Mobile (Expo) ---
 EXPO_PUBLIC_API_URL="http://localhost:3000"

--- a/apps/api/.claude/architecture.md
+++ b/apps/api/.claude/architecture.md
@@ -474,7 +474,7 @@ Prisma Unique Constraint 위반 시 비즈니스 예외로 자동 매핑:
 BullModule.forRootAsync({
   inject: [REDIS_CLIENT],
   useFactory: (redis: Redis) => ({
-    connection: redis as never,
+    connection: redis,
     defaultJobOptions: {
       attempts: 3,
       backoff: { type: "exponential" as const, delay: 1_000 },
@@ -832,12 +832,37 @@ this.encryptionService.decryptSafe(account.accessToken)
 | `ExceptionModule` | `common/exception/` | `GlobalExceptionFilter` |
 | `ResponseModule` | `common/response/` | `ResponseTransformInterceptor` |
 | `PaginationModule` | `common/pagination/` | `PaginationService` |
-| `RedisModule` | `common/redis/` | `REDIS_CLIENT` (ioredis) |
+| `RedisModule` | `common/redis/` | `REDIS_CLIENT` (BullMQ 전용), `REDIS_COMMAND_CLIENT` (명령용 fail-fast) |
 | `LockModule` | `common/lock/` | `ILockProvider` (Redis/InMemory Strategy) |
 | `EntitlementModule` | `common/entitlement/` | `EntitlementService` (플랜별 제한) |
 | `DedupModule` | `common/dedup/` | 알림 중복 방지 |
 
 > `@Global()` 모듈은 `imports` 없이 어디서든 DI 가능.
+
+### 5.1.1 Redis 연결 이원화 & 장애 격리 (포트 계약)
+
+Redis 장애 시 API가 hang하지 않도록 연결을 용도별로 분리한다:
+
+| 토큰 | 옵션 | 사용처 |
+|------|------|--------|
+| `REDIS_CLIENT` | `maxRetriesPerRequest: null`, 오프라인 큐 유지 | **BullMQ 전용** (블로킹 명령 호환). 다른 곳에 주입 금지 |
+| `REDIS_COMMAND_CLIENT` | `enableOfflineQueue: false`, `commandTimeout` 1.5s, `maxRetriesPerRequest: 1` | 캐시/락/스로틀/dedup/푸시 레이트리미터/헬스 ping — 단절 시 즉시 reject |
+
+포트별 장애 계약 (인터페이스 JSDoc에 명문화, 새 어댑터도 준수 필수):
+
+| 포트 | 정책 | 장애 시 동작 |
+|------|------|------------|
+| `ICacheService` | fail-open | 읽기=미스 취급(→DB 폴백), 쓰기=무시. 계약 스펙: `cache-adapter.contract.ts` |
+| `ILockProvider` | fail-closed | acquire=null(busy), release=무시(TTL 정리), isLocked=true |
+| `IDedupProvider` | fail-open | 비중복 취급 (DB unique index가 최종 방어선) |
+| `ThrottlerStorage` (`THROTTLER_STORAGE`) | fail-open | 요청 허용 |
+
+관련 규칙:
+- 에러 로그는 `RedisErrorLogSampler`(30초 윈도우당 1회 + suppressed 카운트)로 남긴다
+- `JwtStrategy`는 세션 캐시 실패 시 DB로 폴백 — Redis 완전 다운이어도 인증 정상
+- `JwtAuthGuard.handleRequest`는 비-HttpException(인프라 오류)을 401로 위장하지 않고 rethrow (401은 클라 강제 로그아웃 유발 — 5xx는 토큰 보존)
+- `/health`의 `queues`는 절대 down(503)을 만들지 않는다 — Redis 다운 시 `up + degraded: true` (재시작으로 해결 불가하므로 ALB가 태스크를 죽이면 안 됨)
+- 연결 종료는 `onApplicationShutdown`에서 quit(3s 타임아웃) → disconnect 폴백
 
 ### 5.2 Dynamic Module 패턴
 

--- a/apps/api/DEPLOYMENT.md
+++ b/apps/api/DEPLOYMENT.md
@@ -174,7 +174,8 @@ Build → Push to ECR → Run Migration Task → Deploy API Service
 
 | 변수 | 필수 | 기본값 | 설명 |
 |------|------|--------|------|
-| `NODE_ENV` | - | development | 실행 환경 |
+| `NODE_ENV` | - | development | 런타임 모드 (빌드 최적화 기준) |
+| `APP_ENV` | - | NODE_ENV 폴백 | 배포 환경 (`development`/`staging`/`production`). **Sentry는 `production`에서만 발송** — 개발서버는 반드시 `APP_ENV=development` 설정 |
 | `PORT` | - | 8080 | API 포트 |
 | `DATABASE_URL` | Y | - | PostgreSQL 연결 URL |
 | `JWT_SECRET` | Y | - | JWT 서명 키 (min 32자) |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -57,7 +57,7 @@
 		"expo-server-sdk": "^5.0.0",
 		"google-auth-library": "^10.6.2",
 		"helmet": "^8.2.0",
-		"ioredis": "^5.11.0",
+		"ioredis": "5.10.1",
 		"jose": "^6.2.3",
 		"nestjs-pino": "^4.6.1",
 		"nestjs-zod": "^5.4.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,7 +2,11 @@ import { BullModule } from "@nestjs/bullmq";
 import { Module } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { APP_GUARD, APP_INTERCEPTOR } from "@nestjs/core";
-import { ThrottlerGuard, ThrottlerModule } from "@nestjs/throttler";
+import {
+	ThrottlerGuard,
+	ThrottlerModule,
+	type ThrottlerStorage,
+} from "@nestjs/throttler";
 import { SentryModule } from "@sentry/nestjs/setup";
 import type Redis from "ioredis";
 import {
@@ -20,7 +24,7 @@ import {
 	ResponseModule,
 } from "@/common";
 import type { EnvConfig } from "@/common/config";
-import { RedisThrottlerStorage } from "@/common/throttle";
+import { THROTTLER_STORAGE, ThrottleModule } from "@/common/throttle";
 import { DatabaseModule } from "@/database";
 import { AdminModule } from "@/modules/admin";
 import { AdminNotificationModule } from "@/modules/admin-notification";
@@ -66,8 +70,7 @@ import { AppService } from "./app.service";
 		BullModule.forRootAsync({
 			inject: [REDIS_CLIENT],
 			useFactory: (redis: Redis) => ({
-				// ioredis 직접 설치 버전 vs bullmq 번들 버전 차이로 인한 타입 캐스팅
-				connection: redis as never,
+				connection: redis,
 				defaultJobOptions: {
 					attempts: 3,
 					backoff: { type: "exponential" as const, delay: 1_000 },
@@ -83,17 +86,19 @@ import { AppService } from "./app.service";
 		ResponseModule,
 		PaginationModule,
 		ThrottlerModule.forRootAsync({
-			inject: [ConfigService, { token: REDIS_CLIENT, optional: true }],
-			useFactory: (config: ConfigService<EnvConfig, true>, redis?: Redis) => ({
+			imports: [ThrottleModule.forRoot()],
+			inject: [ConfigService, { token: THROTTLER_STORAGE, optional: true }],
+			useFactory: (
+				config: ConfigService<EnvConfig, true>,
+				storage?: ThrottlerStorage,
+			) => ({
 				throttlers: [
 					{
 						ttl: config.get("THROTTLE_TTL", { infer: true }),
 						limit: config.get("THROTTLE_LIMIT", { infer: true }),
 					},
 				],
-				...(redis && {
-					storage: new RedisThrottlerStorage(redis),
-				}),
+				...(storage && { storage }),
 			}),
 		}),
 

--- a/apps/api/src/common/bullmq/non-blocking-init.spec.ts
+++ b/apps/api/src/common/bullmq/non-blocking-init.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * runInBackground 단위 테스트
+ *
+ * @description
+ * BullMQ 스케줄러 등록 등 Redis 의존 부트 작업이 앱 기동을 블로킹하지
+ * 않도록 하는 fire-and-forget 헬퍼를 검증합니다.
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test non-blocking-init
+ * ```
+ */
+import { runInBackground } from "./non-blocking-init";
+
+describe("runInBackground — 부팅 논블로킹 초기화", () => {
+	it("작업이 pending이어도 즉시 프로미스를 반환한다 (블로킹 없음)", () => {
+		// Given — Redis 다운: 영원히 pending인 작업
+		const logger = { error: jest.fn() };
+		const neverResolves = () => new Promise<void>(() => {});
+
+		// When — 동기적으로 반환되는지 (await 없이)
+		const result = runInBackground(logger, "test", neverResolves);
+
+		// Then
+		expect(result).toBeInstanceOf(Promise);
+	});
+
+	it("작업 성공 시 에러 로그를 남기지 않는다", async () => {
+		// Given
+		const logger = { error: jest.fn() };
+		const task = jest.fn().mockResolvedValue(undefined);
+
+		// When
+		await runInBackground(logger, "test", task);
+
+		// Then
+		expect(task).toHaveBeenCalledTimes(1);
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it("작업 실패 시 reject하지 않고 에러 로그만 남긴다 (unhandled rejection 방지)", async () => {
+		// Given
+		const logger = { error: jest.fn() };
+		const task = () => Promise.reject(new Error("Connection is closed."));
+
+		// When / Then — reject되지 않아야 한다
+		await expect(
+			runInBackground(logger, "Scheduler registration", task),
+		).resolves.toBeUndefined();
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("Scheduler registration failed"),
+		);
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("Connection is closed."),
+		);
+	});
+});

--- a/apps/api/src/common/bullmq/non-blocking-init.ts
+++ b/apps/api/src/common/bullmq/non-blocking-init.ts
@@ -1,0 +1,24 @@
+import type { Logger } from "@nestjs/common";
+
+/**
+ * 부팅을 블로킹하지 않는 초기화 실행 (fire-and-forget)
+ *
+ * BullMQ 스케줄러 등록처럼 Redis에 의존하는 부트 작업을 onModuleInit에서
+ * await하면 Redis 장애 중 앱 기동 자체가 멈춘다. 이 헬퍼는 작업을
+ * 백그라운드로 넘기고 실패는 로그로만 남긴다 — BullMQ 연결은 오프라인
+ * 큐를 유지하므로 Redis 재연결 시 등록 명령이 마저 실행되어 유실되지
+ * 않는다.
+ *
+ * @returns 절대 reject하지 않는 프로미스 — 테스트에서 완료 대기용
+ */
+export function runInBackground(
+	logger: Pick<Logger, "error">,
+	label: string,
+	task: () => Promise<void>,
+): Promise<void> {
+	return task().catch((error: unknown) => {
+		logger.error(
+			`${label} failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	});
+}

--- a/apps/api/src/common/cache/adapters/cache-adapter.contract.ts
+++ b/apps/api/src/common/cache/adapters/cache-adapter.contract.ts
@@ -1,0 +1,145 @@
+import type { ICacheService } from "../interfaces/cache.interface";
+
+/**
+ * ICacheService 계약 공유 테스트
+ *
+ * 모든 캐시 어댑터(in-memory, Redis, 향후 다른 백엔드)가 동일하게
+ * 통과해야 하는 behavioral spec. 어댑터 교체 가능성의 증명이며,
+ * 새 어댑터를 만들면 이 함수를 spec에서 호출해 계약 준수를 검증한다.
+ *
+ * @example
+ * describeCacheAdapterContract({
+ *   createAdapter: () => new MyCacheAdapter(...),
+ *   cleanup: (adapter) => adapter.reset(),
+ * });
+ */
+export function describeCacheAdapterContract(context: {
+	createAdapter: () => ICacheService;
+	cleanup?: (adapter: ICacheService) => Promise<void> | void;
+}): void {
+	describe("ICacheService 계약", () => {
+		let cache: ICacheService;
+
+		beforeEach(() => {
+			cache = context.createAdapter();
+		});
+
+		afterEach(async () => {
+			await context.cleanup?.(cache);
+		});
+
+		it("set한 값을 get으로 조회할 수 있다", async () => {
+			// Given
+			const value = { foo: "bar", count: 3 };
+
+			// When
+			await cache.set("contract:key", value);
+			const result = await cache.get<typeof value>("contract:key");
+
+			// Then
+			expect(result).toEqual(value);
+		});
+
+		it("존재하지 않는 키는 undefined를 반환한다", async () => {
+			// When
+			const result = await cache.get("contract:missing");
+
+			// Then
+			expect(result).toBeUndefined();
+		});
+
+		it("del한 키는 조회되지 않는다", async () => {
+			// Given
+			await cache.set("contract:key", "value");
+
+			// When
+			await cache.del("contract:key");
+
+			// Then
+			expect(await cache.get("contract:key")).toBeUndefined();
+		});
+
+		it("has는 키 존재 여부를 반환한다", async () => {
+			// Given
+			await cache.set("contract:key", "value");
+
+			// Then
+			expect(await cache.has("contract:key")).toBe(true);
+			expect(await cache.has("contract:missing")).toBe(false);
+		});
+
+		it("존재하지 않는 키의 ttl은 -2를 반환한다", async () => {
+			// When
+			const result = await cache.ttl("contract:missing");
+
+			// Then
+			expect(result).toBe(-2);
+		});
+
+		it("touch는 존재하지 않는 키에 false를 반환한다", async () => {
+			// When
+			const result = await cache.touch("contract:missing", 1000);
+
+			// Then
+			expect(result).toBe(false);
+		});
+
+		it("touch는 존재하는 키의 TTL을 갱신하고 true를 반환한다", async () => {
+			// Given
+			await cache.set("contract:key", "value", 1000);
+
+			// When
+			const result = await cache.touch("contract:key", 60_000);
+
+			// Then
+			expect(result).toBe(true);
+		});
+
+		it("mset한 값들을 mget으로 조회하고, 없는 키는 undefined로 채운다", async () => {
+			// Given
+			await cache.mset([
+				{ key: "contract:a", value: 1 },
+				{ key: "contract:b", value: 2 },
+			]);
+
+			// When
+			const result = await cache.mget<number>([
+				"contract:a",
+				"contract:missing",
+				"contract:b",
+			]);
+
+			// Then
+			expect(result).toEqual([1, undefined, 2]);
+		});
+
+		it("wrap은 캐시 미스 시 factory를 실행하고 결과를 캐싱한다", async () => {
+			// Given
+			const factory = jest.fn().mockResolvedValue("fresh");
+
+			// When
+			const first = await cache.wrap("contract:wrap", factory);
+			const second = await cache.wrap("contract:wrap", factory);
+
+			// Then
+			expect(first).toBe("fresh");
+			expect(second).toBe("fresh");
+			expect(factory).toHaveBeenCalledTimes(1);
+		});
+
+		it("delByPattern은 패턴에 매칭되는 키를 삭제하고 개수를 반환한다", async () => {
+			// Given
+			await cache.set("contract:user:1", "a");
+			await cache.set("contract:user:2", "b");
+			await cache.set("contract:other", "c");
+
+			// When
+			const deleted = await cache.delByPattern("contract:user:*");
+
+			// Then
+			expect(deleted).toBe(2);
+			expect(await cache.get("contract:user:1")).toBeUndefined();
+			expect(await cache.get("contract:other")).toBe("c");
+		});
+	});
+}

--- a/apps/api/src/common/cache/adapters/in-memory-cache.adapter.spec.ts
+++ b/apps/api/src/common/cache/adapters/in-memory-cache.adapter.spec.ts
@@ -9,9 +9,29 @@
  * pnpm --filter @aido/api test in-memory-cache.adapter
  * ```
  */
+import { describeCacheAdapterContract } from "./cache-adapter.contract";
 import { InMemoryCacheAdapter } from "./in-memory-cache.adapter";
 
 describe("InMemoryCacheAdapter — 인메모리 캐시 어댑터", () => {
+	// Redis 어댑터와 동일한 ICacheService 계약 준수 검증 (교체 가능성 증명)
+	const createdAdapters: InMemoryCacheAdapter[] = [];
+
+	describeCacheAdapterContract({
+		createAdapter: () => {
+			const adapter = new InMemoryCacheAdapter({
+				defaultTtlMs: 60_000,
+				maxItems: 100,
+			});
+			createdAdapters.push(adapter);
+			return adapter;
+		},
+		cleanup: async () => {
+			const adapter = createdAdapters.pop();
+			await adapter?.reset();
+			adapter?.onModuleDestroy();
+		},
+	});
+
 	let cache: InMemoryCacheAdapter;
 
 	beforeEach(() => {

--- a/apps/api/src/common/cache/adapters/redis-cache.adapter.spec.ts
+++ b/apps/api/src/common/cache/adapters/redis-cache.adapter.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * RedisCacheAdapter 단위 테스트
+ *
+ * @description
+ * - ICacheService 계약 준수 (ioredis-mock — in-memory 어댑터와 동일 계약)
+ * - Redis 장애 시 fail-open: 읽기는 미스 취급, 쓰기는 조용히 무시
+ * - 로그 샘플러: 장애 중 로그 폭발 방지
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test redis-cache.adapter
+ * ```
+ */
+import RedisMock from "ioredis-mock";
+import { RedisErrorLogSampler } from "../../redis/redis-error-log-sampler";
+import { describeCacheAdapterContract } from "./cache-adapter.contract";
+import { RedisCacheAdapter } from "./redis-cache.adapter";
+
+describe("RedisCacheAdapter — Redis 캐시 어댑터", () => {
+	describeCacheAdapterContract({
+		createAdapter: () => new RedisCacheAdapter(new RedisMock(), 60_000),
+		cleanup: (adapter) => adapter.reset(),
+	});
+
+	describe("fail-open (Redis 장애 시)", () => {
+		const failure = new Error("Connection is closed.");
+		let redis: InstanceType<typeof RedisMock>;
+		let warn: jest.Mock;
+		let cache: RedisCacheAdapter;
+
+		beforeEach(() => {
+			redis = new RedisMock();
+			warn = jest.fn();
+			cache = new RedisCacheAdapter(
+				redis,
+				60_000,
+				new RedisErrorLogSampler({ warn }),
+			);
+		});
+
+		it("get 실패 시 캐시 미스(undefined)로 취급한다", async () => {
+			// Given
+			jest.spyOn(redis, "get").mockRejectedValue(failure);
+
+			// When
+			const result = await cache.get("key");
+
+			// Then
+			expect(result).toBeUndefined();
+		});
+
+		it("mget 실패 시 전원 undefined를 반환한다", async () => {
+			// Given
+			jest.spyOn(redis, "mget").mockRejectedValue(failure);
+
+			// When
+			const result = await cache.mget(["a", "b", "c"]);
+
+			// Then
+			expect(result).toEqual([undefined, undefined, undefined]);
+		});
+
+		it("has 실패 시 false를 반환한다", async () => {
+			// Given
+			jest.spyOn(redis, "exists").mockRejectedValue(failure);
+
+			// When / Then
+			expect(await cache.has("key")).toBe(false);
+		});
+
+		it("ttl 실패 시 -2(키 없음)를 반환한다", async () => {
+			// Given
+			jest.spyOn(redis, "pttl").mockRejectedValue(failure);
+
+			// When / Then
+			expect(await cache.ttl("key")).toBe(-2);
+		});
+
+		it("touch 실패 시 false를 반환한다", async () => {
+			// Given
+			jest.spyOn(redis, "pexpire").mockRejectedValue(failure);
+
+			// When / Then
+			expect(await cache.touch("key", 1000)).toBe(false);
+		});
+
+		it("set/del/mset 실패는 조용히 무시한다 (throw하지 않음)", async () => {
+			// Given
+			jest.spyOn(redis, "set").mockRejectedValue(failure);
+			jest.spyOn(redis, "del").mockRejectedValue(failure);
+			jest.spyOn(redis, "pipeline").mockImplementation(() => {
+				throw failure;
+			});
+
+			// When / Then
+			await expect(cache.set("key", "value")).resolves.toBeUndefined();
+			await expect(cache.del("key")).resolves.toBeUndefined();
+			await expect(
+				cache.mset([{ key: "a", value: 1 }]),
+			).resolves.toBeUndefined();
+		});
+
+		it("delByPattern 실패 시 지금까지 삭제한 개수를 반환한다", async () => {
+			// Given
+			jest.spyOn(redis, "scan").mockRejectedValue(failure);
+
+			// When / Then
+			expect(await cache.delByPattern("user:*")).toBe(0);
+		});
+
+		it("reset 실패는 조용히 무시한다", async () => {
+			// Given
+			jest.spyOn(redis, "scan").mockRejectedValue(failure);
+
+			// When / Then
+			await expect(cache.reset()).resolves.toBeUndefined();
+		});
+
+		it("wrap은 get 실패 시 factory 결과를 그대로 반환한다 (DB 폴백)", async () => {
+			// Given
+			jest.spyOn(redis, "get").mockRejectedValue(failure);
+			jest.spyOn(redis, "set").mockRejectedValue(failure);
+			const factory = jest.fn().mockResolvedValue("from-db");
+
+			// When
+			const result = await cache.wrap("key", factory);
+
+			// Then
+			expect(result).toBe("from-db");
+			expect(factory).toHaveBeenCalledTimes(1);
+		});
+
+		it("장애 중 반복 에러는 샘플러가 억제한다 (warn 1회)", async () => {
+			// Given
+			jest.spyOn(redis, "get").mockRejectedValue(failure);
+
+			// When
+			for (let i = 0; i < 50; i++) {
+				await cache.get("key");
+			}
+
+			// Then
+			expect(warn).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/apps/api/src/common/cache/adapters/redis-cache.adapter.ts
+++ b/apps/api/src/common/cache/adapters/redis-cache.adapter.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import type Redis from "ioredis";
+import { RedisErrorLogSampler } from "../../redis/redis-error-log-sampler";
 import type {
 	CacheStats,
 	ICacheService,
@@ -10,8 +11,15 @@ import { parseTtl } from "../interfaces/cache.interface";
 /**
  * Redis 캐시 어댑터
  *
- * 공유 ioredis 인스턴스를 사용하여 Redis 캐시를 구현합니다.
- * RedisModule이 제공하는 REDIS_CLIENT를 주입받아 사용합니다.
+ * RedisModule이 제공하는 REDIS_COMMAND_CLIENT(fail-fast 연결)를 주입받아
+ * 사용합니다.
+ *
+ * 장애 정책 — fail-open (ICacheService 계약):
+ * - 읽기(get/mget/has/ttl/touch)는 실패 시 캐시 미스로 취급 → 소비처가
+ *   원본(DB)으로 폴백한다
+ * - 쓰기(set/mset/del/reset)는 실패 시 조용히 무시 — TTL이 staleness
+ *   상한이므로 복구 후 자연 소멸한다
+ * - 에러 로그는 RedisErrorLogSampler로 윈도우당 1회만 남긴다
  *
  * Redis 명령어 매핑:
  * - get()         → GET + JSON.parse
@@ -34,38 +42,62 @@ export class RedisCacheAdapter implements ICacheService {
 	readonly #defaultTtlMs: number;
 	readonly #keyPrefix = "cache:";
 	readonly #inflight = new Map<string, Promise<unknown>>();
+	readonly #errorSampler: RedisErrorLogSampler;
 	#stats = { hits: 0, misses: 0 };
 
-	constructor(redis: Redis, defaultTtlMs: number) {
+	constructor(
+		redis: Redis,
+		defaultTtlMs: number,
+		errorSampler?: RedisErrorLogSampler,
+	) {
 		this.#redis = redis;
 		this.#defaultTtlMs = defaultTtlMs;
+		this.#errorSampler = errorSampler ?? new RedisErrorLogSampler(this.#logger);
 		this.#logger.log("RedisCacheAdapter initialized");
 	}
 
 	async get<T>(key: string): Promise<T | undefined> {
-		const data = await this.#redis.get(this.#keyPrefix + key);
+		return this.#failOpen(
+			"GET",
+			async () => {
+				const data = await this.#redis.get(this.#keyPrefix + key);
 
-		if (data === null) {
-			this.#stats.misses++;
-			return undefined;
-		}
+				if (data === null) {
+					this.#stats.misses++;
+					return undefined;
+				}
 
-		this.#stats.hits++;
-		return JSON.parse(data) as T;
+				this.#stats.hits++;
+				return JSON.parse(data) as T;
+			},
+			undefined,
+		);
 	}
 
 	async set<T>(key: string, value: T, ttl?: TtlValue): Promise<void> {
-		const ttlMs = ttl ? parseTtl(ttl) : this.#defaultTtlMs;
-		await this.#redis.set(
-			this.#keyPrefix + key,
-			JSON.stringify(value),
-			"PX",
-			ttlMs,
+		await this.#failOpen(
+			"SET",
+			async () => {
+				const ttlMs = ttl ? parseTtl(ttl) : this.#defaultTtlMs;
+				await this.#redis.set(
+					this.#keyPrefix + key,
+					JSON.stringify(value),
+					"PX",
+					ttlMs,
+				);
+			},
+			undefined,
 		);
 	}
 
 	async del(key: string): Promise<void> {
-		await this.#redis.del(this.#keyPrefix + key);
+		await this.#failOpen(
+			"DEL",
+			async () => {
+				await this.#redis.del(this.#keyPrefix + key);
+			},
+			undefined,
+		);
 	}
 
 	async delByPattern(pattern: string): Promise<number> {
@@ -73,47 +105,59 @@ export class RedisCacheAdapter implements ICacheService {
 		let cursor = "0";
 		let count = 0;
 
-		do {
-			const [nextCursor, keys] = await this.#redis.scan(
-				cursor,
-				"MATCH",
-				fullPattern,
-				"COUNT",
-				100,
-			);
-			cursor = nextCursor;
+		try {
+			do {
+				const [nextCursor, keys] = await this.#redis.scan(
+					cursor,
+					"MATCH",
+					fullPattern,
+					"COUNT",
+					100,
+				);
+				cursor = nextCursor;
 
-			if (keys.length > 0) {
-				await this.#redis.del(...keys);
-				count += keys.length;
-			}
-		} while (cursor !== "0");
+				if (keys.length > 0) {
+					await this.#redis.del(...keys);
+					count += keys.length;
+				}
+			} while (cursor !== "0");
+		} catch (error) {
+			// fail-open: 지금까지 삭제한 개수만 반환 — 남은 키는 TTL로 소멸
+			this.#errorSampler.warn("DEL_PATTERN", error);
+			return count;
+		}
 
 		this.#logger.debug(`DEL_PATTERN ${pattern} (${count} keys)`);
 		return count;
 	}
 
 	async reset(): Promise<void> {
-		const fullPattern = `${this.#keyPrefix}*`;
-		let cursor = "0";
+		await this.#failOpen(
+			"RESET",
+			async () => {
+				const fullPattern = `${this.#keyPrefix}*`;
+				let cursor = "0";
 
-		do {
-			const [nextCursor, keys] = await this.#redis.scan(
-				cursor,
-				"MATCH",
-				fullPattern,
-				"COUNT",
-				100,
-			);
-			cursor = nextCursor;
+				do {
+					const [nextCursor, keys] = await this.#redis.scan(
+						cursor,
+						"MATCH",
+						fullPattern,
+						"COUNT",
+						100,
+					);
+					cursor = nextCursor;
 
-			if (keys.length > 0) {
-				await this.#redis.del(...keys);
-			}
-		} while (cursor !== "0");
+					if (keys.length > 0) {
+						await this.#redis.del(...keys);
+					}
+				} while (cursor !== "0");
 
-		this.#stats = { hits: 0, misses: 0 };
-		this.#logger.debug("RESET completed");
+				this.#stats = { hits: 0, misses: 0 };
+				this.#logger.debug("RESET completed");
+			},
+			undefined,
+		);
 	}
 
 	getStats(): CacheStats {
@@ -128,6 +172,7 @@ export class RedisCacheAdapter implements ICacheService {
 		factory: () => Promise<T>,
 		ttl?: TtlValue,
 	): Promise<T> {
+		// get/set이 fail-open이므로 Redis 장애 시 자동으로 factory 직행 (DB 폴백)
 		const cached = await this.get<T>(key);
 		if (cached !== undefined) {
 			return cached;
@@ -161,17 +206,23 @@ export class RedisCacheAdapter implements ICacheService {
 	async mget<T>(keys: string[]): Promise<(T | undefined)[]> {
 		if (keys.length === 0) return [];
 
-		const prefixedKeys = keys.map((k) => this.#keyPrefix + k);
-		const values = await this.#redis.mget(...prefixedKeys);
+		return this.#failOpen(
+			"MGET",
+			async () => {
+				const prefixedKeys = keys.map((k) => this.#keyPrefix + k);
+				const values = await this.#redis.mget(...prefixedKeys);
 
-		return values.map((data) => {
-			if (data === null) {
-				this.#stats.misses++;
-				return undefined;
-			}
-			this.#stats.hits++;
-			return JSON.parse(data) as T;
-		});
+				return values.map((data) => {
+					if (data === null) {
+						this.#stats.misses++;
+						return undefined;
+					}
+					this.#stats.hits++;
+					return JSON.parse(data) as T;
+				});
+			},
+			keys.map(() => undefined),
+		);
 	}
 
 	async mset<T>(
@@ -179,26 +230,70 @@ export class RedisCacheAdapter implements ICacheService {
 	): Promise<void> {
 		if (entries.length === 0) return;
 
-		const pipeline = this.#redis.pipeline();
-		for (const { key, value, ttl } of entries) {
-			const ttlMs = ttl ? parseTtl(ttl) : this.#defaultTtlMs;
-			pipeline.set(this.#keyPrefix + key, JSON.stringify(value), "PX", ttlMs);
-		}
-		await pipeline.exec();
+		await this.#failOpen(
+			"MSET",
+			async () => {
+				const pipeline = this.#redis.pipeline();
+				for (const { key, value, ttl } of entries) {
+					const ttlMs = ttl ? parseTtl(ttl) : this.#defaultTtlMs;
+					pipeline.set(
+						this.#keyPrefix + key,
+						JSON.stringify(value),
+						"PX",
+						ttlMs,
+					);
+				}
+				await pipeline.exec();
+			},
+			undefined,
+		);
 	}
 
 	async has(key: string): Promise<boolean> {
-		const exists = await this.#redis.exists(this.#keyPrefix + key);
-		return exists === 1;
+		return this.#failOpen(
+			"EXISTS",
+			async () => {
+				const exists = await this.#redis.exists(this.#keyPrefix + key);
+				return exists === 1;
+			},
+			false,
+		);
 	}
 
 	async ttl(key: string): Promise<number> {
-		return this.#redis.pttl(this.#keyPrefix + key);
+		// fail-open 시 -2 = "키 없음" 시맨틱
+		return this.#failOpen(
+			"PTTL",
+			() => this.#redis.pttl(this.#keyPrefix + key),
+			-2,
+		);
 	}
 
 	async touch(key: string, ttl: TtlValue): Promise<boolean> {
-		const ttlMs = parseTtl(ttl);
-		const result = await this.#redis.pexpire(this.#keyPrefix + key, ttlMs);
-		return result === 1;
+		return this.#failOpen(
+			"PEXPIRE",
+			async () => {
+				const ttlMs = parseTtl(ttl);
+				const result = await this.#redis.pexpire(this.#keyPrefix + key, ttlMs);
+				return result === 1;
+			},
+			false,
+		);
+	}
+
+	/**
+	 * fail-open 래퍼: Redis 장애 시 fallback을 반환하고 샘플드 warn만 남긴다
+	 */
+	async #failOpen<T>(
+		operation: string,
+		action: () => Promise<T>,
+		fallback: T,
+	): Promise<T> {
+		try {
+			return await action();
+		} catch (error) {
+			this.#errorSampler.warn(operation, error);
+			return fallback;
+		}
 	}
 }

--- a/apps/api/src/common/cache/cache.module.ts
+++ b/apps/api/src/common/cache/cache.module.ts
@@ -6,7 +6,7 @@ import {
 } from "@nestjs/common";
 import type Redis from "ioredis";
 import { TypedConfigService } from "../config/services/config.service";
-import { REDIS_CLIENT } from "../redis/redis.constants";
+import { REDIS_COMMAND_CLIENT } from "../redis/redis.constants";
 import { InMemoryCacheAdapter } from "./adapters/in-memory-cache.adapter";
 import { RedisCacheAdapter } from "./adapters/redis-cache.adapter";
 import { CacheService } from "./cache.service";
@@ -59,7 +59,10 @@ export class CacheModule {
 					cleanupIntervalMs: cacheConfig.cleanupIntervalMs,
 				});
 			},
-			inject: [TypedConfigService, { token: REDIS_CLIENT, optional: true }],
+			inject: [
+				TypedConfigService,
+				{ token: REDIS_COMMAND_CLIENT, optional: true },
+			],
 		};
 
 		return {

--- a/apps/api/src/common/cache/interfaces/cache.interface.ts
+++ b/apps/api/src/common/cache/interfaces/cache.interface.ts
@@ -180,24 +180,3 @@ export interface CacheStats {
 	keys: number;
 	memoryUsage?: number; // bytes (인메모리 전용)
 }
-
-export interface CacheConfig {
-	type: "memory" | "redis";
-	defaultTtlMs: number;
-	maxItems: number;
-	cleanupIntervalMs?: number;
-	redis?: RedisConfig;
-}
-
-export interface RedisConfig {
-	host: string;
-	port: number;
-	password?: string;
-	db?: number;
-	/** 키 프리픽스 (기본값: 'aido:') */
-	keyPrefix?: string;
-	/** 연결 타임아웃 (밀리초) */
-	connectTimeout?: number;
-	/** 명령 타임아웃 (밀리초) */
-	commandTimeout?: number;
-}

--- a/apps/api/src/common/cache/interfaces/cache.interface.ts
+++ b/apps/api/src/common/cache/interfaces/cache.interface.ts
@@ -52,10 +52,23 @@ export function parseTtl(ttl: TtlValue): number {
 	return Number.parseInt(value, 10) * multipliers[unit];
 }
 
+/**
+ * 캐시 포트
+ *
+ * 장애 계약 (모든 어댑터가 지켜야 함 — fail-open):
+ * - 읽기(get/mget/has/ttl/touch)는 백엔드 장애 시 캐시 미스와 동일하게
+ *   동작한다 (get→undefined, has→false, ttl→-2, touch→false).
+ *   소비처는 미스 경로(DB 폴백)만 준비하면 장애를 따로 처리할 필요가 없다.
+ * - 쓰기(set/mset/del/reset)는 백엔드 장애 시 조용히 무시하고 절대
+ *   throw하지 않는다. TTL이 staleness의 상한이다.
+ *
+ * 이 계약을 지키는 새 어댑터는 소비처 변경 없이 교체 가능하다.
+ * 준수 여부는 `adapters/cache-adapter.contract.ts` 공유 스펙으로 검증한다.
+ */
 export interface ICacheService {
 	/**
 	 * 캐시에서 값 조회
-	 * @returns 캐시 미스 시 undefined
+	 * @returns 캐시 미스 시 undefined (백엔드 장애 시에도 undefined)
 	 */
 	get<T>(key: string): Promise<T | undefined>;
 

--- a/apps/api/src/common/config/schemas/app.schema.ts
+++ b/apps/api/src/common/config/schemas/app.schema.ts
@@ -7,6 +7,13 @@ export const appSchema = z.object({
 	NODE_ENV: z
 		.enum(["development", "production", "test"])
 		.default("development"),
+	/**
+	 * 배포 환경 — NODE_ENV(런타임 모드)와 분리된 개념.
+	 * 개발서버도 production 빌드(NODE_ENV=production)로 돌기 때문에
+	 * "실제 프로덕션" 구분은 이 값이 단일 진실이다 (Sentry 발송 게이트 등).
+	 * 미설정 시 NODE_ENV 기준 폴백 (config.service.appEnv 참조).
+	 */
+	APP_ENV: z.enum(["development", "staging", "production"]).optional(),
 	PORT: z.coerce.number().int().positive().default(8080),
 	LOG_LEVEL: z
 		.enum(["silent", "fatal", "error", "warn", "info", "debug", "trace"])

--- a/apps/api/src/common/config/schemas/cache.schema.ts
+++ b/apps/api/src/common/config/schemas/cache.schema.ts
@@ -12,6 +12,8 @@ export const cacheSchema = z.object({
 	REDIS_PORT: z.coerce.number().int().positive().optional(),
 	REDIS_PASSWORD: z.string().optional(),
 	REDIS_DB: z.coerce.number().int().min(0).optional(),
+	REDIS_COMMAND_TIMEOUT_MS: z.coerce.number().int().positive().default(1500),
+	REDIS_CONNECT_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
 });
 
 export type CacheEnvConfig = z.infer<typeof cacheSchema>;

--- a/apps/api/src/common/config/services/config.service.ts
+++ b/apps/api/src/common/config/services/config.service.ts
@@ -238,6 +238,8 @@ export class TypedConfigService {
 			port: this.get("REDIS_PORT"),
 			password: this.get("REDIS_PASSWORD"),
 			db: this.get("REDIS_DB"),
+			commandTimeoutMs: this.get("REDIS_COMMAND_TIMEOUT_MS"),
+			connectTimeoutMs: this.get("REDIS_CONNECT_TIMEOUT_MS"),
 		};
 	}
 

--- a/apps/api/src/common/config/services/config.service.ts
+++ b/apps/api/src/common/config/services/config.service.ts
@@ -52,6 +52,22 @@ export class TypedConfigService {
 		return this.get("NODE_ENV");
 	}
 
+	/**
+	 * 배포 환경 (development | staging | production)
+	 *
+	 * NODE_ENV와 분리된 개념 — 개발서버도 production 빌드로 돌므로
+	 * "실제 프로덕션" 구분은 APP_ENV가 단일 진실이다.
+	 * 미설정 시 NODE_ENV 기준 폴백 (기존 배포 하위호환).
+	 */
+	get appEnv(): "development" | "staging" | "production" {
+		const appEnv = this.get("APP_ENV");
+		if (appEnv) {
+			return appEnv;
+		}
+
+		return this.isProduction ? "production" : "development";
+	}
+
 	// ============================================
 	// Database Config Helpers
 	// ============================================

--- a/apps/api/src/common/config/utils/sentry-options.spec.ts
+++ b/apps/api/src/common/config/utils/sentry-options.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * resolveSentryOptions 단위 테스트
+ *
+ * @description
+ * Sentry 활성화 여부를 배포 환경(APP_ENV) 기준으로 결정하는 규칙 검증.
+ * 핵심: 개발서버는 production 빌드(NODE_ENV=production)로 돌기 때문에
+ * NODE_ENV만으로는 구분할 수 없다 — APP_ENV가 배포 환경의 단일 진실.
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test sentry-options
+ * ```
+ */
+import { resolveSentryOptions } from "./sentry-options";
+
+const DSN = "https://key@o0.ingest.sentry.io/0";
+
+describe("resolveSentryOptions — Sentry 환경 게이트", () => {
+	it("개발서버(production 빌드 + APP_ENV=development)에서는 비활성화된다", () => {
+		// Given — 배포된 개발서버: production 빌드지만 개발 환경
+		const options = resolveSentryOptions({
+			APP_ENV: "development",
+			NODE_ENV: "production",
+			SENTRY_DSN: DSN,
+		});
+
+		// Then
+		expect(options.enabled).toBe(false);
+		expect(options.environment).toBe("development");
+	});
+
+	it("APP_ENV=production + DSN이면 활성화된다", () => {
+		// When
+		const options = resolveSentryOptions({
+			APP_ENV: "production",
+			NODE_ENV: "production",
+			SENTRY_DSN: DSN,
+		});
+
+		// Then
+		expect(options.enabled).toBe(true);
+		expect(options.environment).toBe("production");
+	});
+
+	it("APP_ENV 미설정 시 NODE_ENV=production이면 production으로 폴백한다 (기존 프로덕션 하위호환)", () => {
+		// Given — 기존 프로덕션 배포는 APP_ENV를 설정하지 않음
+		const options = resolveSentryOptions({
+			NODE_ENV: "production",
+			SENTRY_DSN: DSN,
+		});
+
+		// Then — 배포 인프라 변경 없이 기존 알림 유지
+		expect(options.enabled).toBe(true);
+		expect(options.environment).toBe("production");
+	});
+
+	it("로컬 개발(NODE_ENV=development)에서는 비활성화된다", () => {
+		// When
+		const options = resolveSentryOptions({
+			NODE_ENV: "development",
+			SENTRY_DSN: DSN,
+		});
+
+		// Then
+		expect(options.enabled).toBe(false);
+		expect(options.environment).toBe("development");
+	});
+
+	it("production이어도 DSN이 없으면 비활성화된다", () => {
+		// When
+		const options = resolveSentryOptions({
+			APP_ENV: "production",
+			NODE_ENV: "production",
+		});
+
+		// Then
+		expect(options.enabled).toBe(false);
+	});
+
+	it("staging은 이벤트를 보내지 않는다 (production만 발송)", () => {
+		// When
+		const options = resolveSentryOptions({
+			APP_ENV: "staging",
+			NODE_ENV: "production",
+			SENTRY_DSN: DSN,
+		});
+
+		// Then
+		expect(options.enabled).toBe(false);
+		expect(options.environment).toBe("staging");
+	});
+
+	it("잘못된 APP_ENV 값은 NODE_ENV 폴백을 따른다", () => {
+		// When
+		const options = resolveSentryOptions({
+			APP_ENV: "prod-typo",
+			NODE_ENV: "production",
+			SENTRY_DSN: DSN,
+		});
+
+		// Then
+		expect(options.environment).toBe("production");
+		expect(options.enabled).toBe(true);
+	});
+
+	describe("tracesSampleRate", () => {
+		it("명시된 SENTRY_TRACES_SAMPLE_RATE가 최우선이다", () => {
+			const options = resolveSentryOptions({
+				APP_ENV: "production",
+				SENTRY_TRACES_SAMPLE_RATE: "0.05",
+			});
+			expect(options.tracesSampleRate).toBe(0.05);
+		});
+
+		it("production 기본값은 0.2, 그 외는 1.0이다", () => {
+			expect(
+				resolveSentryOptions({ APP_ENV: "production" }).tracesSampleRate,
+			).toBe(0.2);
+			expect(
+				resolveSentryOptions({ APP_ENV: "development" }).tracesSampleRate,
+			).toBe(1.0);
+		});
+	});
+});

--- a/apps/api/src/common/config/utils/sentry-options.ts
+++ b/apps/api/src/common/config/utils/sentry-options.ts
@@ -1,0 +1,51 @@
+/**
+ * Sentry 초기화 옵션 결정 (instrument.ts에서 사용)
+ *
+ * 배포 환경 구분은 APP_ENV가 단일 진실이다:
+ * - 개발서버도 production 빌드(NODE_ENV=production)로 돌기 때문에
+ *   NODE_ENV만으로는 "실제 프로덕션"을 구분할 수 없다.
+ * - APP_ENV 미설정 시 NODE_ENV로 폴백 — 기존 프로덕션 배포(APP_ENV 없음)의
+ *   알림이 인프라 변경 없이 유지된다 (하위호환).
+ * - 이벤트 발송(enabled)은 production에서만. environment 태그는 항상
+ *   설정되므로 Sentry 서버측 알림 규칙에서도 이중으로 필터 가능하다.
+ */
+
+const APP_ENVIRONMENTS = ["development", "staging", "production"] as const;
+
+export type AppEnvironment = (typeof APP_ENVIRONMENTS)[number];
+
+export interface SentryInstrumentOptions {
+	enabled: boolean;
+	environment: AppEnvironment;
+	tracesSampleRate: number;
+}
+
+/** process.env 호환 — 필요한 키(APP_ENV/NODE_ENV/SENTRY_*)만 읽는다 */
+type SentryEnvSource = Record<string, string | undefined>;
+
+export function resolveSentryOptions(
+	env: SentryEnvSource,
+): SentryInstrumentOptions {
+	const environment = resolveAppEnvironment(env);
+	const isProduction = environment === "production";
+
+	return {
+		enabled: isProduction && Boolean(env.SENTRY_DSN),
+		environment,
+		tracesSampleRate:
+			env.SENTRY_TRACES_SAMPLE_RATE !== undefined
+				? Number(env.SENTRY_TRACES_SAMPLE_RATE)
+				: isProduction
+					? 0.2
+					: 1.0,
+	};
+}
+
+function resolveAppEnvironment(env: SentryEnvSource): AppEnvironment {
+	const appEnv = APP_ENVIRONMENTS.find((value) => value === env.APP_ENV);
+	if (appEnv) {
+		return appEnv;
+	}
+
+	return env.NODE_ENV === "production" ? "production" : "development";
+}

--- a/apps/api/src/common/dedup/adapters/redis-dedup.adapter.ts
+++ b/apps/api/src/common/dedup/adapters/redis-dedup.adapter.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import type Redis from "ioredis";
-import { REDIS_CLIENT } from "../../redis/redis.constants";
+import { REDIS_COMMAND_CLIENT } from "../../redis/redis.constants";
 import type { IDedupProvider } from "../interfaces/dedup.interface";
 
 /**
@@ -18,7 +18,7 @@ export class RedisDedupAdapter implements IDedupProvider {
 	readonly #redis: Redis;
 	readonly #keyPrefix = "dedup:";
 
-	constructor(@Inject(REDIS_CLIENT) redis: Redis) {
+	constructor(@Inject(REDIS_COMMAND_CLIENT) redis: Redis) {
 		this.#redis = redis;
 	}
 

--- a/apps/api/src/common/dedup/adapters/redis-dedup.adapter.ts
+++ b/apps/api/src/common/dedup/adapters/redis-dedup.adapter.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import type Redis from "ioredis";
 import { REDIS_COMMAND_CLIENT } from "../../redis/redis.constants";
+import { RedisErrorLogSampler } from "../../redis/redis-error-log-sampler";
 import type { IDedupProvider } from "../interfaces/dedup.interface";
 
 /**
@@ -17,6 +18,7 @@ export class RedisDedupAdapter implements IDedupProvider {
 	readonly #logger = new Logger(RedisDedupAdapter.name);
 	readonly #redis: Redis;
 	readonly #keyPrefix = "dedup:";
+	readonly #errorSampler = new RedisErrorLogSampler(this.#logger);
 
 	constructor(@Inject(REDIS_COMMAND_CLIENT) redis: Redis) {
 		this.#redis = redis;
@@ -31,9 +33,7 @@ export class RedisDedupAdapter implements IDedupProvider {
 			const results = await this.#redis.smismember(key, ...members);
 			return new Set(members.filter((_, i) => results[i] === 1));
 		} catch (error) {
-			this.#logger.warn(
-				`Redis dedup filterMembers error (fail-open): ${error instanceof Error ? error.message : error}`,
-			);
+			this.#errorSampler.warn("DEDUP_FILTER_MEMBERS", error);
 			return new Set();
 		}
 	}
@@ -42,9 +42,7 @@ export class RedisDedupAdapter implements IDedupProvider {
 		try {
 			return (await this.#redis.sismember(this.#key(setKey), member)) === 1;
 		} catch (error) {
-			this.#logger.warn(
-				`Redis dedup isMember error (fail-open): ${error instanceof Error ? error.message : error}`,
-			);
+			this.#errorSampler.warn("DEDUP_IS_MEMBER", error);
 			return false;
 		}
 	}
@@ -64,9 +62,7 @@ export class RedisDedupAdapter implements IDedupProvider {
 			pipeline.pexpire(key, ttlMs);
 			await pipeline.exec();
 		} catch (error) {
-			this.#logger.warn(
-				`Redis dedup addMembers error (fail-open): ${error instanceof Error ? error.message : error}`,
-			);
+			this.#errorSampler.warn("DEDUP_ADD_MEMBERS", error);
 		}
 	}
 

--- a/apps/api/src/common/dedup/dedup.module.ts
+++ b/apps/api/src/common/dedup/dedup.module.ts
@@ -6,7 +6,7 @@ import {
 } from "@nestjs/common";
 import type Redis from "ioredis";
 import { TypedConfigService } from "../config/services/config.service";
-import { REDIS_CLIENT } from "../redis/redis.constants";
+import { REDIS_COMMAND_CLIENT } from "../redis/redis.constants";
 import { InMemoryDedupAdapter } from "./adapters/in-memory-dedup.adapter";
 import { RedisDedupAdapter } from "./adapters/redis-dedup.adapter";
 import {
@@ -52,7 +52,10 @@ export class DedupModule {
 
 				return new InMemoryDedupAdapter();
 			},
-			inject: [TypedConfigService, { token: REDIS_CLIENT, optional: true }],
+			inject: [
+				TypedConfigService,
+				{ token: REDIS_COMMAND_CLIENT, optional: true },
+			],
 		};
 
 		return {

--- a/apps/api/src/common/lock/adapters/redis-lock.adapter.spec.ts
+++ b/apps/api/src/common/lock/adapters/redis-lock.adapter.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * RedisLockAdapter 단위 테스트
+ *
+ * @description
+ * - SET NX PX 기반 락 획득/해제 happy path (ioredis-mock)
+ * - Redis 장애 시 fail-closed: acquire→null(busy 취급), release는
+ *   no-throw(TTL이 정리), isLocked→true
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test redis-lock.adapter
+ * ```
+ */
+import RedisMock from "ioredis-mock";
+import { RedisErrorLogSampler } from "../../redis/redis-error-log-sampler";
+import { RedisLockAdapter } from "./redis-lock.adapter";
+
+describe("RedisLockAdapter — Redis 분산 잠금 어댑터", () => {
+	let redis: InstanceType<typeof RedisMock>;
+	let warn: jest.Mock;
+	let lock: RedisLockAdapter;
+
+	beforeEach(async () => {
+		// ioredis-mock은 인스턴스 간 전역 스토어를 공유하므로 테스트마다 초기화
+		redis = new RedisMock();
+		await redis.flushall();
+		warn = jest.fn();
+		lock = new RedisLockAdapter(redis, new RedisErrorLogSampler({ warn }));
+	});
+
+	describe("정상 동작", () => {
+		it("락을 획득하면 release 함수를 반환한다", async () => {
+			// When
+			const release = await lock.acquire("resource", 5000);
+
+			// Then
+			expect(release).not.toBeNull();
+			expect(await lock.isLocked("resource")).toBe(true);
+		});
+
+		it("이미 잠긴 리소스는 null을 반환한다", async () => {
+			// Given
+			await lock.acquire("resource", 5000);
+
+			// When
+			const second = await lock.acquire("resource", 5000);
+
+			// Then
+			expect(second).toBeNull();
+		});
+
+		it("release 후 다시 획득할 수 있다", async () => {
+			// Given
+			const release = await lock.acquire("resource", 5000);
+
+			// When
+			await release?.();
+			const reacquired = await lock.acquire("resource", 5000);
+
+			// Then
+			expect(reacquired).not.toBeNull();
+		});
+
+		it("잠기지 않은 리소스의 isLocked는 false다", async () => {
+			// When / Then
+			expect(await lock.isLocked("free")).toBe(false);
+		});
+	});
+
+	describe("fail-closed (Redis 장애 시)", () => {
+		const failure = new Error("Connection is closed.");
+
+		it("acquire 실패 시 null(busy 취급)을 반환한다", async () => {
+			// Given
+			jest.spyOn(redis, "set").mockRejectedValue(failure);
+
+			// When
+			const release = await lock.acquire("resource", 5000);
+
+			// Then — 소비처는 busy와 동일하게 스킵/재시도 경로를 탄다
+			expect(release).toBeNull();
+			expect(warn).toHaveBeenCalledTimes(1);
+		});
+
+		it("release 실패는 throw하지 않는다 (TTL이 정리)", async () => {
+			// Given
+			const release = await lock.acquire("resource", 5000);
+			jest.spyOn(redis, "eval").mockRejectedValue(failure);
+
+			// When / Then
+			await expect(release?.()).resolves.toBeUndefined();
+			expect(warn).toHaveBeenCalledTimes(1);
+		});
+
+		it("isLocked 실패 시 true(fail-closed)를 반환한다", async () => {
+			// Given
+			jest.spyOn(redis, "exists").mockRejectedValue(failure);
+
+			// When / Then
+			expect(await lock.isLocked("resource")).toBe(true);
+		});
+	});
+});

--- a/apps/api/src/common/lock/adapters/redis-lock.adapter.ts
+++ b/apps/api/src/common/lock/adapters/redis-lock.adapter.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { Injectable, Logger } from "@nestjs/common";
 import type Redis from "ioredis";
+import { RedisErrorLogSampler } from "../../redis/redis-error-log-sampler";
 import type { ILockProvider } from "../interfaces/lock.interface";
 
 /**
@@ -23,15 +24,25 @@ const RELEASE_SCRIPT = `
  * - UUID 기반 값으로 안전한 해제 (Lua 스크립트)
  * - TTL 자동 만료로 데드락 방지
  * - 멀티 인스턴스 환경에서 안전
+ *
+ * 장애 정책 — fail-closed (ILockProvider 계약):
+ * 락은 fail-open(장애인데 획득 성공 취급)이면 중복 알림 발송, 웹훅 동시
+ * 처리 같은 사고로 이어진다. 장애 시 "잠겨있음"으로 취급해 소비처가
+ * busy 경로(스킵/재시도)를 타게 한다:
+ * - acquire: 실패 시 null (busy와 동일)
+ * - release: 실패 시 무시 — TTL 자동 만료가 정리한다
+ * - isLocked: 실패 시 true
  */
 @Injectable()
 export class RedisLockAdapter implements ILockProvider {
 	readonly #logger = new Logger(RedisLockAdapter.name);
 	readonly #redis: Redis;
 	readonly #keyPrefix = "lock:";
+	readonly #errorSampler: RedisErrorLogSampler;
 
-	constructor(redis: Redis) {
+	constructor(redis: Redis, errorSampler?: RedisErrorLogSampler) {
 		this.#redis = redis;
+		this.#errorSampler = errorSampler ?? new RedisErrorLogSampler(this.#logger);
 	}
 
 	async acquire(
@@ -41,7 +52,14 @@ export class RedisLockAdapter implements ILockProvider {
 		const key = this.#keyPrefix + resource;
 		const value = randomUUID();
 
-		const result = await this.#redis.set(key, value, "PX", ttlMs, "NX");
+		let result: string | null;
+		try {
+			result = await this.#redis.set(key, value, "PX", ttlMs, "NX");
+		} catch (error) {
+			// fail-closed: busy와 동일하게 취급 — 소비처가 스킵/재시도 경로를 탄다
+			this.#errorSampler.warn("LOCK_ACQUIRE", error);
+			return null;
+		}
 
 		if (result !== "OK") {
 			this.#logger.debug(`LOCK_BUSY ${resource}`);
@@ -51,7 +69,15 @@ export class RedisLockAdapter implements ILockProvider {
 		this.#logger.debug(`LOCK_ACQUIRED ${resource} (TTL: ${ttlMs}ms)`);
 
 		const release = async (): Promise<void> => {
-			const released = await this.#redis.eval(RELEASE_SCRIPT, 1, key, value);
+			let released: unknown;
+			try {
+				released = await this.#redis.eval(RELEASE_SCRIPT, 1, key, value);
+			} catch (error) {
+				// 해제 실패는 무시 — TTL 자동 만료가 정리한다
+				this.#errorSampler.warn("LOCK_RELEASE", error);
+				return;
+			}
+
 			if (released === 1) {
 				this.#logger.debug(`LOCK_RELEASED ${resource}`);
 			} else {
@@ -66,7 +92,14 @@ export class RedisLockAdapter implements ILockProvider {
 
 	async isLocked(resource: string): Promise<boolean> {
 		const key = this.#keyPrefix + resource;
-		const exists = await this.#redis.exists(key);
-		return exists === 1;
+
+		try {
+			const exists = await this.#redis.exists(key);
+			return exists === 1;
+		} catch (error) {
+			// fail-closed: 장애 시 잠긴 것으로 취급
+			this.#errorSampler.warn("LOCK_IS_LOCKED", error);
+			return true;
+		}
 	}
 }

--- a/apps/api/src/common/lock/interfaces/lock.interface.ts
+++ b/apps/api/src/common/lock/interfaces/lock.interface.ts
@@ -6,6 +6,18 @@
 
 export const LOCK_PROVIDER = Symbol("LOCK_PROVIDER");
 
+/**
+ * 분산 잠금 포트
+ *
+ * 장애 계약 (모든 어댑터가 지켜야 함 — fail-closed):
+ * - acquire는 백엔드 장애 시 null(busy와 동일)을 반환한다. 소비처는
+ *   busy 경로(스킵/재시도)만 준비하면 장애를 따로 처리할 필요가 없다.
+ * - release는 백엔드 장애 시 조용히 무시한다 — TTL 자동 만료가 정리한다.
+ * - isLocked는 백엔드 장애 시 true(잠김)를 반환한다.
+ *
+ * fail-open(장애인데 획득 성공 취급)은 중복 알림 발송, 웹훅 동시 처리
+ * 같은 사고로 이어지므로 금지한다.
+ */
 export interface ILockProvider {
 	/**
 	 * 리소스에 대한 잠금을 획득합니다.

--- a/apps/api/src/common/lock/lock.module.ts
+++ b/apps/api/src/common/lock/lock.module.ts
@@ -6,7 +6,7 @@ import {
 } from "@nestjs/common";
 import type Redis from "ioredis";
 import { TypedConfigService } from "../config/services/config.service";
-import { REDIS_CLIENT } from "../redis/redis.constants";
+import { REDIS_COMMAND_CLIENT } from "../redis/redis.constants";
 import { InMemoryLockAdapter } from "./adapters/in-memory-lock.adapter";
 import { RedisLockAdapter } from "./adapters/redis-lock.adapter";
 import { type ILockProvider, LOCK_PROVIDER } from "./interfaces/lock.interface";
@@ -49,7 +49,10 @@ export class LockModule {
 
 				return new InMemoryLockAdapter();
 			},
-			inject: [TypedConfigService, { token: REDIS_CLIENT, optional: true }],
+			inject: [
+				TypedConfigService,
+				{ token: REDIS_COMMAND_CLIENT, optional: true },
+			],
 		};
 
 		return {

--- a/apps/api/src/common/redis/redis-client.factory.spec.ts
+++ b/apps/api/src/common/redis/redis-client.factory.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Redis 클라이언트 옵션 팩토리 단위 테스트
+ *
+ * @description
+ * 연결 없이 순수 함수로 BullMQ용/명령용 옵션을 검증합니다.
+ * - BullMQ용: maxRetriesPerRequest는 반드시 null (BullMQ 요구사항)
+ * - 명령용: fail-fast 옵션 (enableOfflineQueue: false + commandTimeout)
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test redis-client.factory
+ * ```
+ */
+import {
+	buildBullRedisOptions,
+	buildCommandRedisOptions,
+	type RedisConnectionSettings,
+} from "./redis-client.factory";
+
+describe("redis-client.factory — Redis 클라이언트 옵션 팩토리", () => {
+	const baseSettings: RedisConnectionSettings = {
+		connectTimeoutMs: 5000,
+		commandTimeoutMs: 1500,
+	};
+
+	describe("buildBullRedisOptions (BullMQ 전용)", () => {
+		it("BullMQ 요구사항인 maxRetriesPerRequest: null을 유지한다", () => {
+			// When
+			const options = buildBullRedisOptions(baseSettings);
+
+			// Then
+			expect(options.maxRetriesPerRequest).toBeNull();
+			expect(options.enableReadyCheck).toBe(true);
+			expect(options.connectionName).toBe("aido-main");
+		});
+
+		it("명령 타임아웃/오프라인 큐 비활성화를 적용하지 않는다 (블로킹 명령 보호)", () => {
+			// When
+			const options = buildBullRedisOptions(baseSettings);
+
+			// Then
+			expect(options.commandTimeout).toBeUndefined();
+			expect(options.enableOfflineQueue).toBeUndefined();
+		});
+
+		it("URL이 없으면 host/port/password/db를 옵션에 포함한다", () => {
+			// Given
+			const settings: RedisConnectionSettings = {
+				...baseSettings,
+				host: "redis.internal",
+				port: 6380,
+				password: "secret",
+				db: 2,
+			};
+
+			// When
+			const options = buildBullRedisOptions(settings);
+
+			// Then
+			expect(options.host).toBe("redis.internal");
+			expect(options.port).toBe(6380);
+			expect(options.password).toBe("secret");
+			expect(options.db).toBe(2);
+		});
+
+		it("URL이 있으면 host/port를 옵션에 포함하지 않는다 (URL이 우선)", () => {
+			// Given
+			const settings: RedisConnectionSettings = {
+				...baseSettings,
+				url: "redis://redis:6379",
+				host: "ignored",
+			};
+
+			// When
+			const options = buildBullRedisOptions(settings);
+
+			// Then
+			expect(options.host).toBeUndefined();
+			expect(options.port).toBeUndefined();
+		});
+
+		it("URL과 host가 모두 없으면 localhost:6379 기본값을 사용한다", () => {
+			// When
+			const options = buildBullRedisOptions(baseSettings);
+
+			// Then
+			expect(options.host).toBe("localhost");
+			expect(options.port).toBe(6379);
+			expect(options.db).toBe(0);
+		});
+	});
+
+	describe("buildCommandRedisOptions (캐시/락/스로틀/dedup용)", () => {
+		it("fail-fast 옵션을 적용한다 (오프라인 큐 비활성화 + 명령 타임아웃)", () => {
+			// When
+			const options = buildCommandRedisOptions(baseSettings);
+
+			// Then
+			expect(options.enableOfflineQueue).toBe(false);
+			expect(options.commandTimeout).toBe(1500);
+			expect(options.connectTimeout).toBe(5000);
+			expect(options.maxRetriesPerRequest).toBe(1);
+			expect(options.enableReadyCheck).toBe(true);
+			expect(options.connectionName).toBe("aido-command");
+		});
+
+		it("설정된 타임아웃 값을 그대로 반영한다", () => {
+			// Given
+			const settings: RedisConnectionSettings = {
+				connectTimeoutMs: 3000,
+				commandTimeoutMs: 800,
+			};
+
+			// When
+			const options = buildCommandRedisOptions(settings);
+
+			// Then
+			expect(options.commandTimeout).toBe(800);
+			expect(options.connectTimeout).toBe(3000);
+		});
+
+		it("URL이 없으면 host/port 기본값을 포함한다", () => {
+			// When
+			const options = buildCommandRedisOptions(baseSettings);
+
+			// Then
+			expect(options.host).toBe("localhost");
+			expect(options.port).toBe(6379);
+		});
+	});
+});

--- a/apps/api/src/common/redis/redis-client.factory.ts
+++ b/apps/api/src/common/redis/redis-client.factory.ts
@@ -1,0 +1,75 @@
+import type { RedisOptions } from "ioredis";
+
+/**
+ * Redis 연결 설정 (config.service의 redisUrl/redis getter에서 조립)
+ */
+export interface RedisConnectionSettings {
+	/** REDIS_URL — 존재하면 host/port/password/db보다 우선 */
+	url?: string;
+	host?: string;
+	port?: number;
+	password?: string;
+	db?: number;
+	/** 연결 수립 타임아웃 (명령용 클라이언트에만 적용) */
+	connectTimeoutMs: number;
+	/** 명령 응답 타임아웃 (명령용 클라이언트에만 적용) */
+	commandTimeoutMs: number;
+}
+
+/**
+ * BullMQ 전용 클라이언트 옵션
+ *
+ * BullMQ는 블로킹 명령(BRPOPLPUSH 등)을 사용하므로:
+ * - `maxRetriesPerRequest: null` 필수 (BullMQ 요구사항 — 절대 변경 금지)
+ * - `commandTimeout`/`enableOfflineQueue: false`를 적용하면 안 됨
+ *   (블로킹 대기가 타임아웃으로 끊기거나 재연결 중 잡이 유실됨)
+ */
+export function buildBullRedisOptions(
+	settings: RedisConnectionSettings,
+): RedisOptions {
+	return {
+		...baseHostOptions(settings),
+		maxRetriesPerRequest: null,
+		enableReadyCheck: true,
+		connectionName: "aido-main",
+	};
+}
+
+/**
+ * 명령용(캐시/락/스로틀/dedup/헬스) 클라이언트 옵션 — fail-fast
+ *
+ * Redis 단절 시 명령이 오프라인 큐에서 무한 대기하지 않고 즉시 reject되어
+ * 소비처의 fail-open/fail-closed 처리가 작동하도록 한다:
+ * - `enableOfflineQueue: false`: 단절 중 명령 즉시 reject (핵심)
+ * - `commandTimeout`: 연결은 살아있는데 응답이 없는 blackhole 상황 상한
+ * - `maxRetriesPerRequest: 1`: 재연결 후 1회만 재시도
+ *
+ * retryStrategy는 ioredis 기본값 유지 — 백그라운드 자동 재접속이
+ * half-open probe 역할을 하므로 복구 시 별도 조치 없이 정상화된다.
+ */
+export function buildCommandRedisOptions(
+	settings: RedisConnectionSettings,
+): RedisOptions {
+	return {
+		...baseHostOptions(settings),
+		maxRetriesPerRequest: 1,
+		enableOfflineQueue: false,
+		commandTimeout: settings.commandTimeoutMs,
+		connectTimeout: settings.connectTimeoutMs,
+		enableReadyCheck: true,
+		connectionName: "aido-command",
+	};
+}
+
+function baseHostOptions(settings: RedisConnectionSettings): RedisOptions {
+	if (settings.url) {
+		return {};
+	}
+
+	return {
+		host: settings.host ?? "localhost",
+		port: settings.port ?? 6379,
+		password: settings.password,
+		db: settings.db ?? 0,
+	};
+}

--- a/apps/api/src/common/redis/redis-error-log-sampler.spec.ts
+++ b/apps/api/src/common/redis/redis-error-log-sampler.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * RedisErrorLogSampler 단위 테스트
+ *
+ * @description
+ * Redis 장애 중 요청마다 에러가 발생해도 로그가 폭발하지 않도록
+ * 윈도우당 1회만 warn하고 나머지는 억제 카운트로 집계하는지 검증합니다.
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test redis-error-log-sampler
+ * ```
+ */
+import { RedisErrorLogSampler } from "./redis-error-log-sampler";
+
+describe("RedisErrorLogSampler — Redis 에러 로그 샘플러", () => {
+	let warn: jest.Mock;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		warn = jest.fn();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("첫 에러는 즉시 warn 로그를 남긴다", () => {
+		// Given
+		const sampler = new RedisErrorLogSampler({ warn }, 30_000);
+
+		// When
+		sampler.warn("GET", new Error("Connection is closed."));
+
+		// Then
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("Connection is closed."),
+		);
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("GET"));
+	});
+
+	it("윈도우 내 반복 에러는 억제한다 (로그 1회만)", () => {
+		// Given
+		const sampler = new RedisErrorLogSampler({ warn }, 30_000);
+
+		// When — 같은 윈도우 안에서 100회 에러
+		for (let i = 0; i < 100; i++) {
+			sampler.warn("GET", new Error("boom"));
+		}
+
+		// Then
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("윈도우가 지나면 억제된 개수와 함께 다시 로그를 남긴다", () => {
+		// Given
+		const sampler = new RedisErrorLogSampler({ warn }, 30_000);
+		for (let i = 0; i < 5; i++) {
+			sampler.warn("GET", new Error("boom"));
+		}
+
+		// When — 윈도우 경과 후 새 에러
+		jest.advanceTimersByTime(30_000);
+		sampler.warn("SET", new Error("still down"));
+
+		// Then
+		expect(warn).toHaveBeenCalledTimes(2);
+		expect(warn).toHaveBeenLastCalledWith(
+			expect.stringContaining("+4 suppressed"),
+		);
+	});
+
+	it("Error가 아닌 값도 메시지로 변환한다", () => {
+		// Given
+		const sampler = new RedisErrorLogSampler({ warn }, 30_000);
+
+		// When
+		sampler.warn("DEL", "raw string error");
+
+		// Then
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("raw string error"),
+		);
+	});
+});

--- a/apps/api/src/common/redis/redis-error-log-sampler.ts
+++ b/apps/api/src/common/redis/redis-error-log-sampler.ts
@@ -1,0 +1,42 @@
+import type { Logger } from "@nestjs/common";
+
+/**
+ * Redis 에러 로그 샘플러
+ *
+ * fail-fast 클라이언트는 Redis 장애 중 요청마다 즉시 에러를 내므로,
+ * 어댑터가 에러를 그대로 로깅하면 로그가 폭발한다. 윈도우(기본 30초)당
+ * 1회만 warn을 남기고 나머지는 억제 카운트로 집계해 다음 로그에
+ * `(+N suppressed)`로 덧붙인다.
+ */
+export class RedisErrorLogSampler {
+	readonly #logger: Pick<Logger, "warn">;
+	readonly #intervalMs: number;
+	#windowStartedAt = Number.NEGATIVE_INFINITY;
+	#suppressed = 0;
+
+	constructor(logger: Pick<Logger, "warn">, intervalMs = 30_000) {
+		this.#logger = logger;
+		this.#intervalMs = intervalMs;
+	}
+
+	warn(operation: string, error: unknown): void {
+		const now = Date.now();
+
+		if (now - this.#windowStartedAt < this.#intervalMs) {
+			this.#suppressed++;
+			return;
+		}
+
+		const suffix =
+			this.#suppressed > 0 ? ` (+${this.#suppressed} suppressed)` : "";
+		this.#logger.warn(
+			`Redis ${operation} failed (fail-open): ${toMessage(error)}${suffix}`,
+		);
+		this.#windowStartedAt = now;
+		this.#suppressed = 0;
+	}
+}
+
+function toMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/apps/api/src/common/redis/redis.constants.ts
+++ b/apps/api/src/common/redis/redis.constants.ts
@@ -1,4 +1,20 @@
 /**
  * Redis 모듈 DI 토큰
  */
+
+/**
+ * BullMQ 전용 연결 (maxRetriesPerRequest: null, 오프라인 큐 유지)
+ *
+ * 블로킹 명령을 쓰는 BullMQ 외에는 주입 금지 — 일반 명령에 쓰면
+ * Redis 단절 시 명령이 오프라인 큐에서 무한 대기한다.
+ */
 export const REDIS_CLIENT = Symbol("REDIS_CLIENT");
+
+/**
+ * 명령용 연결 (fail-fast: enableOfflineQueue false + commandTimeout)
+ *
+ * 캐시/락/스로틀/dedup/헬스 등 요청 경로의 일반 명령은 이 토큰을 사용한다.
+ * Redis 단절 시 명령이 즉시 reject되어 소비처의 fail-open/fail-closed
+ * 처리가 작동한다.
+ */
+export const REDIS_COMMAND_CLIENT = Symbol("REDIS_COMMAND_CLIENT");

--- a/apps/api/src/common/redis/redis.module.spec.ts
+++ b/apps/api/src/common/redis/redis.module.spec.ts
@@ -135,6 +135,29 @@ describe("RedisModule — Redis 연결 모듈", () => {
 			jest.useRealTimers();
 		});
 
+		it("두 번 호출돼도 quit/disconnect는 한 번만 실행된다 (멱등)", async () => {
+			// Given — main.ts의 enableShutdownHooks + 자체 SIGTERM 핸들러가
+			// app.close()를 중복 호출하는 상황
+			const bullClient = createFakeClient({
+				quit: jest.fn().mockReturnValue(
+					new Promise((resolve) => {
+						setTimeout(() => resolve("OK"), 10);
+					}),
+				),
+			});
+			const module = new RedisModule(bullClient, null);
+
+			// When — 동시 중복 호출
+			await Promise.all([
+				module.onApplicationShutdown(),
+				module.onApplicationShutdown(),
+			]);
+
+			// Then
+			expect(bullClient.quit).toHaveBeenCalledTimes(1);
+			expect(bullClient.disconnect).not.toHaveBeenCalled();
+		});
+
 		it("이미 종료된(end) 클라이언트는 건드리지 않는다", async () => {
 			// Given
 			const endedClient = createFakeClient({ status: "end" });

--- a/apps/api/src/common/redis/redis.module.spec.ts
+++ b/apps/api/src/common/redis/redis.module.spec.ts
@@ -10,18 +10,19 @@
  * pnpm --filter @aido/api test redis.module
  * ```
  */
-import type { ValueProvider } from "@nestjs/common";
-import type Redis from "ioredis";
+import type { Provider, ValueProvider } from "@nestjs/common";
+import Redis from "ioredis";
 import { REDIS_CLIENT, REDIS_COMMAND_CLIENT } from "./redis.constants";
-import { RedisModule } from "./redis.module";
+import { type RedisLifecycleClient, RedisModule } from "./redis.module";
 
-interface FakeRedis {
-	status: string;
+interface FakeRedisClient extends RedisLifecycleClient {
 	quit: jest.Mock;
 	disconnect: jest.Mock;
 }
 
-function createFakeRedis(overrides: Partial<FakeRedis> = {}): FakeRedis {
+function createFakeClient(
+	overrides: Partial<FakeRedisClient> = {},
+): FakeRedisClient {
 	return {
 		status: "ready",
 		quit: jest.fn().mockResolvedValue("OK"),
@@ -30,60 +31,67 @@ function createFakeRedis(overrides: Partial<FakeRedis> = {}): FakeRedis {
 	};
 }
 
-function asRedis(fake: FakeRedis): Redis {
-	return fake as unknown as Redis;
+function isValueProvider(provider: Provider): provider is ValueProvider {
+	return typeof provider === "object" && "useValue" in provider;
+}
+
+function findUseValue(
+	providers: Provider[] | undefined,
+	token: symbol,
+): unknown {
+	return (providers ?? [])
+		.filter(isValueProvider)
+		.find((provider) => provider.provide === token)?.useValue;
 }
 
 describe("RedisModule — Redis 연결 모듈", () => {
 	describe("forTesting", () => {
-		it("클라이언트 하나만 주면 두 토큰 모두 같은 클라이언트를 제공한다", () => {
-			// Given
-			const client = asRedis(createFakeRedis());
+		let client: Redis;
+		let commandClient: Redis;
 
+		beforeEach(() => {
+			// lazyConnect: 명령 실행 전까지 실제 연결을 만들지 않음
+			client = new Redis({ lazyConnect: true });
+			commandClient = new Redis({ lazyConnect: true });
+		});
+
+		afterEach(() => {
+			client.disconnect();
+			commandClient.disconnect();
+		});
+
+		it("클라이언트 하나만 주면 두 토큰 모두 같은 클라이언트를 제공한다", () => {
 			// When
 			const dynamicModule = RedisModule.forTesting(client);
 
 			// Then
-			const providers = (dynamicModule.providers ?? []) as ValueProvider[];
-			const bullProvider = providers.find((p) => p.provide === REDIS_CLIENT);
-			const commandProvider = providers.find(
-				(p) => p.provide === REDIS_COMMAND_CLIENT,
+			expect(findUseValue(dynamicModule.providers, REDIS_CLIENT)).toBe(client);
+			expect(findUseValue(dynamicModule.providers, REDIS_COMMAND_CLIENT)).toBe(
+				client,
 			);
-			expect(bullProvider?.useValue).toBe(client);
-			expect(commandProvider?.useValue).toBe(client);
 			expect(dynamicModule.exports).toEqual(
 				expect.arrayContaining([REDIS_CLIENT, REDIS_COMMAND_CLIENT]),
 			);
 		});
 
 		it("명령용 클라이언트를 따로 주면 토큰별로 다른 클라이언트를 제공한다", () => {
-			// Given
-			const bullClient = asRedis(createFakeRedis());
-			const commandClient = asRedis(createFakeRedis());
-
 			// When
-			const dynamicModule = RedisModule.forTesting(bullClient, commandClient);
+			const dynamicModule = RedisModule.forTesting(client, commandClient);
 
 			// Then
-			const providers = (dynamicModule.providers ?? []) as ValueProvider[];
-			const bullProvider = providers.find((p) => p.provide === REDIS_CLIENT);
-			const commandProvider = providers.find(
-				(p) => p.provide === REDIS_COMMAND_CLIENT,
+			expect(findUseValue(dynamicModule.providers, REDIS_CLIENT)).toBe(client);
+			expect(findUseValue(dynamicModule.providers, REDIS_COMMAND_CLIENT)).toBe(
+				commandClient,
 			);
-			expect(bullProvider?.useValue).toBe(bullClient);
-			expect(commandProvider?.useValue).toBe(commandClient);
 		});
 	});
 
 	describe("onApplicationShutdown", () => {
 		it("quit이 성공하면 disconnect를 호출하지 않는다", async () => {
 			// Given
-			const bullClient = createFakeRedis();
-			const commandClient = createFakeRedis();
-			const module = new RedisModule(
-				asRedis(bullClient),
-				asRedis(commandClient),
-			);
+			const bullClient = createFakeClient();
+			const commandClient = createFakeClient();
+			const module = new RedisModule(bullClient, commandClient);
 
 			// When
 			await module.onApplicationShutdown();
@@ -97,10 +105,10 @@ describe("RedisModule — Redis 연결 모듈", () => {
 
 		it("quit이 reject되면 disconnect로 강제 종료한다", async () => {
 			// Given
-			const bullClient = createFakeRedis({
+			const bullClient = createFakeClient({
 				quit: jest.fn().mockRejectedValue(new Error("Connection is closed.")),
 			});
-			const module = new RedisModule(asRedis(bullClient), null);
+			const module = new RedisModule(bullClient, null);
 
 			// When
 			await module.onApplicationShutdown();
@@ -112,10 +120,10 @@ describe("RedisModule — Redis 연결 모듈", () => {
 		it("quit이 응답하지 않으면(hang) 타임아웃 후 disconnect로 폴백한다", async () => {
 			// Given — Redis 다운 중 종료: 오프라인 큐에 걸린 quit은 영원히 pending
 			jest.useFakeTimers();
-			const bullClient = createFakeRedis({
+			const bullClient = createFakeClient({
 				quit: jest.fn().mockReturnValue(new Promise(() => {})),
 			});
-			const module = new RedisModule(asRedis(bullClient), null);
+			const module = new RedisModule(bullClient, null);
 
 			// When
 			const shutdown = module.onApplicationShutdown();
@@ -129,8 +137,8 @@ describe("RedisModule — Redis 연결 모듈", () => {
 
 		it("이미 종료된(end) 클라이언트는 건드리지 않는다", async () => {
 			// Given
-			const endedClient = createFakeRedis({ status: "end" });
-			const module = new RedisModule(asRedis(endedClient), null);
+			const endedClient = createFakeClient({ status: "end" });
+			const module = new RedisModule(endedClient, null);
 
 			// When
 			await module.onApplicationShutdown();

--- a/apps/api/src/common/redis/redis.module.spec.ts
+++ b/apps/api/src/common/redis/redis.module.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * RedisModule 단위 테스트
+ *
+ * @description
+ * - forTesting이 두 토큰(REDIS_CLIENT, REDIS_COMMAND_CLIENT)을 모두 제공하는지
+ * - onApplicationShutdown이 quit 실패/hang 시 disconnect로 폴백하는지
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test redis.module
+ * ```
+ */
+import type { ValueProvider } from "@nestjs/common";
+import type Redis from "ioredis";
+import { REDIS_CLIENT, REDIS_COMMAND_CLIENT } from "./redis.constants";
+import { RedisModule } from "./redis.module";
+
+interface FakeRedis {
+	status: string;
+	quit: jest.Mock;
+	disconnect: jest.Mock;
+}
+
+function createFakeRedis(overrides: Partial<FakeRedis> = {}): FakeRedis {
+	return {
+		status: "ready",
+		quit: jest.fn().mockResolvedValue("OK"),
+		disconnect: jest.fn(),
+		...overrides,
+	};
+}
+
+function asRedis(fake: FakeRedis): Redis {
+	return fake as unknown as Redis;
+}
+
+describe("RedisModule — Redis 연결 모듈", () => {
+	describe("forTesting", () => {
+		it("클라이언트 하나만 주면 두 토큰 모두 같은 클라이언트를 제공한다", () => {
+			// Given
+			const client = asRedis(createFakeRedis());
+
+			// When
+			const dynamicModule = RedisModule.forTesting(client);
+
+			// Then
+			const providers = (dynamicModule.providers ?? []) as ValueProvider[];
+			const bullProvider = providers.find((p) => p.provide === REDIS_CLIENT);
+			const commandProvider = providers.find(
+				(p) => p.provide === REDIS_COMMAND_CLIENT,
+			);
+			expect(bullProvider?.useValue).toBe(client);
+			expect(commandProvider?.useValue).toBe(client);
+			expect(dynamicModule.exports).toEqual(
+				expect.arrayContaining([REDIS_CLIENT, REDIS_COMMAND_CLIENT]),
+			);
+		});
+
+		it("명령용 클라이언트를 따로 주면 토큰별로 다른 클라이언트를 제공한다", () => {
+			// Given
+			const bullClient = asRedis(createFakeRedis());
+			const commandClient = asRedis(createFakeRedis());
+
+			// When
+			const dynamicModule = RedisModule.forTesting(bullClient, commandClient);
+
+			// Then
+			const providers = (dynamicModule.providers ?? []) as ValueProvider[];
+			const bullProvider = providers.find((p) => p.provide === REDIS_CLIENT);
+			const commandProvider = providers.find(
+				(p) => p.provide === REDIS_COMMAND_CLIENT,
+			);
+			expect(bullProvider?.useValue).toBe(bullClient);
+			expect(commandProvider?.useValue).toBe(commandClient);
+		});
+	});
+
+	describe("onApplicationShutdown", () => {
+		it("quit이 성공하면 disconnect를 호출하지 않는다", async () => {
+			// Given
+			const bullClient = createFakeRedis();
+			const commandClient = createFakeRedis();
+			const module = new RedisModule(
+				asRedis(bullClient),
+				asRedis(commandClient),
+			);
+
+			// When
+			await module.onApplicationShutdown();
+
+			// Then
+			expect(bullClient.quit).toHaveBeenCalledTimes(1);
+			expect(commandClient.quit).toHaveBeenCalledTimes(1);
+			expect(bullClient.disconnect).not.toHaveBeenCalled();
+			expect(commandClient.disconnect).not.toHaveBeenCalled();
+		});
+
+		it("quit이 reject되면 disconnect로 강제 종료한다", async () => {
+			// Given
+			const bullClient = createFakeRedis({
+				quit: jest.fn().mockRejectedValue(new Error("Connection is closed.")),
+			});
+			const module = new RedisModule(asRedis(bullClient), null);
+
+			// When
+			await module.onApplicationShutdown();
+
+			// Then
+			expect(bullClient.disconnect).toHaveBeenCalledTimes(1);
+		});
+
+		it("quit이 응답하지 않으면(hang) 타임아웃 후 disconnect로 폴백한다", async () => {
+			// Given — Redis 다운 중 종료: 오프라인 큐에 걸린 quit은 영원히 pending
+			jest.useFakeTimers();
+			const bullClient = createFakeRedis({
+				quit: jest.fn().mockReturnValue(new Promise(() => {})),
+			});
+			const module = new RedisModule(asRedis(bullClient), null);
+
+			// When
+			const shutdown = module.onApplicationShutdown();
+			await jest.advanceTimersByTimeAsync(3_000);
+			await shutdown;
+
+			// Then
+			expect(bullClient.disconnect).toHaveBeenCalledTimes(1);
+			jest.useRealTimers();
+		});
+
+		it("이미 종료된(end) 클라이언트는 건드리지 않는다", async () => {
+			// Given
+			const endedClient = createFakeRedis({ status: "end" });
+			const module = new RedisModule(asRedis(endedClient), null);
+
+			// When
+			await module.onApplicationShutdown();
+
+			// Then
+			expect(endedClient.quit).not.toHaveBeenCalled();
+			expect(endedClient.disconnect).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/apps/api/src/common/redis/redis.module.ts
+++ b/apps/api/src/common/redis/redis.module.ts
@@ -21,6 +21,18 @@ import {
 const QUIT_TIMEOUT_MS = 3_000;
 
 /**
+ * 종료 처리에 필요한 최소 클라이언트 계약
+ *
+ * ioredis Redis가 구조적으로 만족하며, 테스트에서 캐스트 없이
+ * fake를 주입할 수 있도록 좁혀 둔다.
+ */
+export interface RedisLifecycleClient {
+	status: string;
+	quit(): Promise<"OK">;
+	disconnect(reconnect?: boolean): void;
+}
+
+/**
  * Redis 모듈
  *
  * 용도별로 분리된 두 ioredis 인스턴스를 제공하는 글로벌 모듈:
@@ -44,10 +56,10 @@ export class RedisModule implements OnApplicationShutdown {
 	constructor(
 		@Optional()
 		@Inject(REDIS_CLIENT)
-		private readonly bullClient: Redis | null,
+		private readonly bullClient: RedisLifecycleClient | null,
 		@Optional()
 		@Inject(REDIS_COMMAND_CLIENT)
-		private readonly commandClient: Redis | null,
+		private readonly commandClient: RedisLifecycleClient | null,
 	) {}
 
 	static forRoot(): DynamicModule {
@@ -109,7 +121,7 @@ export class RedisModule implements OnApplicationShutdown {
 	}
 
 	private async shutdownClient(
-		client: Redis | null,
+		client: RedisLifecycleClient | null,
 		name: string,
 	): Promise<void> {
 		if (!client || client.status === "end") {

--- a/apps/api/src/common/redis/redis.module.ts
+++ b/apps/api/src/common/redis/redis.module.ts
@@ -1,20 +1,32 @@
 import {
 	type DynamicModule,
 	Global,
+	Inject,
 	Logger,
 	Module,
-	type OnModuleDestroy,
+	type OnApplicationShutdown,
+	Optional,
 	type Provider,
 } from "@nestjs/common";
-import Redis from "ioredis";
+import Redis, { type RedisOptions } from "ioredis";
 import { TypedConfigService } from "../config/services/config.service";
-import { REDIS_CLIENT } from "./redis.constants";
+import { REDIS_CLIENT, REDIS_COMMAND_CLIENT } from "./redis.constants";
+import {
+	buildBullRedisOptions,
+	buildCommandRedisOptions,
+	type RedisConnectionSettings,
+} from "./redis-client.factory";
+
+/** quit이 오프라인 큐에 걸려 hang할 때 disconnect로 폴백하기까지의 대기 시간 */
+const QUIT_TIMEOUT_MS = 3_000;
 
 /**
  * Redis 모듈
  *
- * 공유 ioredis 인스턴스를 제공하는 글로벌 모듈.
- * Lock, Cache, BullMQ가 동일한 Redis 연결을 공유합니다.
+ * 용도별로 분리된 두 ioredis 인스턴스를 제공하는 글로벌 모듈:
+ * - `REDIS_CLIENT`: BullMQ 전용 (블로킹 명령 호환 — 오프라인 큐 유지)
+ * - `REDIS_COMMAND_CLIENT`: 캐시/락/스로틀/dedup용 (fail-fast —
+ *   Redis 단절 시 명령이 즉시 reject되어 어댑터의 fail-open이 작동)
  *
  * @example
  * // app.module.ts
@@ -22,77 +34,140 @@ import { REDIS_CLIENT } from "./redis.constants";
  *
  * @example
  * // 서비스에서 직접 사용 (일반적으로 Lock/Cache 어댑터를 통해 접근)
- * constructor(@Inject(REDIS_CLIENT) private readonly redis: Redis) {}
+ * constructor(@Inject(REDIS_COMMAND_CLIENT) private readonly redis: Redis) {}
  */
 @Global()
 @Module({})
-export class RedisModule implements OnModuleDestroy {
-	private static logger = new Logger(RedisModule.name);
-	private static client: Redis | null = null;
+export class RedisModule implements OnApplicationShutdown {
+	private static readonly logger = new Logger(RedisModule.name);
+
+	constructor(
+		@Optional()
+		@Inject(REDIS_CLIENT)
+		private readonly bullClient: Redis | null,
+		@Optional()
+		@Inject(REDIS_COMMAND_CLIENT)
+		private readonly commandClient: Redis | null,
+	) {}
 
 	static forRoot(): DynamicModule {
-		const redisProvider: Provider = {
+		const bullProvider: Provider = {
 			provide: REDIS_CLIENT,
-			useFactory: (configService: TypedConfigService): Redis => {
-				const url = configService.redisUrl;
+			useFactory: (configService: TypedConfigService): Redis =>
+				RedisModule.createClient(configService, buildBullRedisOptions, "main"),
+			inject: [TypedConfigService],
+		};
 
-				const client = url
-					? new Redis(url, {
-							maxRetriesPerRequest: null,
-							enableReadyCheck: true,
-							connectionName: "aido-main",
-						})
-					: new Redis({
-							host: configService.redis.host ?? "localhost",
-							port: configService.redis.port ?? 6379,
-							password: configService.redis.password,
-							db: configService.redis.db ?? 0,
-							maxRetriesPerRequest: null,
-							enableReadyCheck: true,
-							connectionName: "aido-main",
-						});
-
-				client.on("connect", () => {
-					RedisModule.logger.log("Redis connected");
-				});
-
-				client.on("error", (error) => {
-					RedisModule.logger.error(`Redis error: ${error.message}`);
-				});
-
-				client.on("close", () => {
-					RedisModule.logger.warn("Redis connection closed");
-				});
-
-				RedisModule.client = client;
-				return client;
-			},
+		const commandProvider: Provider = {
+			provide: REDIS_COMMAND_CLIENT,
+			useFactory: (configService: TypedConfigService): Redis =>
+				RedisModule.createClient(
+					configService,
+					buildCommandRedisOptions,
+					"command",
+				),
 			inject: [TypedConfigService],
 		};
 
 		return {
 			module: RedisModule,
-			providers: [TypedConfigService, redisProvider],
-			exports: [REDIS_CLIENT],
+			providers: [TypedConfigService, bullProvider, commandProvider],
+			exports: [REDIS_CLIENT, REDIS_COMMAND_CLIENT],
 		};
 	}
 
 	/**
 	 * 테스트용 모듈 설정
+	 *
+	 * @param client BullMQ용 클라이언트
+	 * @param commandClient 명령용 클라이언트 (생략 시 client 재사용)
 	 */
-	static forTesting(client: Redis): DynamicModule {
+	static forTesting(
+		client: Redis,
+		commandClient: Redis = client,
+	): DynamicModule {
 		return {
 			module: RedisModule,
-			providers: [{ provide: REDIS_CLIENT, useValue: client }],
-			exports: [REDIS_CLIENT],
+			providers: [
+				{ provide: REDIS_CLIENT, useValue: client },
+				{ provide: REDIS_COMMAND_CLIENT, useValue: commandClient },
+			],
+			exports: [REDIS_CLIENT, REDIS_COMMAND_CLIENT],
 		};
 	}
 
-	async onModuleDestroy(): Promise<void> {
-		if (RedisModule.client) {
-			await RedisModule.client.quit();
-			RedisModule.client = null;
-			RedisModule.logger.log("Redis disconnected");
+	/**
+	 * BullMQ Worker/Queue가 같은 훅에서 먼저 정리된 뒤(Nest가 의존 역순 호출)
+	 * 연결을 닫는다 — onModuleDestroy에서 닫으면 in-flight 명령이
+	 * "Connection is closed." unhandled rejection을 일으킨다.
+	 */
+	async onApplicationShutdown(): Promise<void> {
+		await Promise.allSettled([
+			this.shutdownClient(this.commandClient, "command"),
+			this.shutdownClient(this.bullClient, "main"),
+		]);
+	}
+
+	private async shutdownClient(
+		client: Redis | null,
+		name: string,
+	): Promise<void> {
+		if (!client || client.status === "end") {
+			return;
 		}
+
+		try {
+			// Redis 다운 중 종료 시 quit이 오프라인 큐에 걸려 hang할 수 있다
+			await RedisModule.withTimeout(client.quit(), QUIT_TIMEOUT_MS);
+			RedisModule.logger.log(`Redis[${name}] disconnected`);
+		} catch {
+			client.disconnect();
+			RedisModule.logger.warn(`Redis[${name}] force-disconnected`);
+		}
+	}
+
+	private static createClient(
+		configService: TypedConfigService,
+		buildOptions: (settings: RedisConnectionSettings) => RedisOptions,
+		name: string,
+	): Redis {
+		const settings: RedisConnectionSettings = {
+			url: configService.redisUrl,
+			...configService.redis,
+		};
+
+		const options = buildOptions(settings);
+		const client = settings.url
+			? new Redis(settings.url, options)
+			: new Redis(options);
+
+		client.on("connect", () => {
+			RedisModule.logger.log(`Redis[${name}] connected`);
+		});
+
+		client.on("error", (error) => {
+			RedisModule.logger.error(`Redis[${name}] error: ${error.message}`);
+		});
+
+		client.on("close", () => {
+			RedisModule.logger.warn(`Redis[${name}] connection closed`);
+		});
+
+		return client;
+	}
+
+	private static withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+		let timer: NodeJS.Timeout | undefined;
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => {
+				reject(new Error(`Redis quit timed out after ${ms}ms`));
+			}, ms);
+		});
+
+		return Promise.race([promise, timeout]).finally(() => {
+			if (timer) {
+				clearTimeout(timer);
+			}
+		});
 	}
 }

--- a/apps/api/src/common/redis/redis.module.ts
+++ b/apps/api/src/common/redis/redis.module.ts
@@ -53,6 +53,7 @@ export interface RedisLifecycleClient {
 @Module({})
 export class RedisModule implements OnApplicationShutdown {
 	private static readonly logger = new Logger(RedisModule.name);
+	private shutdownPromise: Promise<void> | null = null;
 
 	constructor(
 		@Optional()
@@ -115,6 +116,13 @@ export class RedisModule implements OnApplicationShutdown {
 	 * "Connection is closed." unhandled rejection을 일으킨다.
 	 */
 	async onApplicationShutdown(): Promise<void> {
+		// main.ts의 enableShutdownHooks + 자체 SIGTERM 핸들러가 app.close()를
+		// 중복 호출할 수 있으므로 멱등하게 처리한다
+		this.shutdownPromise ??= this.closeClients();
+		await this.shutdownPromise;
+	}
+
+	private async closeClients(): Promise<void> {
 		await Promise.allSettled([
 			this.shutdownClient(this.commandClient, "command"),
 			this.shutdownClient(this.bullClient, "main"),

--- a/apps/api/src/common/redis/redis.module.ts
+++ b/apps/api/src/common/redis/redis.module.ts
@@ -16,6 +16,7 @@ import {
 	buildCommandRedisOptions,
 	type RedisConnectionSettings,
 } from "./redis-client.factory";
+import { withTimeout } from "./with-timeout";
 
 /** quit이 오프라인 큐에 걸려 hang할 때 disconnect로 폴백하기까지의 대기 시간 */
 const QUIT_TIMEOUT_MS = 3_000;
@@ -130,7 +131,7 @@ export class RedisModule implements OnApplicationShutdown {
 
 		try {
 			// Redis 다운 중 종료 시 quit이 오프라인 큐에 걸려 hang할 수 있다
-			await RedisModule.withTimeout(client.quit(), QUIT_TIMEOUT_MS);
+			await withTimeout(client.quit(), QUIT_TIMEOUT_MS, "Redis quit");
 			RedisModule.logger.log(`Redis[${name}] disconnected`);
 		} catch {
 			client.disconnect();
@@ -166,20 +167,5 @@ export class RedisModule implements OnApplicationShutdown {
 		});
 
 		return client;
-	}
-
-	private static withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-		let timer: NodeJS.Timeout | undefined;
-		const timeout = new Promise<never>((_, reject) => {
-			timer = setTimeout(() => {
-				reject(new Error(`Redis quit timed out after ${ms}ms`));
-			}, ms);
-		});
-
-		return Promise.race([promise, timeout]).finally(() => {
-			if (timer) {
-				clearTimeout(timer);
-			}
-		});
 	}
 }

--- a/apps/api/src/common/redis/with-timeout.ts
+++ b/apps/api/src/common/redis/with-timeout.ts
@@ -1,0 +1,24 @@
+/**
+ * Promise에 타임아웃을 건다
+ *
+ * 타임아웃 시 reject하며, 어느 쪽이 먼저 끝나든 타이머를 정리한다
+ * (jest open handle / 이벤트 루프 잔류 방지).
+ */
+export function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	label: string,
+): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => {
+			reject(new Error(`${label} timed out after ${ms}ms`));
+		}, ms);
+	});
+
+	return Promise.race([promise, timeout]).finally(() => {
+		if (timer) {
+			clearTimeout(timer);
+		}
+	});
+}

--- a/apps/api/src/common/throttle/index.ts
+++ b/apps/api/src/common/throttle/index.ts
@@ -1,1 +1,3 @@
 export { RedisThrottlerStorage } from "./redis-throttler-storage";
+export { THROTTLER_STORAGE } from "./throttle.constants";
+export { ThrottleModule } from "./throttle.module";

--- a/apps/api/src/common/throttle/redis-throttler-storage.ts
+++ b/apps/api/src/common/throttle/redis-throttler-storage.ts
@@ -50,6 +50,37 @@ const THROTTLE_INCREMENT_SCRIPT = `
 `;
 
 /**
+ * Lua 스크립트 결과를 검증해 ThrottlerStorageRecord로 변환
+ *
+ * @throws 예상 형태([number x4])가 아니면 에러 — increment의 catch에서
+ *         fail-open으로 흡수된다
+ */
+function isNumberQuad(raw: unknown): raw is [number, number, number, number] {
+	return (
+		Array.isArray(raw) &&
+		raw.length === 4 &&
+		raw.every((value) => typeof value === "number")
+	);
+}
+
+function parseThrottleResult(raw: unknown): ThrottlerStorageRecord {
+	if (!isNumberQuad(raw)) {
+		throw new Error(
+			`Unexpected throttle script result: ${JSON.stringify(raw)}`,
+		);
+	}
+
+	const [totalHits, timeToExpire, isBlocked, timeToBlockExpire] = raw;
+
+	return {
+		totalHits,
+		timeToExpire,
+		isBlocked: isBlocked === 1,
+		timeToBlockExpire,
+	};
+}
+
+/**
  * Redis 기반 ThrottlerStorage
  *
  * - Lua 스크립트로 atomic increment + TTL + block 처리
@@ -76,7 +107,7 @@ export class RedisThrottlerStorage implements ThrottlerStorage {
 		const blockKey = `${hitKey}:blocked`;
 
 		try {
-			const result = (await this.#redis.eval(
+			const raw = await this.#redis.eval(
 				THROTTLE_INCREMENT_SCRIPT,
 				2,
 				hitKey,
@@ -84,14 +115,9 @@ export class RedisThrottlerStorage implements ThrottlerStorage {
 				ttl,
 				limit,
 				blockDuration,
-			)) as [number, number, number, number];
+			);
 
-			return {
-				totalHits: result[0],
-				timeToExpire: result[1],
-				isBlocked: result[2] === 1,
-				timeToBlockExpire: result[3],
-			};
+			return parseThrottleResult(raw);
 		} catch (error) {
 			this.#logger.warn(
 				`Redis throttle error (fail-open): ${error instanceof Error ? error.message : error}`,

--- a/apps/api/src/common/throttle/redis-throttler-storage.ts
+++ b/apps/api/src/common/throttle/redis-throttler-storage.ts
@@ -2,6 +2,7 @@ import { Logger } from "@nestjs/common";
 import type { ThrottlerStorage } from "@nestjs/throttler";
 import type { ThrottlerStorageRecord } from "@nestjs/throttler/dist/throttler-storage-record.interface";
 import type Redis from "ioredis";
+import { RedisErrorLogSampler } from "../redis/redis-error-log-sampler";
 
 /**
  * Lua 스크립트: atomic throttle increment + block 처리
@@ -89,6 +90,7 @@ function parseThrottleResult(raw: unknown): ThrottlerStorageRecord {
  */
 export class RedisThrottlerStorage implements ThrottlerStorage {
 	readonly #logger = new Logger(RedisThrottlerStorage.name);
+	readonly #errorSampler = new RedisErrorLogSampler(this.#logger);
 	readonly #redis: Redis;
 	readonly #keyPrefix = "throttle:";
 
@@ -119,9 +121,7 @@ export class RedisThrottlerStorage implements ThrottlerStorage {
 
 			return parseThrottleResult(raw);
 		} catch (error) {
-			this.#logger.warn(
-				`Redis throttle error (fail-open): ${error instanceof Error ? error.message : error}`,
-			);
+			this.#errorSampler.warn("THROTTLE_INCREMENT", error);
 
 			// fail-open: Redis 장애 시 요청 허용
 			return {

--- a/apps/api/src/common/throttle/throttle.constants.ts
+++ b/apps/api/src/common/throttle/throttle.constants.ts
@@ -1,0 +1,7 @@
+/**
+ * 스로틀 모듈 DI 토큰
+ *
+ * `@nestjs/throttler`의 `ThrottlerStorage` 인터페이스가 포트 역할을 한다.
+ * Redis 사용 시 `RedisThrottlerStorage`, 아니면 undefined(기본 in-memory).
+ */
+export const THROTTLER_STORAGE = Symbol("THROTTLER_STORAGE");

--- a/apps/api/src/common/throttle/throttle.module.ts
+++ b/apps/api/src/common/throttle/throttle.module.ts
@@ -1,0 +1,62 @@
+import { type DynamicModule, Module, type Provider } from "@nestjs/common";
+import type { ThrottlerStorage } from "@nestjs/throttler";
+import type Redis from "ioredis";
+import { TypedConfigService } from "../config/services/config.service";
+import { REDIS_COMMAND_CLIENT } from "../redis/redis.constants";
+import { RedisThrottlerStorage } from "./redis-throttler-storage";
+import { THROTTLER_STORAGE } from "./throttle.constants";
+
+/**
+ * 스로틀 스토리지 모듈
+ *
+ * cache/lock/dedup 모듈과 동일한 포트/어댑터 조립 형태:
+ * CACHE_TYPE=redis + Redis 연결이 있으면 RedisThrottlerStorage,
+ * 아니면 undefined(@nestjs/throttler 기본 in-memory storage 사용).
+ *
+ * @example
+ * // app.module.ts
+ * ThrottlerModule.forRootAsync({
+ *   imports: [ThrottleModule.forRoot()],
+ *   inject: [ConfigService, { token: THROTTLER_STORAGE, optional: true }],
+ *   ...
+ * })
+ */
+@Module({})
+export class ThrottleModule {
+	static forRoot(): DynamicModule {
+		const storageProvider: Provider = {
+			provide: THROTTLER_STORAGE,
+			useFactory: (
+				configService: TypedConfigService,
+				redis?: Redis,
+			): ThrottlerStorage | undefined => {
+				if (configService.cache.type === "redis" && redis) {
+					return new RedisThrottlerStorage(redis);
+				}
+
+				return undefined;
+			},
+			inject: [
+				TypedConfigService,
+				{ token: REDIS_COMMAND_CLIENT, optional: true },
+			],
+		};
+
+		return {
+			module: ThrottleModule,
+			providers: [TypedConfigService, storageProvider],
+			exports: [THROTTLER_STORAGE],
+		};
+	}
+
+	/**
+	 * 테스트용 모듈 설정
+	 */
+	static forTesting(storage?: ThrottlerStorage): DynamicModule {
+		return {
+			module: ThrottleModule,
+			providers: [{ provide: THROTTLER_STORAGE, useValue: storage }],
+			exports: [THROTTLER_STORAGE],
+		};
+	}
+}

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -1,17 +1,16 @@
 import * as Sentry from "@sentry/nestjs";
+import { resolveSentryOptions } from "./common/config/utils/sentry-options";
 
-const isProduction = process.env.NODE_ENV === "production";
+const options = resolveSentryOptions(process.env);
 
 Sentry.init({
-	dsn: isProduction ? process.env.SENTRY_DSN : undefined,
-	environment: process.env.NODE_ENV || "development",
+	dsn: process.env.SENTRY_DSN,
+	// production(APP_ENV 기준)에서만 발송 — 개발서버/스테이징/로컬은 무발송.
+	// enabled: false면 SDK가 transport를 만들지 않아 capture가 전부 no-op이다.
+	enabled: options.enabled,
+	environment: options.environment,
 	// TODO: 서비스 스케일업 시 릴리스 버저닝 추가 (e.g., release: process.env.SENTRY_RELEASE)
-	tracesSampleRate:
-		process.env.SENTRY_TRACES_SAMPLE_RATE !== undefined
-			? Number(process.env.SENTRY_TRACES_SAMPLE_RATE)
-			: process.env.NODE_ENV === "production"
-				? 0.2
-				: 1.0,
+	tracesSampleRate: options.tracesSampleRate,
 
 	beforeSend(event) {
 		// 요청 헤더에서 민감 정보 제거

--- a/apps/api/src/modules/admin-notification/jobs/daily-signup-summary.job.ts
+++ b/apps/api/src/modules/admin-notification/jobs/daily-signup-summary.job.ts
@@ -2,6 +2,7 @@ import { InjectQueue } from "@nestjs/bullmq";
 import { Injectable, Logger, type OnModuleInit } from "@nestjs/common";
 import type { Queue } from "bullmq";
 
+import { runInBackground } from "@/common/bullmq/non-blocking-init";
 import { subtractDays } from "@/common/date/utils/arithmetic";
 import { toDateString } from "@/common/date/utils/format";
 import {
@@ -47,17 +48,27 @@ export class DailySignupSummaryJob implements OnModuleInit {
 		private readonly processor: AdminNotificationProcessor,
 	) {}
 
-	async onModuleInit(): Promise<void> {
+	/** 스케줄러 등록 완료 프로미스 (테스트 대기용) — 부팅을 블로킹하지 않는다 */
+	schedulerRegistration: Promise<void> = Promise.resolve();
+
+	onModuleInit(): void {
 		// Processor에 자신을 등록 (순환 참조 방지)
 		this.processor.setDailySummaryJob(this);
 
-		await this.queue.upsertJobScheduler(
-			"daily-signup-summary-scheduler",
-			{ pattern: "0 0 * * *", tz: "Asia/Seoul" },
-			{ name: AdminNotificationJobName.DISPATCH_SUMMARY, data: {} },
-		);
+		// Redis 다운 중에도 부팅은 진행 — 오프라인 큐가 재연결 시 등록을 완료한다
+		this.schedulerRegistration = runInBackground(
+			this.#logger,
+			"Daily signup summary scheduler registration",
+			async () => {
+				await this.queue.upsertJobScheduler(
+					"daily-signup-summary-scheduler",
+					{ pattern: "0 0 * * *", tz: "Asia/Seoul" },
+					{ name: AdminNotificationJobName.DISPATCH_SUMMARY, data: {} },
+				);
 
-		this.#logger.log("Daily signup summary scheduler registered");
+				this.#logger.log("Daily signup summary scheduler registered");
+			},
+		);
 	}
 
 	/**

--- a/apps/api/src/modules/ai-report/jobs/report-generation.job.spec.ts
+++ b/apps/api/src/modules/ai-report/jobs/report-generation.job.spec.ts
@@ -50,7 +50,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-10T10:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.upsertJobScheduler).toHaveBeenCalledTimes(2);
@@ -71,7 +72,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-10T10:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockProcessor.setReportJob).toHaveBeenCalledWith(job);
@@ -84,7 +86,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T03:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).toHaveBeenCalledWith(
@@ -99,7 +102,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-04-01T02:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).toHaveBeenCalledWith(
@@ -114,7 +118,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-06-01T03:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).toHaveBeenCalledTimes(2);
@@ -135,7 +140,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T00:30:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).not.toHaveBeenCalled();
@@ -146,7 +152,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-10T10:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).not.toHaveBeenCalled();
@@ -157,7 +164,8 @@ describe("ReportGenerationJob — 리포트 생성 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-15T10:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).not.toHaveBeenCalled();

--- a/apps/api/src/modules/ai-report/jobs/report-generation.job.ts
+++ b/apps/api/src/modules/ai-report/jobs/report-generation.job.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger, type OnModuleInit } from "@nestjs/common";
 import type { Job, Queue } from "bullmq";
 import dayjs from "dayjs";
 import { AI_PER_USER_JOB_OPTS } from "@/common/bullmq/job-options";
+import { runInBackground } from "@/common/bullmq/non-blocking-init";
 import { forEachBatch } from "@/common/database";
 import { toIsoMonthId, toIsoWeekId } from "@/common/date/utils/format";
 import { DatabaseService } from "@/database/database.service";
@@ -40,30 +41,40 @@ export class ReportGenerationJob implements OnModuleInit {
 		private readonly processor: ReportGenerationProcessor,
 	) {}
 
-	async onModuleInit(): Promise<void> {
+	/** 스케줄러 등록 완료 프로미스 (테스트 대기용) — 부팅을 블로킹하지 않는다 */
+	schedulerRegistration: Promise<void> = Promise.resolve();
+
+	onModuleInit(): void {
 		// Processor에 자신을 등록 (순환 참조 방지)
 		this.processor.setReportJob(this);
 
-		await this.queue.upsertJobScheduler(
-			"weekly-report-scheduler",
-			{ pattern: "0 1 * * 1", tz: CRON_TZ },
-			{
-				name: AiReportJobName.DISPATCH,
-				data: { reportType: "WEEKLY" } satisfies AiReportJobData,
+		// Redis 다운 중에도 부팅은 진행 — 오프라인 큐가 재연결 시 등록을 완료한다
+		this.schedulerRegistration = runInBackground(
+			this.#logger,
+			"Report generation scheduler registration",
+			async () => {
+				await this.queue.upsertJobScheduler(
+					"weekly-report-scheduler",
+					{ pattern: "0 1 * * 1", tz: CRON_TZ },
+					{
+						name: AiReportJobName.DISPATCH,
+						data: { reportType: "WEEKLY" } satisfies AiReportJobData,
+					},
+				);
+				await this.queue.upsertJobScheduler(
+					"monthly-report-scheduler",
+					{ pattern: "0 2 1 * *", tz: CRON_TZ },
+					{
+						name: AiReportJobName.DISPATCH,
+						data: { reportType: "MONTHLY" } satisfies AiReportJobData,
+					},
+				);
+
+				this.#logger.log("Report generation schedulers registered");
+
+				await this.#catchUpIfNeeded();
 			},
 		);
-		await this.queue.upsertJobScheduler(
-			"monthly-report-scheduler",
-			{ pattern: "0 2 1 * *", tz: CRON_TZ },
-			{
-				name: AiReportJobName.DISPATCH,
-				data: { reportType: "MONTHLY" } satisfies AiReportJobData,
-			},
-		);
-
-		this.#logger.log("Report generation schedulers registered");
-
-		await this.#catchUpIfNeeded();
 	}
 
 	/**

--- a/apps/api/src/modules/ai-suggestion/jobs/suggestion-analysis.job.spec.ts
+++ b/apps/api/src/modules/ai-suggestion/jobs/suggestion-analysis.job.spec.ts
@@ -51,7 +51,8 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T07:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.upsertJobScheduler).toHaveBeenCalledWith(
@@ -66,7 +67,8 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T07:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.removeJobScheduler).toHaveBeenCalledWith(
@@ -79,7 +81,8 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T07:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			const removeOrder =
@@ -94,7 +97,8 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T07:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockProcessor.setSuggestionJob).toHaveBeenCalledWith(job);
@@ -107,7 +111,8 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T08:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).toHaveBeenCalledWith(
@@ -122,7 +127,8 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T07:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).not.toHaveBeenCalled();

--- a/apps/api/src/modules/ai-suggestion/jobs/suggestion-analysis.job.ts
+++ b/apps/api/src/modules/ai-suggestion/jobs/suggestion-analysis.job.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger, type OnModuleInit } from "@nestjs/common";
 import type { Job, Queue } from "bullmq";
 import dayjs from "dayjs";
 import { AI_PER_USER_JOB_OPTS } from "@/common/bullmq/job-options";
+import { runInBackground } from "@/common/bullmq/non-blocking-init";
 import { forEachBatch } from "@/common/database";
 import { subtractDays } from "@/common/date/utils/arithmetic";
 
@@ -36,22 +37,32 @@ export class SuggestionAnalysisJob implements OnModuleInit {
 		private readonly processor: SuggestionAnalysisProcessor,
 	) {}
 
-	async onModuleInit(): Promise<void> {
+	/** 스케줄러 등록 완료 프로미스 (테스트 대기용) — 부팅을 블로킹하지 않는다 */
+	schedulerRegistration: Promise<void> = Promise.resolve();
+
+	onModuleInit(): void {
 		// Processor에 자신을 등록 (순환 참조 방지)
 		this.processor.setSuggestionJob(this);
 
-		// 구 weekly 스케줄러 제거 (마이그레이션)
-		await this.queue.removeJobScheduler("weekly-suggestion-scheduler");
+		// Redis 다운 중에도 부팅은 진행 — 오프라인 큐가 재연결 시 등록을 완료한다
+		this.schedulerRegistration = runInBackground(
+			this.#logger,
+			"Suggestion analysis scheduler registration",
+			async () => {
+				// 구 weekly 스케줄러 제거 (마이그레이션)
+				await this.queue.removeJobScheduler("weekly-suggestion-scheduler");
 
-		await this.queue.upsertJobScheduler(
-			"daily-suggestion-scheduler",
-			{ pattern: "30 7 * * *", tz: "Asia/Seoul" },
-			{ name: AiSuggestionJobName.DISPATCH, data: {} },
+				await this.queue.upsertJobScheduler(
+					"daily-suggestion-scheduler",
+					{ pattern: "30 7 * * *", tz: "Asia/Seoul" },
+					{ name: AiSuggestionJobName.DISPATCH, data: {} },
+				);
+
+				this.#logger.log("Suggestion analysis scheduler registered");
+
+				await this.#catchUpIfNeeded();
+			},
 		);
-
-		this.#logger.log("Suggestion analysis scheduler registered");
-
-		await this.#catchUpIfNeeded();
 	}
 
 	/**

--- a/apps/api/src/modules/auth/guards/jwt-auth.guard.spec.ts
+++ b/apps/api/src/modules/auth/guards/jwt-auth.guard.spec.ts
@@ -14,7 +14,10 @@ import { Reflector } from "@nestjs/core";
 import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
 import { createMockExecutionContext } from "@test/mocks";
-import { BusinessException } from "@/common/exception/services/business-exception.service";
+import {
+	BusinessException,
+	BusinessExceptions,
+} from "@/common/exception/services/business-exception.service";
 
 import { IS_PUBLIC_KEY } from "../decorators/public.decorator";
 import { JwtAuthGuard } from "./jwt-auth.guard";
@@ -65,9 +68,9 @@ describe("JwtAuthGuard — JWT 인증 가드", () => {
 			expect(result).toBe(mockUser);
 		});
 
-		it("에러가 존재하면 BusinessException을 던져야 한다", () => {
-			// Given
-			const error = new Error("Token expired");
+		it("BusinessException(의도적 401)은 invalidToken으로 재포장해야 한다", () => {
+			// Given — validate()의 assertSessionValid/계정 상태 검증 등이 던진 예외
+			const error = BusinessExceptions.accountLocked("User");
 			const mockUser = {
 				userId: "user-1",
 				email: "test@test.com",
@@ -75,7 +78,7 @@ describe("JwtAuthGuard — JWT 인증 가드", () => {
 				role: "USER",
 			};
 
-			// When & Then
+			// When & Then — 기존(변경 전) 동작 유지: 클라 계약 불변
 			expect(() => guard.handleRequest(error, mockUser)).toThrow(
 				BusinessException,
 			);
@@ -86,9 +89,9 @@ describe("JwtAuthGuard — JWT 인증 가드", () => {
 			expect(() => guard.handleRequest(null, false)).toThrow(BusinessException);
 		});
 
-		it("에러 발생 시 AUTH_0101 에러 코드를 반환해야 한다", () => {
+		it("HttpException 에러 발생 시 AUTH_0101 에러 코드를 반환해야 한다", () => {
 			// Given
-			const error = new Error("Token expired");
+			const error = BusinessExceptions.accountSuspended("User");
 
 			// When & Then
 			try {
@@ -98,6 +101,19 @@ describe("JwtAuthGuard — JWT 인증 가드", () => {
 				expect(error).toBeInstanceOf(BusinessException);
 				expect((error as BusinessException).errorCode).toBe("AUTH_0101");
 			}
+		});
+
+		it("비-HttpException(인프라 오류)은 401로 위장하지 않고 그대로 rethrow해야 한다", () => {
+			// Given — DB 연결 실패 등 인프라 오류가 validate()에서 전파된 상황.
+			// 401로 위장하면 구버전 클라가 토큰을 삭제(강제 로그아웃)하므로
+			// 반드시 5xx로 흘려보내야 한다 (5xx는 토큰 보존 + Sentry 리포트).
+			const infraError = new Error("Connection terminated unexpectedly");
+
+			// When & Then
+			expect(() => guard.handleRequest(infraError, false)).toThrow(infraError);
+			expect(() => guard.handleRequest(infraError, false)).not.toThrow(
+				BusinessException,
+			);
 		});
 
 		it("에러 메시지가 없으면 기본 메시지를 사용해야 한다", () => {

--- a/apps/api/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/apps/api/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, Injectable } from "@nestjs/common";
+import { ExecutionContext, HttpException, Injectable } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { AuthGuard } from "@nestjs/passport";
 
@@ -32,6 +32,13 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
 	}
 
 	override handleRequest<TUser>(err: Error | null, user: TUser | false): TUser {
+		if (err && !(err instanceof HttpException)) {
+			// 인프라 오류(DB/캐시 장애 등)는 401로 위장하지 않는다.
+			// 401은 클라이언트가 토큰 삭제(강제 로그아웃)로 반응하므로,
+			// GlobalExceptionFilter가 500으로 처리 + Sentry 리포트되도록 rethrow.
+			throw err;
+		}
+
 		if (err || !user) {
 			throw BusinessExceptions.invalidToken({
 				reason: err?.message || "Access token is missing or invalid",

--- a/apps/api/src/modules/auth/jobs/account-purge.job.spec.ts
+++ b/apps/api/src/modules/auth/jobs/account-purge.job.spec.ts
@@ -62,7 +62,8 @@ describe("AccountPurgeJob — 계정 삭제 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T02:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.upsertJobScheduler).toHaveBeenCalledWith(
@@ -77,10 +78,36 @@ describe("AccountPurgeJob — 계정 삭제 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T02:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockProcessor.setPurgeJob).toHaveBeenCalledWith(job);
+		});
+
+		it("Redis가 무응답이어도 부팅(onModuleInit)이 블로킹되지 않는다", () => {
+			// Given — Redis 다운: 등록 명령이 영원히 pending
+			(mockQueue.upsertJobScheduler as jest.Mock).mockReturnValue(
+				new Promise(() => {}),
+			);
+
+			// When — 동기 반환 (await 없이 즉시 완료돼야 부팅이 안 막힌다)
+			const result = job.onModuleInit();
+
+			// Then
+			expect(result).toBeUndefined();
+			expect(mockProcessor.setPurgeJob).toHaveBeenCalledWith(job);
+		});
+
+		it("스케줄러 등록 실패 시 로그만 남기고 throw하지 않는다", async () => {
+			// Given
+			(mockQueue.upsertJobScheduler as jest.Mock).mockRejectedValue(
+				new Error("Connection is closed."),
+			);
+
+			// When / Then — 부팅 실패로 이어지지 않아야 한다
+			job.onModuleInit();
+			await expect(job.schedulerRegistration).resolves.toBeUndefined();
 		});
 	});
 
@@ -90,7 +117,8 @@ describe("AccountPurgeJob — 계정 삭제 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T05:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).toHaveBeenCalledWith(
@@ -105,7 +133,8 @@ describe("AccountPurgeJob — 계정 삭제 잡", () => {
 			jest.useFakeTimers({ now: new Date("2026-03-09T02:00:00+09:00") });
 
 			// When
-			await job.onModuleInit();
+			job.onModuleInit();
+			await job.schedulerRegistration;
 
 			// Then
 			expect(mockQueue.add).not.toHaveBeenCalled();

--- a/apps/api/src/modules/auth/jobs/account-purge.job.ts
+++ b/apps/api/src/modules/auth/jobs/account-purge.job.ts
@@ -2,6 +2,7 @@ import { InjectQueue } from "@nestjs/bullmq";
 import { Injectable, Logger, type OnModuleInit } from "@nestjs/common";
 import type { Queue } from "bullmq";
 import dayjs from "dayjs";
+import { runInBackground } from "@/common/bullmq/non-blocking-init";
 import { DatabaseService } from "@/database";
 
 import { ACCOUNT_DELETION, SECURITY_EVENT } from "../constants/auth.constants";
@@ -32,19 +33,29 @@ export class AccountPurgeJob implements OnModuleInit {
 		private readonly processor: AccountPurgeProcessor,
 	) {}
 
-	async onModuleInit(): Promise<void> {
+	/** 스케줄러 등록 완료 프로미스 (테스트 대기용) — 부팅을 블로킹하지 않는다 */
+	schedulerRegistration: Promise<void> = Promise.resolve();
+
+	onModuleInit(): void {
 		// Processor에 자신을 등록 (순환 참조 방지)
 		this.processor.setPurgeJob(this);
 
-		await this.queue.upsertJobScheduler(
-			"daily-account-purge-scheduler",
-			{ pattern: "0 3 * * *", tz: "Asia/Seoul" },
-			{ name: "purge-accounts", data: {} },
+		// Redis 다운 중에도 부팅은 진행 — 오프라인 큐가 재연결 시 등록을 완료한다
+		this.schedulerRegistration = runInBackground(
+			this.#logger,
+			"Account purge scheduler registration",
+			async () => {
+				await this.queue.upsertJobScheduler(
+					"daily-account-purge-scheduler",
+					{ pattern: "0 3 * * *", tz: "Asia/Seoul" },
+					{ name: "purge-accounts", data: {} },
+				);
+
+				this.#logger.log("Account purge scheduler registered");
+
+				await this.#catchUpIfNeeded();
+			},
 		);
-
-		this.#logger.log("Account purge scheduler registered");
-
-		await this.#catchUpIfNeeded();
 	}
 
 	/**

--- a/apps/api/src/modules/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/modules/auth/strategies/jwt.strategy.spec.ts
@@ -210,4 +210,62 @@ describe("JwtStrategy — JWT 전략", () => {
 			BusinessException,
 		);
 	});
+
+	describe("캐시 장애 폴백 (Redis 다운이어도 인증은 계속된다)", () => {
+		const cacheFailure = new Error("Connection is closed.");
+		const futureDate = new Date(Date.now() + 86400000);
+
+		it("세션 캐시 읽기 실패 시 DB 조회로 폴백해 정상 인증한다", async () => {
+			// Given
+			(cacheService.getSession as jest.Mock).mockRejectedValue(cacheFailure);
+			(sessionRepo.findById as jest.Mock).mockResolvedValue({
+				id: "session-456",
+				userId: "user-123",
+				expiresAt: futureDate,
+				revokedAt: null,
+			});
+
+			// When
+			const result = await strategy.validate(validPayload);
+
+			// Then
+			expect(result.userId).toBe("user-123");
+			expect(sessionRepo.findById).toHaveBeenCalledWith("session-456");
+		});
+
+		it("세션 캐시 쓰기 실패는 무시하고 정상 인증한다", async () => {
+			// Given
+			(cacheService.getSession as jest.Mock).mockResolvedValue(null);
+			(cacheService.setSession as jest.Mock).mockRejectedValue(cacheFailure);
+			(sessionRepo.findById as jest.Mock).mockResolvedValue({
+				id: "session-456",
+				userId: "user-123",
+				expiresAt: futureDate,
+				revokedAt: null,
+			});
+
+			// When
+			const result = await strategy.validate(validPayload);
+
+			// Then
+			expect(result.userId).toBe("user-123");
+		});
+
+		it("캐시 폴백은 의도적 401(세션 무효)을 삼키지 않는다", async () => {
+			// Given — 캐시는 정상, 세션이 진짜로 폐기된 상황
+			(cacheService.getSession as jest.Mock).mockResolvedValue({
+				userId: "user-123",
+				expiresAt: futureDate,
+				revokedAt: new Date(),
+			});
+			sessionService.assertSessionValid.mockImplementation(() => {
+				throw BusinessExceptions.sessionRevoked();
+			});
+
+			// When & Then
+			await expect(strategy.validate(validPayload)).rejects.toThrow(
+				BusinessException,
+			);
+		});
+	});
 });

--- a/apps/api/src/modules/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,9 +1,9 @@
 import type { CurrentUserPayload } from "@aido/validators";
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
 
-import { CacheService } from "@/common/cache/cache.service";
+import { type CachedSession, CacheService } from "@/common/cache/cache.service";
 import { TypedConfigService } from "@/common/config/services/config.service";
 import { toISOStringOrNull } from "@/common/date/utils/format";
 import { BusinessExceptions } from "@/common/exception/services/business-exception.service";
@@ -25,6 +25,8 @@ export type { CurrentUserPayload };
  */
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
+	readonly #logger = new Logger(JwtStrategy.name);
+
 	constructor(
 		readonly configService: TypedConfigService,
 		private readonly sessionRepository: SessionRepository,
@@ -62,8 +64,8 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
 			throw BusinessExceptions.invalidToken({ reason: "Missing sessionId" });
 		}
 
-		// 1. 캐시에서 세션 조회 (캐시-aside 패턴)
-		const cachedSession = await this.cacheService.getSession(payload.sessionId);
+		// 1. 캐시에서 세션 조회 (캐시-aside 패턴, 캐시 장애 시 미스 취급 → DB 폴백)
+		const cachedSession = await this.#getCachedSessionSafe(payload.sessionId);
 
 		if (cachedSession) {
 			// 캐시 히트: 캐시된 데이터로 유효성 검증
@@ -99,8 +101,9 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
 			this.#assertUserStatus(userStatus, userDeletedAt);
 		}
 
-		// 4. 유효한 세션을 캐시에 저장 (30초 TTL) — 사용자 상태 포함
-		await this.cacheService.setSession(payload.sessionId, {
+		// 4. 유효한 세션을 캐시에 저장 (30초 TTL) — 사용자 상태 포함.
+		//    캐시 장애 시 저장 실패는 무시 (다음 요청이 다시 DB를 탈 뿐)
+		await this.#setCachedSessionSafe(payload.sessionId, {
 			userId: session.userId,
 			expiresAt: session.expiresAt,
 			revokedAt: session.revokedAt,
@@ -117,6 +120,42 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
 	}
 
 	/**
+	 * 세션 캐시 읽기 — 캐시 장애를 미스로 격리 (belt-and-suspenders)
+	 *
+	 * 캐시 어댑터 자체가 fail-open이지만, 인증은 최후 방어선이므로 전략
+	 * 레벨에서도 한 번 더 격리한다. try 안에는 캐시 I/O만 둔다 —
+	 * assertSessionValid/#assertUserStatus의 의도적 401은 절대 삼키지 않는다.
+	 */
+	async #getCachedSessionSafe(
+		sessionId: string,
+	): Promise<CachedSession | undefined> {
+		try {
+			return await this.cacheService.getSession(sessionId);
+		} catch (error) {
+			this.#logger.warn(
+				`Session cache read failed — falling back to DB: ${toMessage(error)}`,
+			);
+			return undefined;
+		}
+	}
+
+	/**
+	 * 세션 캐시 쓰기 — 실패 시 무시 (다음 요청이 다시 DB를 탈 뿐)
+	 */
+	async #setCachedSessionSafe(
+		sessionId: string,
+		session: CachedSession,
+	): Promise<void> {
+		try {
+			await this.cacheService.setSession(sessionId, session);
+		} catch (error) {
+			this.#logger.warn(
+				`Session cache write failed — skipping: ${toMessage(error)}`,
+			);
+		}
+	}
+
+	/**
 	 * 사용자 상태 검증 (Defense in Depth)
 	 *
 	 * 세션이 유효하더라도 사용자가 잠금/정지/탈퇴 상태이면 접근을 거부합니다.
@@ -129,4 +168,8 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
 			throw BusinessExceptions.accountSuspended("User");
 		}
 	}
+}
+
+function toMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -42,6 +42,10 @@ export class HealthController {
 - \`up\`: 정상 동작 중
 - \`down\`: 서비스 이상
 
+> \`queues\`는 Redis 장애 시에도 \`up\`을 유지하고 \`degraded: true\` +
+> \`reason\`을 덧붙입니다 (Redis 다운은 태스크 재시작으로 해결되지 않으므로
+> 503을 만들지 않음). 모니터링 알람은 \`degraded\` 필드를 기준으로 합니다.
+
 ### 사용 예시
 \`\`\`bash
 curl https://api.aido.com/health

--- a/apps/api/src/modules/health/indicators/bull.health.spec.ts
+++ b/apps/api/src/modules/health/indicators/bull.health.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * BullHealthIndicator 단위 테스트
+ *
+ * @description
+ * Redis 다운은 태스크 재시작으로 해결되지 않으므로 queues 체크는 절대
+ * 503(down)을 만들지 않는다 — ALB/ECS가 멀쩡한 태스크를 죽이는 것을 방지.
+ * - ping 게이트: Redis 다운 시 큐 API를 호출하지 않고 up + degraded
+ * - 큐 API가 느리거나 실패해도 up + degraded (타임아웃 2초)
+ *
+ * 실행 명령:
+ * ```bash
+ * pnpm --filter @aido/api test bull.health
+ * ```
+ */
+import { HealthIndicatorService } from "@nestjs/terminus";
+import { BullHealthIndicator, type QueueHealthSource } from "./bull.health";
+
+interface FakeQueue extends QueueHealthSource {
+	isPaused: jest.Mock;
+	getJobCounts: jest.Mock;
+}
+
+function createFakeQueue(): FakeQueue {
+	return {
+		isPaused: jest.fn().mockResolvedValue(false),
+		getJobCounts: jest
+			.fn()
+			.mockResolvedValue({ active: 1, waiting: 2, failed: 0 }),
+	};
+}
+
+describe("BullHealthIndicator — BullMQ 큐 헬스 인디케이터", () => {
+	let queues: [FakeQueue, FakeQueue, FakeQueue, FakeQueue];
+
+	beforeEach(() => {
+		queues = [
+			createFakeQueue(),
+			createFakeQueue(),
+			createFakeQueue(),
+			createFakeQueue(),
+		];
+	});
+
+	function createIndicator(redis: { ping: jest.Mock } | null) {
+		return new BullHealthIndicator(
+			new HealthIndicatorService(),
+			queues[0],
+			queues[1],
+			queues[2],
+			queues[3],
+			redis,
+		);
+	}
+
+	it("Redis ping 실패 시 큐 API를 호출하지 않고 up + degraded를 반환한다", async () => {
+		// Given
+		const redis = {
+			ping: jest.fn().mockRejectedValue(new Error("Connection is closed.")),
+		};
+		const indicator = createIndicator(redis);
+
+		// When
+		const result = await indicator.isHealthy("queues");
+
+		// Then — down이 아니라 up: Redis 다운은 재시작으로 해결 안 됨
+		expect(result.queues?.status).toBe("up");
+		expect(result.queues).toMatchObject({ degraded: true });
+		expect(queues[0].isPaused).not.toHaveBeenCalled();
+		expect(queues[0].getJobCounts).not.toHaveBeenCalled();
+	});
+
+	it("Redis 정상 + 큐 정상이면 up과 큐 카운트를 반환한다", async () => {
+		// Given
+		const redis = { ping: jest.fn().mockResolvedValue("PONG") };
+		const indicator = createIndicator(redis);
+
+		// When
+		const result = await indicator.isHealthy("queues");
+
+		// Then
+		expect(result.queues?.status).toBe("up");
+		expect(result.queues).toMatchObject({
+			"ai-suggestion": { isPaused: false, active: 1, waiting: 2, failed: 0 },
+		});
+		expect(result.queues).not.toMatchObject({ degraded: true });
+	});
+
+	it("Redis 클라이언트가 없으면(메모리 모드) ping 없이 큐를 검사한다", async () => {
+		// Given
+		const indicator = createIndicator(null);
+
+		// When
+		const result = await indicator.isHealthy("queues");
+
+		// Then
+		expect(result.queues?.status).toBe("up");
+		expect(queues[0].getJobCounts).toHaveBeenCalled();
+	});
+
+	it("큐 API 실패 시에도 up + degraded를 반환한다 (down 금지)", async () => {
+		// Given
+		const redis = { ping: jest.fn().mockResolvedValue("PONG") };
+		queues[1].getJobCounts.mockRejectedValue(new Error("queue broken"));
+		const indicator = createIndicator(redis);
+
+		// When
+		const result = await indicator.isHealthy("queues");
+
+		// Then
+		expect(result.queues?.status).toBe("up");
+		expect(result.queues).toMatchObject({ degraded: true });
+	});
+
+	it("큐 API가 응답하지 않으면 2초 타임아웃 후 up + degraded를 반환한다", async () => {
+		// Given
+		jest.useFakeTimers();
+		const redis = { ping: jest.fn().mockResolvedValue("PONG") };
+		queues[0].isPaused.mockReturnValue(new Promise(() => {}));
+		const indicator = createIndicator(redis);
+
+		// When
+		const pending = indicator.isHealthy("queues");
+		await jest.advanceTimersByTimeAsync(2_000);
+		const result = await pending;
+
+		// Then
+		expect(result.queues?.status).toBe("up");
+		expect(result.queues).toMatchObject({ degraded: true });
+		jest.useRealTimers();
+	});
+});

--- a/apps/api/src/modules/health/indicators/bull.health.ts
+++ b/apps/api/src/modules/health/indicators/bull.health.ts
@@ -1,57 +1,115 @@
 import { InjectQueue } from "@nestjs/bullmq";
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable, Optional } from "@nestjs/common";
 import {
 	type HealthIndicatorResult,
 	HealthIndicatorService,
 } from "@nestjs/terminus";
-import type { Queue } from "bullmq";
+import { REDIS_COMMAND_CLIENT } from "@/common/redis/redis.constants";
+import { withTimeout } from "@/common/redis/with-timeout";
 import { ADMIN_NOTIFICATION_QUEUE } from "@/modules/admin-notification/queue/admin-notification-queue.constants";
 import { AI_REPORT_QUEUE } from "@/modules/ai-report/processors/report-generation.processor";
 import { AI_SUGGESTION_QUEUE } from "@/modules/ai-suggestion/processors/suggestion-analysis.processor";
 import { TODO_REMINDER_QUEUE } from "@/modules/scheduler/reminder/adapters/bullmq-reminder-scheduler.adapter";
 
+/** 큐 상태 수집 타임아웃 — 초과 시 up + degraded로 응답 */
+const QUEUE_STATS_TIMEOUT_MS = 2_000;
+
+/**
+ * 헬스 체크에 필요한 최소 큐 계약 (BullMQ Queue가 구조적으로 만족)
+ */
+export interface QueueHealthSource {
+	isPaused(): Promise<boolean>;
+	getJobCounts(...types: string[]): Promise<Record<string, number>>;
+}
+
+/**
+ * ping 게이트에 필요한 최소 Redis 계약
+ */
+export interface RedisPingSource {
+	ping(): Promise<string>;
+}
+
 /**
  * BullMQ 큐 헬스 체크 인디케이터
  *
  * 핵심 4개 큐의 상태(일시정지 여부, 잡 카운트)를 모니터링합니다.
+ *
+ * 절대 down(503)을 만들지 않는다: Redis 다운은 태스크 재시작으로 해결되지
+ * 않으므로, ALB/ECS가 멀쩡한 태스크를 죽이지 않도록 장애 시에도
+ * `up + degraded: true`로 응답한다. 모니터링/알람은 degraded 필드를 본다.
+ *
+ * ping 게이트: 큐 API(isPaused/getJobCounts)는 BullMQ 공유 클라이언트
+ * (오프라인 큐 유지)를 타므로 Redis 다운 중 호출하면 명령이 무한 대기
+ * 상태로 쌓인다. fail-fast 명령용 클라이언트로 먼저 ping해 Redis가
+ * 죽어있으면 큐 API를 아예 호출하지 않는다.
  */
 @Injectable()
 export class BullHealthIndicator {
 	constructor(
 		private readonly healthIndicatorService: HealthIndicatorService,
 		@InjectQueue(AI_SUGGESTION_QUEUE)
-		private readonly aiSuggestionQueue: Queue,
+		private readonly aiSuggestionQueue: QueueHealthSource,
 		@InjectQueue(AI_REPORT_QUEUE)
-		private readonly aiReportQueue: Queue,
+		private readonly aiReportQueue: QueueHealthSource,
 		@InjectQueue(ADMIN_NOTIFICATION_QUEUE)
-		private readonly adminNotificationQueue: Queue,
+		private readonly adminNotificationQueue: QueueHealthSource,
 		@InjectQueue(TODO_REMINDER_QUEUE)
-		private readonly todoReminderQueue: Queue,
+		private readonly todoReminderQueue: QueueHealthSource,
+		@Optional()
+		@Inject(REDIS_COMMAND_CLIENT)
+		private readonly redis: RedisPingSource | null = null,
 	) {}
 
 	async isHealthy(key: string): Promise<HealthIndicatorResult> {
 		const indicator = this.healthIndicatorService.check(key);
 
-		try {
-			const queues = [
-				{ name: "ai-suggestion", queue: this.aiSuggestionQueue },
-				{ name: "ai-report", queue: this.aiReportQueue },
-				{ name: "admin-notification", queue: this.adminNotificationQueue },
-				{ name: "todo-reminder", queue: this.todoReminderQueue },
-			];
-
-			const results: Record<string, unknown> = {};
-			for (const { name, queue } of queues) {
-				const [isPaused, counts] = await Promise.all([
-					queue.isPaused(),
-					queue.getJobCounts("active", "waiting", "failed"),
-				]);
-				results[name] = { isPaused, ...counts };
+		if (this.redis) {
+			try {
+				await this.redis.ping();
+			} catch (error) {
+				return indicator.up({
+					degraded: true,
+					reason: `redis unavailable: ${toMessage(error)}`,
+				});
 			}
+		}
 
+		try {
+			const results = await withTimeout(
+				this.#collectQueueStats(),
+				QUEUE_STATS_TIMEOUT_MS,
+				"Queue stats collection",
+			);
 			return indicator.up(results);
 		} catch (error) {
-			return indicator.down({ error: (error as Error).message });
+			return indicator.up({
+				degraded: true,
+				reason: toMessage(error),
+			});
 		}
 	}
+
+	async #collectQueueStats(): Promise<Record<string, unknown>> {
+		const queues = [
+			{ name: "ai-suggestion", queue: this.aiSuggestionQueue },
+			{ name: "ai-report", queue: this.aiReportQueue },
+			{ name: "admin-notification", queue: this.adminNotificationQueue },
+			{ name: "todo-reminder", queue: this.todoReminderQueue },
+		];
+
+		const results: Record<string, unknown> = {};
+		for (const { name, queue } of queues) {
+			const [isPaused, counts] = await Promise.all([
+				queue.isPaused(),
+				queue.getJobCounts("active", "waiting", "failed"),
+			]);
+			results[name] = { isPaused, ...counts };
+		}
+
+		return results;
+	}
+}
+
+function toMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }

--- a/apps/api/src/modules/notification/notification.module.ts
+++ b/apps/api/src/modules/notification/notification.module.ts
@@ -2,7 +2,7 @@ import { Module } from "@nestjs/common";
 import type Redis from "ioredis";
 
 import { TypedConfigService } from "@/common/config/services/config.service";
-import { REDIS_CLIENT } from "@/common/redis/redis.constants";
+import { REDIS_COMMAND_CLIENT } from "@/common/redis/redis.constants";
 import { UserSettingsModule } from "@/modules/user-settings/user-settings.module";
 
 import { NotificationController } from "./notification.controller";
@@ -60,7 +60,10 @@ import {
 				}
 				return new InMemoryPushRateLimiter();
 			},
-			inject: [TypedConfigService, { token: REDIS_CLIENT, optional: true }],
+			inject: [
+				TypedConfigService,
+				{ token: REDIS_COMMAND_CLIENT, optional: true },
+			],
 		},
 		// BullMQ Queue Processor
 		NotificationQueueProcessor,

--- a/apps/api/src/modules/notification/rate-limiter/redis-push-rate-limiter.ts
+++ b/apps/api/src/modules/notification/rate-limiter/redis-push-rate-limiter.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@nestjs/common";
 import type Redis from "ioredis";
+import { RedisErrorLogSampler } from "@/common/redis/redis-error-log-sampler";
 import type { IPushRateLimiter } from "./push-rate-limiter.interface";
 
 /** 1시간 윈도우 내 최대 푸시 횟수 */
@@ -53,6 +54,7 @@ export class RedisPushRateLimiter implements IPushRateLimiter {
 	readonly #logger = new Logger(RedisPushRateLimiter.name);
 	readonly #redis: Redis;
 	readonly #keyPrefix = "push-rate:";
+	readonly #errorSampler = new RedisErrorLogSampler(this.#logger);
 
 	constructor(redis: Redis) {
 		this.#redis = redis;
@@ -76,9 +78,7 @@ export class RedisPushRateLimiter implements IPushRateLimiter {
 
 			return result === 1;
 		} catch (error) {
-			this.#logger.warn(
-				`Redis push rate limit error (fail-open): ${error instanceof Error ? error.message : error}`,
-			);
+			this.#errorSampler.warn("PUSH_RATE_LIMIT", error);
 			// fail-open: Redis 장애 시 발송 허용
 			return false;
 		}

--- a/apps/api/src/modules/scheduler/jobs/timezone-aware-reminder.job.ts
+++ b/apps/api/src/modules/scheduler/jobs/timezone-aware-reminder.job.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, type OnModuleInit } from "@nestjs/common";
 import dayjs from "dayjs";
 
+import { runInBackground } from "@/common/bullmq/non-blocking-init";
 import { CacheService } from "@/common/cache/cache.service";
 import { addDays } from "@/common/date/utils/arithmetic";
 import { todayInTimezone } from "@/common/date/utils/timezone";
@@ -59,11 +60,19 @@ export class TimezoneAwareReminderJob implements OnModuleInit {
 		private readonly weatherEvening: WeatherEveningStrategy,
 	) {}
 
-	async onModuleInit(): Promise<void> {
+	/** 스케줄러 등록 완료 프로미스 (테스트 대기용) — 부팅을 블로킹하지 않는다 */
+	schedulerRegistration: Promise<void> = Promise.resolve();
+
+	onModuleInit(): void {
 		// Processor에 자신을 등록 (순환 참조 방지)
 		this.processor.setReminderJob(this);
 
-		await this.queueService.registerSweepScheduler();
+		// Redis 다운 중에도 부팅은 진행 — 오프라인 큐가 재연결 시 등록을 완료한다
+		this.schedulerRegistration = runInBackground(
+			this.#logger,
+			"Timezone reminder sweep scheduler registration",
+			() => this.queueService.registerSweepScheduler(),
+		);
 	}
 
 	/**

--- a/apps/api/test/e2e/__snapshots__/openapi-contract.e2e-spec.ts.snap
+++ b/apps/api/test/e2e/__snapshots__/openapi-contract.e2e-spec.ts.snap
@@ -20845,6 +20845,10 @@ GET /daily-completions?startDate=2026-01-01&endDate=2026-01-31
 - \`up\`: 정상 동작 중
 - \`down\`: 서비스 이상
 
+> \`queues\`는 Redis 장애 시에도 \`up\`을 유지하고 \`degraded: true\` +
+> \`reason\`을 덧붙입니다 (Redis 다운은 태스크 재시작으로 해결되지 않으므로
+> 503을 만들지 않음). 모니터링 알람은 \`degraded\` 필드를 기준으로 합니다.
+
 ### 사용 예시
 \`\`\`bash
 curl https://api.aido.com/health

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
     image: redis:7-alpine
     container_name: aido-dev-redis
     ports:
-      - "6379:6379"
+      - "${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - dev_redis_data:/data
     healthcheck:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,8 +158,8 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       ioredis:
-        specifier: ^5.11.0
-        version: 5.11.1
+        specifier: 5.10.1
+        version: 5.10.1
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -256,7 +256,7 @@ importers:
         version: 5.0.6
       '@types/ioredis-mock':
         specifier: ^8.2.7
-        version: 8.2.7(ioredis@5.11.1)
+        version: 8.2.7(ioredis@5.10.1)
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
@@ -286,7 +286,7 @@ importers:
         version: 7.2.0
       ioredis-mock:
         specifier: ^8.13.1
-        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.11.1))(ioredis@5.11.1)
+        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1)
       jest:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@22.19.7)(ts-node@10.9.2(@swc/core@1.15.41)(@types/node@22.19.7)(typescript@5.9.3))
@@ -1149,10 +1149,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -4886,10 +4882,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cluster-key-slot@1.1.1:
-    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
-    engines: {node: '>=0.10.0'}
-
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
@@ -6500,10 +6492,6 @@ packages:
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
-    engines: {node: '>=12.22.0'}
-
-  ioredis@5.11.1:
-    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
     engines: {node: '>=12.22.0'}
 
   ipaddr.js@1.9.1:
@@ -10400,8 +10388,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/runtime@7.28.6': {}
-
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
@@ -13479,9 +13465,9 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/ioredis-mock@8.2.7(ioredis@5.11.1)':
+  '@types/ioredis-mock@8.2.7(ioredis@5.10.1)':
     dependencies:
-      ioredis: 5.11.1
+      ioredis: 5.10.1
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -14220,58 +14206,6 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-expo@57.0.1(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@57.0.2)(react-refresh@0.14.2):
-    dependencies:
-      '@babel/generator': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@react-native/babel-plugin-codegen': 0.86.0(@babel/core@7.29.0)
-      babel-plugin-react-compiler: 1.0.0
-      babel-plugin-react-native-web: 0.21.2
-      babel-plugin-syntax-hermes-parser: 0.36.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      debug: 4.4.3
-      react-refresh: 0.14.2
-    optionalDependencies:
-      '@babel/runtime': 7.28.6
-      expo: 57.0.2(@babel/core@7.29.0)(@expo/dom-webview@57.0.0)(@expo/metro-runtime@57.0.3)(expo-router@57.0.3)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   babel-preset-expo@57.0.1(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@57.0.2)(react-refresh@0.14.2):
     dependencies:
       '@babel/generator': 7.29.7
@@ -14704,8 +14638,6 @@ snapshots:
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
-
-  cluster-key-slot@1.1.1: {}
 
   cluster-key-slot@1.1.2: {}
 
@@ -15779,7 +15711,7 @@ snapshots:
 
   expo@57.0.2(@babel/core@7.29.0)(@expo/dom-webview@57.0.0)(@expo/metro-runtime@57.0.3)(expo-router@57.0.3)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@expo/cli': 57.0.4(@expo/dom-webview@57.0.0)(@expo/metro-runtime@57.0.3)(expo-constants@57.0.3)(expo-font@57.0.0)(expo-router@57.0.3)(expo@57.0.2)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@expo/config': 57.0.2(typescript@5.9.3)
       '@expo/config-plugins': 57.0.2(typescript@5.9.3)
@@ -15790,7 +15722,7 @@ snapshots:
       '@expo/metro': 56.0.0
       '@expo/metro-config': 57.0.3(expo@57.0.2)(typescript@5.9.3)
       '@ungap/structured-clone': 1.3.2
-      babel-preset-expo: 57.0.1(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@57.0.2)(react-refresh@0.14.2)
+      babel-preset-expo: 57.0.1(@babel/core@7.29.0)(@babel/runtime@7.29.7)(expo@57.0.2)(react-refresh@0.14.2)
       expo-asset: 57.0.3(expo@57.0.2)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       expo-constants: 57.0.3(expo@57.0.2)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
       expo-file-system: 57.0.0(expo@57.0.2)(react-native@0.86.0(@babel/core@7.29.0)(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
@@ -16534,14 +16466,14 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.11.1))(ioredis@5.11.1):
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1):
     dependencies:
       '@ioredis/as-callback': 3.0.0
       '@ioredis/commands': 1.10.0
-      '@types/ioredis-mock': 8.2.7(ioredis@5.11.1)
+      '@types/ioredis-mock': 8.2.7(ioredis@5.10.1)
       fengari: 0.1.5
       fengari-interop: 0.1.4(fengari@0.1.5)
-      ioredis: 5.11.1
+      ioredis: 5.10.1
       semver: 7.8.5
 
   ioredis@5.10.1:
@@ -16552,18 +16484,6 @@ snapshots:
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ioredis@5.11.1:
-    dependencies:
-      '@ioredis/commands': 1.10.0
-      cluster-key-slot: 1.1.1
-      debug: 4.4.3
-      denque: 2.1.0
       redis-errors: 1.2.0
       redis-parser: 3.0.0
       standard-as-callback: 2.1.0
@@ -17752,7 +17672,7 @@ snapshots:
 
   metro-runtime@0.84.4:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
   metro-source-map@0.84.4:
@@ -18744,7 +18664,7 @@ snapshots:
 
   react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@react-native/normalize-colors': 0.74.89
       fbjs: 3.0.5
       inline-style-prefixer: 7.0.1


### PR DESCRIPTION
## 요약

Redis가 죽으면 모든 HTTP 요청이 무한 대기하던 문제를 실무 표준 패턴(용도별 연결 분리 + fail-fast + graceful degradation)으로 해결합니다. 새 외부 라이브러리 없이 ioredis 내장 옵션으로 구현했고, 클라이언트 영향은 0입니다.

Closes #600
Closes #601
Closes #602

## 핵심 변경

### 1. Redis 연결 이원화 (근본 원인 해결)
- `REDIS_CLIENT`: BullMQ 전용 (`maxRetriesPerRequest: null` + 오프라인 큐 유지 — 블로킹 명령 요구사항)
- `REDIS_COMMAND_CLIENT` 신설: `enableOfflineQueue: false` + `commandTimeout` 1.5s + `maxRetriesPerRequest: 1` — 단절 시 명령이 즉시 reject되어 어댑터의 fail-open이 작동
- 캐시/락/스로틀/dedup/푸시 레이트리미터/헬스 ping이 명령용 클라이언트 사용

### 2. 포트별 장애 계약 명문화 (인터페이스 JSDoc + 계약 공유 스펙)
| 포트 | 정책 | 장애 시 |
|---|---|---|
| `ICacheService` | fail-open | 읽기=미스 취급(DB 폴백), 쓰기=무시 |
| `ILockProvider` | fail-closed | acquire=null(busy), release=무시(TTL 정리) |
| `IDedupProvider` | fail-open | 비중복 취급 (DB unique가 최종 방어선) |
| `ThrottlerStorage` | fail-open | 요청 허용 |

`cache-adapter.contract.ts` 공유 스펙을 in-memory/Redis 양쪽에 실행해 어댑터 교체 가능성을 검증합니다. ThrottlerStorage 조립도 `ThrottleModule.forRoot()`로 분리해 다른 포트와 형태를 통일했습니다.

### 3. 인증 방어선 (#601)
- `JwtStrategy`: 세션 캐시 실패 → DB 폴백. Redis 완전 다운에도 로그인 유저 정상 200
- `JwtAuthGuard.handleRequest`: 비-HttpException(인프라 오류)을 401로 위장하지 않고 rethrow → 500 + Sentry. 배포된 클라(v1.3.x~1.4.1)의 token-refresher는 401→토큰 삭제 / 5xx→토큰 보존이므로 이 변경이 구버전 앱을 **보호**합니다

### 4. /health — 절대 503을 만들지 않음
Redis 다운은 태스크 재시작으로 해결되지 않으므로 `queues`는 `up + degraded: true`로 응답 (ALB가 멀쩡한 태스크를 죽이지 않도록). 명령용 클라이언트 ping 게이트로 BullMQ 오프라인 큐 누적도 방지. 모니터링 알람은 `degraded` 필드 기준.

### 5. 부팅/종료 견고화 (#602)
- BullMQ 스케줄러 등록 5곳을 `runInBackground`로 논블로킹 전환 — Redis 다운 중에도 배포 가능, 복구 시 오프라인 큐가 자동 등록
- 종료 훅을 `onApplicationShutdown`(멱등)으로 이관 — BullMQ Worker 정리 후 quit(3s 타임아웃 → disconnect 폴백). 'Connection is closed.' unhandled rejection(Sentry 2096건) 해소

### 6. 부수 개선
- Sentry 발송을 배포 환경(`APP_ENV`) 기준으로 게이트 — 미설정 시 NODE_ENV 폴백(하위호환, 인프라 무변경). 개발서버가 나중에 prod 빌드로 전환돼도 알림이 새지 않음
- `RedisErrorLogSampler`: 장애 중 로그 폭발 방지 (30초 윈도우당 warn 1회)
- ioredis를 bullmq 고정 버전(5.10.1)으로 단일화 → `connection: redis as never` 캐스트 제거

## 검증 (docker:dev 클린 기동, 실측)

| 시나리오 | 이전 | 현재 |
|---|---|---|
| Redis 정지 중 인증 요청 50연속 | 전부 무한 hang | 전부 200, 6~30ms (DB 폴백) |
| Redis 정지 중 주요 API (todos CRUD·memos·notifications·follows 등) | hang | 전부 200 |
| Redis 정지 중 MQ 적재 (팔로우 알림) | — | 201 즉시 응답, 복구 8초 내 잡 자동 처리·알림 도착 |
| Redis 정지 중 /health | hang | 200 + degraded |
| blackhole (docker pause) | hang | 200, 요청당 최대 ~4.5s 상한 |
| Redis 다운 상태 부팅 | 부트스트랩 무한 정지 | 정상 기동, 복구 시 스케줄러 5개 자동 등록 |
| 정상 배포 SIGTERM | unhandled rejection | 1초 내 클린 종료, 0건 |

- 단위 2,407개 / E2E 371개 전부 통과, typecheck·lint 클린
- **클라 계약 불변**: openapi-contract 스냅샷 diff = /health Swagger 설명 문구 4줄뿐 (스키마/상태코드 변화 0)

## 스코프 밖 (별도 이슈 유지)
- #603 Dockerfile /app/certs 권한 → RDS CA 미적재
- #604 ElastiCache maxmemory-policy (파라미터 그룹, 코드로 불가)
- Redis 다운 '중' 종료는 여전히 BullMQ Worker.close 대기 → 오케스트레이터 SIGKILL 폴백(30s)에 의존 (develop과 동일한 기존 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)