### PR TITLE
ci(tooling): SSH 배포 Action 경고 제거 (#648)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,11 @@ jobs:
 
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           command_timeout: 20m
-          script_stop: true
           script: |
-            ~/apps/deploy.sh
+            bash -e ~/apps/deploy.sh


### PR DESCRIPTION
## 📋 개요

`appleboy/ssh-action@v1`에서 제거된 `script_stop` 입력 때문에 발생하는 운영 배포 경고를 제거하고, 현재 사용 중인 v1.2.5를 검증된 전체 commit SHA로 고정합니다. 원격 `deploy.sh`의 기존 `set -e`에 더해 workflow에서도 `bash -e`로 실행해 fail-fast 의도를 버전 관리되는 설정에 명시합니다.

서버 코드, API 계약, DB, 모바일, dependency, 환경변수 변경은 없습니다.

## 🏷️ 변경 유형

- [x] 👷 `ci` - CI/CD 설정 및 스크립트 변경

## 📦 영향 범위

- [x] `tooling/*` - GitHub Actions 배포 workflow

## 📝 변경 내용

- 미지원 `script_stop: true` 입력 제거
- `appleboy/ssh-action`을 공식 v1.2.5의 검증된 전체 SHA `0ff4204d59e8e51228ff73bce53f80d53301dee2`로 고정
- 같은 줄의 `# v1.2.5` 주석을 유지해 기존 Dependabot GitHub Actions 주간 업데이트와 연동
- 원격 배포 스크립트를 `bash -e ~/apps/deploy.sh`로 호출해 command 실패 전파를 workflow에서도 보장

## 🧪 테스트

### 테스트 방법

```bash
actionlint -verbose .github/workflows/deploy.yml
pnpm lint
pnpm typecheck
pnpm build
git diff --check
```

현재 설정에서 unsupported input·mutable tag·fail-fast 호출 누락을 검출하는 정적 검사를 먼저 실패시킨 뒤, 수정 후 동일 검사가 통과하는 것을 확인했습니다.

### 테스트 결과

- [x] actionlint parse errors 0
- [x] root lint / typecheck / build 통과
- [x] workflow 회귀 검사 통과 (`script_stop` 0건, 고정 SHA·`bash -e` 각 1건)
- [x] 공식 v1.2.5 tag가 고정 SHA를 가리키는지 GitHub API로 확인
- [x] 운영 `~/apps/deploy.sh`의 `set -e`, 명시적 health failure `exit 1`, `bash -n` 성공 확인

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm lint` 검사를 통과했습니다
- [x] 변경사항에 대한 RED/GREEN 회귀 검사를 수행했습니다
- [x] `pnpm typecheck`를 통과했습니다
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 신규 문서가 필요 없는 단일 workflow 설정 변경입니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

### 리뷰어 확인

- [ ] 배포 실패가 GitHub Deploy job 실패로 계속 전파됩니다
- [ ] 고정한 Action SHA가 공식 v1.2.5 release commit입니다
- [ ] Dependabot 업데이트 경로가 유지됩니다
- [ ] 서버·클라이언트 런타임 계약 변경이 없습니다

## 🔗 관련 이슈

Closes #648

## 💬 추가 정보

이 PR을 develop에 병합해도 운영 배포는 시작되지 않습니다. 이후 develop → main 배포 PR을 merge commit으로 병합하고, main CI 뒤 `Deploy to EC2` 로그에서 `Unexpected input(s) 'script_stop'` 경고가 사라졌는지와 `Health check: OK`를 확인합니다.