### PR TITLE
fix(api): runInBackground 동기 throw 흡수 (gemini 리뷰 반영)

### DIFF
--- a/apps/api/src/common/bullmq/non-blocking-init.spec.ts
+++ b/apps/api/src/common/bullmq/non-blocking-init.spec.ts
@@ -38,6 +38,22 @@ describe("runInBackground — 부팅 논블로킹 초기화", () => {
 		expect(logger.error).not.toHaveBeenCalled();
 	});
 
+	it("동기 throw도 호출부로 전파하지 않고 로그만 남긴다 (부트스트랩 크래시 방지)", async () => {
+		// Given — 프로미스를 반환하기 전에 동기적으로 터지는 작업
+		const logger = { error: jest.fn() };
+		const task = (): Promise<void> => {
+			throw new Error("sync boom");
+		};
+
+		// When / Then — 호출 자체가 throw하면 안 된다
+		await expect(
+			runInBackground(logger, "Scheduler registration", task),
+		).resolves.toBeUndefined();
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("sync boom"),
+		);
+	});
+
 	it("작업 실패 시 reject하지 않고 에러 로그만 남긴다 (unhandled rejection 방지)", async () => {
 		// Given
 		const logger = { error: jest.fn() };

--- a/apps/api/src/common/bullmq/non-blocking-init.ts
+++ b/apps/api/src/common/bullmq/non-blocking-init.ts
@@ -11,14 +11,17 @@ import type { Logger } from "@nestjs/common";
  *
  * @returns 절대 reject하지 않는 프로미스 — 테스트에서 완료 대기용
  */
-export function runInBackground(
+export async function runInBackground(
 	logger: Pick<Logger, "error">,
 	label: string,
 	task: () => Promise<void>,
 ): Promise<void> {
-	return task().catch((error: unknown) => {
+	try {
+		// async 함수라 task()의 동기 throw도 catch로 흡수된다 (부트스트랩 크래시 방지)
+		await task();
+	} catch (error: unknown) {
 		logger.error(
 			`${label} failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
-	});
+	}
 }


### PR DESCRIPTION
#614 gemini 리뷰 반영 — `runInBackground`의 `task()`가 프로미스 반환 전에 동기 throw하면 `.catch()`에 도달하지 못하고 부트스트랩이 크래시할 수 있는 문제를 async try/catch로 방어합니다.

현재 5개 호출부는 전부 async 함수라 실제 발생 경로는 없지만, 재사용 가능한 공용 헬퍼이므로 계약("절대 reject하지 않는다")을 완전하게 만듭니다. TDD로 동기 throw 케이스 스펙 추가 (RED→GREEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)