### PR TITLE
fix(api): RDS CA 디렉터리 권한 영구 수정 배포 (develop → main)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -96,6 +96,11 @@ COPY --from=builder --chown=nestjs:nodejs /app/apps/api/dist ./dist
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/src/generated ./src/generated
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./prisma
 
+# ADD의 --chmod가 새로 생성된 상위 디렉터리에도 적용되지 않도록 먼저 권한을 고정
+RUN mkdir -p /app/certs && \
+	chown nestjs:nodejs /app/certs && \
+	chmod 0755 /app/certs
+
 # RDS CA 인증서 다운로드 (COPY 이후에 배치 — nestjs 유저가 읽을 수 있도록 chown)
 ADD --chmod=644 --chown=nestjs:nodejs https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/certs/rds-ca.pem
 
@@ -106,6 +111,9 @@ ENV NODE_EXTRA_CA_CERTS=/app/certs/rds-ca.pem
 EXPOSE 8080
 
 USER nestjs
+
+# non-root 런타임에서 CA를 읽을 수 없는 이미지는 빌드 단계에서 차단
+RUN test -r "$NODE_EXTRA_CA_CERTS"
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -98,8 +98,8 @@ COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./prisma
 
 # ADD의 --chmod가 새로 생성된 상위 디렉터리에도 적용되지 않도록 먼저 권한을 고정
 RUN mkdir -p /app/certs && \
-	chown nestjs:nodejs /app/certs && \
-	chmod 0755 /app/certs
+    chown nestjs:nodejs /app/certs && \
+    chmod 0755 /app/certs
 
 # RDS CA 인증서 다운로드 (COPY 이후에 배치 — nestjs 유저가 읽을 수 있도록 chown)
 ADD --chmod=644 --chown=nestjs:nodejs https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/certs/rds-ca.pem


### PR DESCRIPTION
# RDS CA 디렉터리 권한 영구 수정 서버 배포

> `develop` → `main`
>
> ⚠️ **서버 이미지 설정 단독 배포** — API 로직·계약, DB schema/data, 모바일 앱, 의존성 및 환경변수 변경은 포함하지 않습니다.
>
> 🔀 **최종 merge는 `Create a merge commit` 필수** — squash/rebase merge하지 않습니다.

## 📋 개요

production API 이미지에서 `/app/certs` 디렉터리가 `0644`로 생성돼 non-root `nestjs` 프로세스가 RDS CA 파일을 읽지 못하던 문제를 영구 수정합니다. `main..develop`은 source PR #652의 squash commit `518d7b25` 1개이며, 순 변경은 `apps/api/Dockerfile` 1개 파일의 8 insertions입니다.

운영 컨테이너에는 동일한 `0755` hotfix와 API 재시작을 이미 적용해 CA 경고 제거, container health, 내부·외부 `/health`를 확인했습니다. 이 배포는 다음 이미지 재생성에도 같은 권한이 유지되도록 합니다.

## 📦 배포 범위

- [x] `apps/api/Dockerfile` production stage — 인증서 디렉터리 권한과 build-time read invariant
- [ ] API route / DTO / ErrorCode / 응답 계약 — 변경 없음
- [ ] Prisma schema / migration 파일 / SQL / DB table data — 변경 없음
- [ ] 서버 환경변수 / package dependency — 변경 없음
- [ ] `apps/mobile` / 모바일 배포 — 변경 없음

## 🔄 Before / After

| 구분 | Before | After |
|---|---|---|
| `/app/certs` | `0644`, 디렉터리 탐색 불가 | `0755`, non-root 탐색 가능 |
| CA 파일 | `nestjs:nodejs`, `0644`이나 접근 실패 | 소유자·파일 모드 유지, 실제 읽기 성공 |
| Node 시작 | `NODE_EXTRA_CA_CERTS` permission denied 경고 | 추가 CA 정상 로드, 권한 경고 0 |
| 회귀 차단 | 이미지 빌드가 잘못된 권한을 허용 | `USER nestjs`의 `RUN test -r`로 빌드 실패 처리 |
| 런타임 권한 | non-root `nestjs` | 동일 — root 우회 없음 |

## 🛡️ DB·클라이언트 영향

- Prisma schema/migration/SQL diff가 없고 애플리케이션 테이블과 데이터 변경이 없습니다.
- 표준 배포의 기존 migration gate는 pending migration 0을 확인하며 적용할 schema 변경은 없습니다.
- API endpoint, request/response DTO, HTTP status, ErrorCode 및 클라이언트 파싱 계약이 동일합니다.
- 현재 API DB adapter의 연결 동작은 변경하지 않고 이미지 파일 접근 권한만 정상화합니다.

## 🧪 검증

| 항목 | 결과 |
|---|---|
| RED 재현 | 기존 운영 `nestjs` CA 읽기 exit 1, permission denied 경고 |
| production Docker build | pass — `USER nestjs` build-time read invariant 통과 |
| 생성 이미지 | user `nestjs`, directory `0755`, CA `0644`, Node CA 경고 0 |
| root lint / typecheck / build | pass |
| 전체 unit test | API 2,275 passed / Mobile 941 passed |
| Source PR GitHub CI | Build · Lint & Type Check · Test 3/3 pass |
| Gemini review | 구현 의도와 non-root 검증 확인, comment/thread 0 |
| release diff scope | `apps/api/Dockerfile` 1개 파일, 8 insertions |

## 🚀 배포 순서 및 주의사항

1. 이 PR을 반드시 GitHub의 **Create a merge commit** 또는 `gh pr merge --merge`로 합칩니다.
2. main CI 통과 후 `Deploy to EC2`가 실행되는지 확인합니다.
3. 운영 이미지에서 `/app/certs` `0755`, CA `0644`, `nestjs` 읽기 성공을 확인합니다.
4. 새 API 기동 로그에서 `Ignoring extra certs`와 permission denied 경고가 0건인지 확인합니다.
5. container `healthy`, 내부·외부 `/health` HTTP 200, database/queues `up`을 확인합니다.
6. 원격 `develop`을 main merge commit으로 fast-forward하고 SHA/tree diff 0을 확인합니다.

## 🔗 관련 작업

- Source PR: #652
- Issue: #651
- Source squash commit: `518d7b25`