### PR TITLE
fix(api): RDS CA 디렉터리 권한 영구 수정 (#651)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -96,6 +96,11 @@ COPY --from=builder --chown=nestjs:nodejs /app/apps/api/dist ./dist
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/src/generated ./src/generated
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./prisma
 
+# ADD의 --chmod가 새로 생성된 상위 디렉터리에도 적용되지 않도록 먼저 권한을 고정
+RUN mkdir -p /app/certs && \
+	chown nestjs:nodejs /app/certs && \
+	chmod 0755 /app/certs
+
 # RDS CA 인증서 다운로드 (COPY 이후에 배치 — nestjs 유저가 읽을 수 있도록 chown)
 ADD --chmod=644 --chown=nestjs:nodejs https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/certs/rds-ca.pem
 
@@ -106,6 +111,9 @@ ENV NODE_EXTRA_CA_CERTS=/app/certs/rds-ca.pem
 EXPOSE 8080
 
 USER nestjs
+
+# non-root 런타임에서 CA를 읽을 수 없는 이미지는 빌드 단계에서 차단
+RUN test -r "$NODE_EXTRA_CA_CERTS"
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1


### PR DESCRIPTION
## 📋 개요

production API 이미지에서 `/app/certs`가 `0644`로 생성돼 non-root `nestjs` 프로세스가 RDS CA 파일을 읽지 못하던 문제를 영구 수정합니다. 현재 운영 컨테이너에는 동일한 `0755` hotfix를 적용해 경고 제거와 health를 확인했으며, 이 PR은 다음 이미지 재생성에도 수정이 유지되도록 Dockerfile에 반영합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 버그 수정

## 📦 영향 범위

- [x] `apps/api` - production Docker 이미지 권한

## 📝 변경 내용

- 인증서 추가 전에 `/app/certs`를 `nestjs:nodejs`, `0755`로 명시적으로 생성
- CA 파일은 기존 `nestjs:nodejs`, `0644` 유지
- `USER nestjs` 상태에서 `RUN test -r "$NODE_EXTRA_CA_CERTS"`를 실행해 권한 회귀가 있는 이미지는 빌드 단계에서 차단
- Prisma schema/migration, SQL, 애플리케이션 테이블, API·클라이언트 계약 변경 없음

## 🧪 테스트

### 테스트 방법

```bash
# RED: 수정 전 운영 이미지의 nestjs 읽기 실패
docker exec aido-prod-api test -r /app/certs/rds-ca.pem

# GREEN: production 이미지 빌드 및 non-root 실행 검증
docker build --target production -t aido-api:rds-ca-permissions -f apps/api/Dockerfile .
docker run --rm --entrypoint test aido-api:rds-ca-permissions -r /app/certs/rds-ca.pem

pnpm lint
pnpm typecheck
pnpm build
pnpm test
```

### 테스트 결과

- [x] 수정 전 운영 `nestjs` 읽기 테스트 exit 1 및 permission denied 경고 재현
- [x] production Docker build 성공 — `USER nestjs`의 CA 읽기 invariant 통과
- [x] 생성 이미지: user `nestjs`, directory `0755`, file `0644`, Node CA 경고 0건
- [x] API unit 280 suites / 2,275 passed / 4 skipped
- [x] Mobile unit 90 suites / 941 passed
- [x] monorepo lint / typecheck / build 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] Biome 검사를 통과했습니다
- [x] 변경사항에 대한 RED/GREEN 검증을 수행했습니다
- [x] 모든 테스트가 통과합니다
- [x] 빌드가 성공합니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

### 리뷰어 확인

- [ ] Dockerfile 권한과 non-root 검증 순서가 올바릅니다
- [ ] 보안상 과도한 권한을 부여하지 않습니다
- [ ] DB schema/data 변경이 없습니다

## 🔗 관련 이슈

Closes #651

## 💬 추가 정보

운영 hotfix는 API 컨테이너의 `/app/certs`에만 적용했고 API만 재시작했습니다. DB·테이블·데이터·migration 컨테이너는 건드리지 않았습니다.