### PR TITLE
fix(api): Dockerfile 들여쓰기 일관성 정리 (#651)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -98,8 +98,8 @@ COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./prisma
 
 # ADD의 --chmod가 새로 생성된 상위 디렉터리에도 적용되지 않도록 먼저 권한을 고정
 RUN mkdir -p /app/certs && \
-	chown nestjs:nodejs /app/certs && \
-	chmod 0755 /app/certs
+    chown nestjs:nodejs /app/certs && \
+    chmod 0755 /app/certs
 
 # RDS CA 인증서 다운로드 (COPY 이후에 배치 — nestjs 유저가 읽을 수 있도록 chown)
 ADD --chmod=644 --chown=nestjs:nodejs https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/certs/rds-ca.pem


### PR DESCRIPTION
## 📋 개요

배포 PR #653의 Gemini inline review에 따라 RDS CA 권한 `RUN` 블록의 탭 들여쓰기를 Dockerfile 기존 스타일인 4 spaces로 통일합니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 리뷰 후속 수정

## 📦 영향 범위

- [x] `apps/api` - Dockerfile whitespace only

## 📝 변경 내용

- `chown`, `chmod` continuation line의 탭 2개를 4 spaces로 변경
- 명령, 레이어, 권한, 이미지 동작 변경 없음
- Prisma schema/migration, SQL, DB table/data 변경 없음

## 🧪 테스트

- [x] production Docker build 성공
- [x] `USER nestjs` CA read invariant 통과
- [x] root lint / typecheck / build 통과
- [x] `git diff --check` 통과

## ✅ 체크리스트

- [x] Gemini review 내용과 일치합니다
- [x] 기능 diff 없이 whitespace만 변경합니다
- [x] API·클라이언트 계약이 동일합니다

## 🔗 관련 작업

- Issue: #651
- Source PR: #652
- Deploy PR review: #653
- Gemini thread: https://github.com/Aiddoo/Aido-platform/pull/653#discussion_r3599943154