### PR TITLE
ci(tooling): SSH 배포 Action 경고 제거 배포 (develop → main)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,11 @@ jobs:
 
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           command_timeout: 20m
-          script_stop: true
           script: |
-            ~/apps/deploy.sh
+            bash -e ~/apps/deploy.sh


### PR DESCRIPTION
# SSH 배포 Action 경고 제거 배포

> `develop` → `main`
>
> ⚠️ **CI/CD 설정 단독 배포** — 서버 애플리케이션, API 계약, DB, 모바일 앱, 의존성 및 환경변수 변경은 포함하지 않습니다.
>
> 🔀 **최종 merge는 `Create a merge commit` 필수** — squash/rebase merge하지 않습니다.

## 📋 개요

GitHub Actions의 `appleboy/ssh-action`에서 발생하던 미지원 `script_stop` 입력 경고를 제거하고, Action을 검증된 v1.2.5 전체 commit SHA로 고정합니다. `main..develop`은 source PR #649의 squash commit `824aa118` 1개이며, 순 변경은 `.github/workflows/deploy.yml` 1개 파일의 2 insertions / 3 deletions입니다.

`apps/api`, `apps/mobile`, shared packages, Prisma schema/migration, package dependency, 환경변수 diff는 **0**입니다.

## 📦 배포 범위

- [x] `.github/workflows/deploy.yml` — SSH Action 입력·버전·실패 전파 보강
- [ ] 서버 애플리케이션 / API 계약 — 변경 없음
- [ ] PostgreSQL schema / migration — 변경 없음
- [ ] 서버 환경변수 / package dependency — 변경 없음
- [ ] `apps/mobile` / 모바일 배포 — 변경 없음

## 🔄 Before / After

| 구분 | Before | After |
|---|---|---|
| 미지원 입력 | `script_stop: true` 경고 발생 | 미지원 입력 제거 |
| Action 참조 | 가변 major tag `@v1` | verified v1.2.5 commit `0ff4204d...` 전체 SHA |
| 실패 전파 | 원격 `deploy.sh`의 `set -e`에 의존 | workflow의 `bash -e` + 원격 script의 `set -e` |
| 자동 갱신 | Dependabot GitHub Actions 주간 갱신 | 기존 경로 그대로 유지 |

## 🛡️ 보안·호환성

- 기존 `@v1`이 현재 해석하던 commit과 고정한 v1.2.5 SHA가 같아 Action 실행 artifact 자체는 바뀌지 않습니다.
- 전체 SHA로 공급망 참조를 불변으로 만들고, 같은 줄의 `# v1.2.5` 주석으로 Dependabot 갱신 가능성과 가독성을 유지합니다.
- 미지원 입력만 제거하며 SSH host/username/key/timeout/script 계약은 그대로입니다.
- 원격 `~/apps/deploy.sh`는 이미 `set -e`, health 실패 시 `exit 1`을 사용하며 workflow에서도 `bash -e`로 명시적으로 호출합니다.

## 🧪 검증

| 항목 | 결과 |
|---|---|
| `actionlint -verbose .github/workflows/deploy.yml` | pass — parse error 0 |
| monorepo lint / typecheck / build | pass |
| Source PR GitHub CI | Build · Lint & Type Check · Test 3/3 pass |
| upstream Action 검증 | v1.2.5 tag SHA 일치, commit signature verified, 사용 입력 지원 확인 |
| 원격 deploy script | `bash -n` pass, `set -e` 및 health 실패 `exit 1` 확인 |
| Gemini review | 5분 이상 대기했으나 서비스 종료 시점과 겹쳐 생성 없음, unresolved 0 |
| release diff scope | workflow 1개 파일, 2 insertions / 3 deletions |

## 🚀 배포 순서 및 주의사항

1. 이 PR을 반드시 GitHub의 **Create a merge commit** 또는 `gh pr merge --merge`로 합칩니다.
2. `main` CI 통과 후 `workflow_run`으로 `Deploy to EC2`가 실행되는지 확인합니다.
3. 배포 로그에서 unsupported input 경고가 사라졌는지, 고정 SHA Action 실행, main merge SHA checkout, build/migration/restart, `Health check: OK`를 확인합니다.
4. 공개 `https://api.aido.kr/health`의 HTTP 200과 database/queues 상태를 확인합니다.
5. 원격 `develop`을 `main` merge commit으로 fast-forward 동기화하고 SHA/tree diff 0을 확인합니다.

## 🔗 관련 작업

- Source PR: #649
- Issue: #648
- Source squash commit: `824aa118`