### PR TITLE
fix(api): AI 제안 큐 실패 보존 정책 안정화 배포 (develop → main)

### DIFF
--- a/apps/api/src/ai-suggestion/ai-suggestion.module.ts
+++ b/apps/api/src/ai-suggestion/ai-suggestion.module.ts
@@ -21,6 +21,7 @@ import { SuggestionAnalysisJob } from "./infrastructure/jobs/suggestion-analysis
 import { PrismaAiSuggestionRepository } from "./infrastructure/persistence/prisma-ai-suggestion.repository";
 import { SuggestionAnalysisProcessor } from "./infrastructure/processors/suggestion-analysis.processor";
 import { AI_SUGGESTION_QUEUE } from "./infrastructure/queue/ai-suggestion-queue";
+import { AiSuggestionQueueMaintenanceService } from "./infrastructure/queue/ai-suggestion-queue-maintenance.service";
 import { AiSuggestionController } from "./presentation/ai-suggestion.controller";
 
 /**
@@ -64,6 +65,7 @@ import { AiSuggestionController } from "./presentation/ai-suggestion.controller"
 		AiSuggestionFacade,
 		SuggestionAnalysisJob,
 		SuggestionAnalysisProcessor,
+		AiSuggestionQueueMaintenanceService,
 	],
 	exports: [AiSuggestionFacade],
 })

--- a/apps/api/src/ai-suggestion/infrastructure/jobs/suggestion-analysis.job.spec.ts
+++ b/apps/api/src/ai-suggestion/infrastructure/jobs/suggestion-analysis.job.spec.ts
@@ -15,6 +15,7 @@ import type { Queue } from "bullmq";
 import { DatabaseService } from "@/shared/infrastructure/database/database.service";
 import { SuggestionAnalysisProcessor } from "../processors/suggestion-analysis.processor";
 import { AI_SUGGESTION_QUEUE } from "../queue/ai-suggestion-queue";
+import { AiSuggestionQueueMaintenanceService } from "../queue/ai-suggestion-queue-maintenance.service";
 import { SuggestionAnalysisJob } from "./suggestion-analysis.job";
 
 describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
@@ -22,6 +23,7 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 	let mockDatabase: Mocked<DatabaseService>;
 	let mockQueue: Mocked<Queue>;
 	let mockProcessor: Mocked<SuggestionAnalysisProcessor>;
+	let mockQueueMaintenance: Mocked<AiSuggestionQueueMaintenanceService>;
 
 	beforeEach(async () => {
 		const { unit, unitRef } = await TestBed.solitary(SuggestionAnalysisJob)
@@ -32,12 +34,15 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 				upsertJobScheduler: jest.fn().mockResolvedValue(undefined),
 				removeJobScheduler: jest.fn().mockResolvedValue(undefined),
 			}))
+			.mock(AiSuggestionQueueMaintenanceService)
+			.impl(() => ({ cleanExpiredFailures: jest.fn().mockResolvedValue(0) }))
 			.compile();
 
 		job = unit;
 		mockDatabase = unitRef.get(DatabaseService);
 		mockQueue = unitRef.get(getQueueToken(AI_SUGGESTION_QUEUE));
 		mockProcessor = unitRef.get(SuggestionAnalysisProcessor);
+		mockQueueMaintenance = unitRef.get(AiSuggestionQueueMaintenanceService);
 	});
 
 	afterEach(() => {
@@ -57,7 +62,11 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			expect(mockQueue.upsertJobScheduler).toHaveBeenCalledWith(
 				"daily-suggestion-scheduler",
 				{ pattern: "30 7 * * *", tz: "Asia/Seoul" },
-				{ name: "dispatch-analysis", data: {} },
+				{
+					name: "dispatch-analysis",
+					data: {},
+					opts: { removeOnFail: { age: 604_800, count: 1_000 } },
+				},
 			);
 		});
 
@@ -117,7 +126,10 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 			expect(mockQueue.add).toHaveBeenCalledWith(
 				"dispatch-analysis",
 				{},
-				{ jobId: expect.stringContaining("dispatch_suggestion_") },
+				{
+					jobId: expect.stringContaining("dispatch_suggestion_"),
+					removeOnFail: { age: 604_800, count: 1_000 },
+				},
 			);
 		});
 
@@ -135,6 +147,39 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 	});
 
 	describe("dispatchAnalysis", () => {
+		it("dispatch 전에 7일이 지난 실패 잡을 최대 1,000건 정리해야 한다", async () => {
+			// Given
+			asMock(mockDatabase.user.findMany).mockResolvedValue([]);
+
+			// When
+			await job.dispatchAnalysis();
+
+			// Then
+			expect(mockQueueMaintenance.cleanExpiredFailures).toHaveBeenCalledTimes(
+				1,
+			);
+			const cleanOrder =
+				mockQueueMaintenance.cleanExpiredFailures.mock.invocationCallOrder[0] ??
+				0;
+			const findOrder =
+				asMock(mockDatabase.user.findMany).mock.invocationCallOrder[0] ?? 0;
+			expect(cleanOrder).toBeLessThan(findOrder);
+		});
+
+		it("실패 잡 정리 결과가 0이어도 사용자 분석 dispatch를 계속해야 한다", async () => {
+			// Given
+			mockQueueMaintenance.cleanExpiredFailures.mockResolvedValue(0);
+			asMock(mockDatabase.user.findMany).mockResolvedValue([
+				{ id: "user-1", preference: { timezone: "Asia/Seoul" } },
+			]);
+
+			// When
+			await expect(job.dispatchAnalysis()).resolves.toBeUndefined();
+
+			// Then
+			expect(mockQueue.addBulk).toHaveBeenCalledTimes(1);
+		});
+
 		it("최근 할 일이 있는 모든 사용자에 대해 큐에 잡을 등록해야 한다", async () => {
 			// Given
 			const users = [
@@ -201,7 +246,7 @@ describe("SuggestionAnalysisJob — AI 제안 분석 잡", () => {
 					attempts: 3,
 					backoff: { type: "exponential", delay: 5_000 },
 					removeOnComplete: { age: 604_800, count: 10_000 },
-					removeOnFail: { count: 100, age: 86_400 },
+					removeOnFail: { count: 1_000, age: 604_800 },
 				}),
 			);
 		});

--- a/apps/api/src/ai-suggestion/infrastructure/jobs/suggestion-analysis.job.ts
+++ b/apps/api/src/ai-suggestion/infrastructure/jobs/suggestion-analysis.job.ts
@@ -14,6 +14,8 @@ import {
 	type AiSuggestionJobData,
 	AiSuggestionJobName,
 } from "../queue/ai-suggestion-queue";
+import { AiSuggestionQueueMaintenanceService } from "../queue/ai-suggestion-queue-maintenance.service";
+import { AI_SUGGESTION_FAILED_JOB_RETENTION } from "../queue/ai-suggestion-retention.policy";
 
 /** 잡 enqueue용 배치 크기 (API 호출 없이 큐 적재만 하므로 크게 설정) */
 const ENQUEUE_BATCH_SIZE = 50;
@@ -34,6 +36,7 @@ export class SuggestionAnalysisJob implements OnModuleInit {
 		@InjectQueue(AI_SUGGESTION_QUEUE)
 		private readonly queue: Queue<AiSuggestionJobData>,
 		private readonly processor: SuggestionAnalysisProcessor,
+		private readonly queueMaintenance: AiSuggestionQueueMaintenanceService,
 	) {}
 
 	/** 스케줄러 등록 완료 프로미스 (테스트 대기용) — 부팅을 블로킹하지 않는다 */
@@ -54,7 +57,11 @@ export class SuggestionAnalysisJob implements OnModuleInit {
 				await this.queue.upsertJobScheduler(
 					"daily-suggestion-scheduler",
 					{ pattern: "30 7 * * *", tz: "Asia/Seoul" },
-					{ name: AiSuggestionJobName.DISPATCH, data: {} },
+					{
+						name: AiSuggestionJobName.DISPATCH,
+						data: {},
+						opts: { removeOnFail: AI_SUGGESTION_FAILED_JOB_RETENTION },
+					},
 				);
 
 				this.#logger.log("Suggestion analysis scheduler registered");
@@ -69,6 +76,7 @@ export class SuggestionAnalysisJob implements OnModuleInit {
 	 */
 	async dispatchAnalysis(dispatchJob?: Job): Promise<void> {
 		this.#logger.log("Starting suggestion analysis dispatch...");
+		await this.queueMaintenance.cleanExpiredFailures();
 
 		const twoWeeksAgo = subtractDays(14);
 
@@ -121,6 +129,7 @@ export class SuggestionAnalysisJob implements OnModuleInit {
 					} satisfies AiSuggestionAnalyzeData,
 					opts: {
 						...AI_PER_USER_JOB_OPTS,
+						removeOnFail: AI_SUGGESTION_FAILED_JOB_RETENTION,
 						jobId: `suggestion_${user.id}_${periodId}`,
 					},
 				}));
@@ -151,6 +160,7 @@ export class SuggestionAnalysisJob implements OnModuleInit {
 				{},
 				{
 					jobId: `dispatch_suggestion_${kstNow.format("YYYY-MM-DD")}`,
+					removeOnFail: AI_SUGGESTION_FAILED_JOB_RETENTION,
 				},
 			);
 		}

--- a/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-queue-maintenance.service.spec.ts
+++ b/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-queue-maintenance.service.spec.ts
@@ -1,0 +1,64 @@
+import { getQueueToken } from "@nestjs/bullmq";
+import type { Mocked } from "@suites/doubles.jest";
+import { TestBed } from "@suites/unit";
+import type { Queue } from "bullmq";
+import { AI_SUGGESTION_QUEUE } from "./ai-suggestion-queue";
+import { AiSuggestionQueueMaintenanceService } from "./ai-suggestion-queue-maintenance.service";
+
+describe("AiSuggestionQueueMaintenanceService — AI 제안 큐 유지보수", () => {
+	let service: AiSuggestionQueueMaintenanceService;
+	let queue: Mocked<Queue>;
+
+	beforeEach(async () => {
+		const { unit, unitRef } = await TestBed.solitary(
+			AiSuggestionQueueMaintenanceService,
+		)
+			.mock(getQueueToken(AI_SUGGESTION_QUEUE))
+			.impl(() => ({ clean: jest.fn().mockResolvedValue([]) }))
+			.compile();
+
+		service = unit;
+		queue = unitRef.get(getQueueToken(AI_SUGGESTION_QUEUE));
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it("7일이 지난 실패 잡을 최대 1,000건 정리하고 삭제 수를 반환한다", async () => {
+		// Given
+		queue.clean.mockResolvedValue(["failed-1", "failed-2"]);
+
+		// When
+		const removedCount = await service.cleanExpiredFailures();
+
+		// Then
+		expect(queue.clean).toHaveBeenCalledWith(
+			7 * 24 * 60 * 60 * 1_000,
+			1_000,
+			"failed",
+		);
+		expect(removedCount).toBe(2);
+	});
+
+	it("Redis 정리가 실패하면 예외를 전파하지 않고 0을 반환한다", async () => {
+		// Given
+		queue.clean.mockRejectedValue(new Error("redis cleanup failed"));
+
+		// When & Then
+		await expect(service.cleanExpiredFailures()).resolves.toBe(0);
+	});
+
+	it("Redis 정리가 응답하지 않으면 2초 후 0을 반환한다", async () => {
+		// Given
+		jest.useFakeTimers();
+		queue.clean.mockReturnValue(new Promise<string[]>(() => {}));
+
+		// When
+		const pending = service.cleanExpiredFailures();
+		await jest.advanceTimersByTimeAsync(2_000);
+
+		// Then
+		await expect(pending).resolves.toBe(0);
+	});
+});

--- a/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-queue-maintenance.service.ts
+++ b/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-queue-maintenance.service.ts
@@ -1,0 +1,48 @@
+import { InjectQueue } from "@nestjs/bullmq";
+import { Injectable, Logger } from "@nestjs/common";
+import type { Queue } from "bullmq";
+import { toErrorMessage } from "@/shared/application/utils/error-message.util";
+import { withTimeout } from "@/shared/application/utils/with-timeout.util";
+import {
+	AI_SUGGESTION_QUEUE,
+	type AiSuggestionJobData,
+} from "./ai-suggestion-queue";
+import { AI_SUGGESTION_FAILED_JOB_RETENTION } from "./ai-suggestion-retention.policy";
+
+const CLEANUP_TIMEOUT_MS = 2_000;
+
+/** AI 제안 큐의 완료된 실패 기록만 보존 정책에 맞춰 정리한다. */
+@Injectable()
+export class AiSuggestionQueueMaintenanceService {
+	readonly #logger = new Logger(AiSuggestionQueueMaintenanceService.name);
+
+	constructor(
+		@InjectQueue(AI_SUGGESTION_QUEUE)
+		private readonly queue: Queue<AiSuggestionJobData>,
+	) {}
+
+	async cleanExpiredFailures(): Promise<number> {
+		try {
+			const removedJobIds = await withTimeout(
+				this.queue.clean(
+					AI_SUGGESTION_FAILED_JOB_RETENTION.age * 1_000,
+					AI_SUGGESTION_FAILED_JOB_RETENTION.count,
+					"failed",
+				),
+				CLEANUP_TIMEOUT_MS,
+				"AI suggestion failed job cleanup",
+			);
+			if (removedJobIds.length > 0) {
+				this.#logger.log(
+					`Expired suggestion failures cleaned: count=${removedJobIds.length}`,
+				);
+			}
+			return removedJobIds.length;
+		} catch (error) {
+			this.#logger.warn(
+				`Failed to clean expired suggestion failures: ${toErrorMessage(error)}`,
+			);
+			return 0;
+		}
+	}
+}

--- a/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-retention.policy.ts
+++ b/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-retention.policy.ts
@@ -1,0 +1,5 @@
+/** AI 제안 실패 잡 보존 정책 — 원인 분석을 위해 7일, 메모리 상한은 1,000건 */
+export const AI_SUGGESTION_FAILED_JOB_RETENTION = {
+	age: 7 * 24 * 60 * 60,
+	count: 1_000,
+} as const;

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -8,6 +8,7 @@ import { TODO_REMINDER_QUEUE } from "@/scheduler";
 import { HealthController } from "./health.controller";
 import { BullHealthIndicator } from "./indicators/bull.health";
 import { DatabaseHealthIndicator } from "./indicators/database.health";
+import { RedisEvictionPolicyProbe } from "./indicators/redis-eviction-policy.probe";
 
 @Module({
 	imports: [
@@ -20,6 +21,10 @@ import { DatabaseHealthIndicator } from "./indicators/database.health";
 		),
 	],
 	controllers: [HealthController],
-	providers: [DatabaseHealthIndicator, BullHealthIndicator],
+	providers: [
+		DatabaseHealthIndicator,
+		BullHealthIndicator,
+		RedisEvictionPolicyProbe,
+	],
 })
 export class HealthModule {}

--- a/apps/api/src/health/indicators/bull.health.spec.ts
+++ b/apps/api/src/health/indicators/bull.health.spec.ts
@@ -14,6 +14,7 @@
  */
 import { HealthIndicatorService } from "@nestjs/terminus";
 import { BullHealthIndicator, type QueueHealthSource } from "./bull.health";
+import { RedisEvictionPolicyProbe } from "./redis-eviction-policy.probe";
 
 interface FakeQueue extends QueueHealthSource {
 	isPaused: jest.Mock;
@@ -41,13 +42,19 @@ describe("BullHealthIndicator — BullMQ 큐 헬스 인디케이터", () => {
 		];
 	});
 
-	function createIndicator(redis: { ping: jest.Mock } | null) {
+	function createIndicator(
+		redis: { ping: jest.Mock } | null,
+		probe = new RedisEvictionPolicyProbe({
+			info: jest.fn().mockResolvedValue("maxmemory_policy:noeviction\n"),
+		}),
+	) {
 		return new BullHealthIndicator(
 			new HealthIndicatorService(),
 			queues[0],
 			queues[1],
 			queues[2],
 			queues[3],
+			probe,
 			redis,
 		);
 	}
@@ -83,6 +90,45 @@ describe("BullHealthIndicator — BullMQ 큐 헬스 인디케이터", () => {
 			"ai-suggestion": { isPaused: false, active: 1, waiting: 2, failed: 0 },
 		});
 		expect(result.queues).not.toMatchObject({ degraded: true });
+	});
+
+	it("Redis 정책이 volatile-lru이면 큐 통계와 함께 up + degraded를 반환한다", async () => {
+		// Given
+		const redis = { ping: jest.fn().mockResolvedValue("PONG") };
+		const probe = new RedisEvictionPolicyProbe({
+			info: jest.fn().mockResolvedValue("maxmemory_policy:volatile-lru\n"),
+		});
+		const indicator = createIndicator(redis, probe);
+
+		// When
+		const result = await indicator.isHealthy("queues");
+
+		// Then — HTTP 상태를 내리지 않고 기존 degraded 계약으로만 노출
+		expect(result.queues?.status).toBe("up");
+		expect(result.queues).toMatchObject({
+			degraded: true,
+			reason: "redis maxmemory_policy incompatible with BullMQ: volatile-lru",
+			"ai-suggestion": { isPaused: false, active: 1, waiting: 2, failed: 0 },
+		});
+	});
+
+	it("Redis 정책을 확인할 수 없으면 up + degraded와 원인을 반환한다", async () => {
+		// Given
+		const redis = { ping: jest.fn().mockResolvedValue("PONG") };
+		const probe = new RedisEvictionPolicyProbe({
+			info: jest.fn().mockRejectedValue(new Error("NOPERM INFO denied")),
+		});
+		const indicator = createIndicator(redis, probe);
+
+		// When
+		const result = await indicator.isHealthy("queues");
+
+		// Then
+		expect(result.queues?.status).toBe("up");
+		expect(result.queues).toMatchObject({
+			degraded: true,
+			reason: "redis maxmemory_policy unknown: NOPERM INFO denied",
+		});
 	});
 
 	it("Redis 클라이언트가 없으면(메모리 모드) ping 없이 큐를 검사한다", async () => {

--- a/apps/api/src/health/indicators/bull.health.ts
+++ b/apps/api/src/health/indicators/bull.health.ts
@@ -11,6 +11,10 @@ import { TODO_REMINDER_QUEUE } from "@/scheduler";
 import { toErrorMessage } from "@/shared/application/utils/error-message.util";
 import { withTimeout } from "@/shared/application/utils/with-timeout.util";
 import { REDIS_COMMAND_CLIENT } from "@/shared/infrastructure/redis/redis.constants";
+import {
+	type RedisEvictionPolicyInspection,
+	RedisEvictionPolicyProbe,
+} from "./redis-eviction-policy.probe";
 
 /** 큐 상태 수집 타임아웃 — 초과 시 up + degraded로 응답 */
 const QUEUE_STATS_TIMEOUT_MS = 2_000;
@@ -56,6 +60,7 @@ export class BullHealthIndicator {
 		private readonly adminNotificationQueue: QueueHealthSource,
 		@InjectQueue(TODO_REMINDER_QUEUE)
 		private readonly todoReminderQueue: QueueHealthSource,
+		private readonly evictionPolicyProbe: RedisEvictionPolicyProbe,
 		@Optional()
 		@Inject(REDIS_COMMAND_CLIENT)
 		private readonly redis: RedisPingSource | null = null,
@@ -76,12 +81,20 @@ export class BullHealthIndicator {
 		}
 
 		try {
-			const results = await withTimeout(
-				this.#collectQueueStats(),
+			const [results, policyInspection] = await withTimeout(
+				Promise.all([
+					this.#collectQueueStats(),
+					this.redis
+						? this.evictionPolicyProbe.inspect()
+						: Promise.resolve(null),
+				]),
 				QUEUE_STATS_TIMEOUT_MS,
 				"Queue stats collection",
 			);
-			return indicator.up(results);
+			return indicator.up({
+				...results,
+				...this.#policyDegradation(policyInspection),
+			});
 		} catch (error) {
 			return indicator.up({
 				degraded: true,
@@ -108,5 +121,23 @@ export class BullHealthIndicator {
 		}
 
 		return results;
+	}
+
+	#policyDegradation(
+		inspection: RedisEvictionPolicyInspection | null,
+	): Record<string, unknown> {
+		if (!inspection || inspection.state === "compatible") {
+			return {};
+		}
+		if (inspection.state === "incompatible") {
+			return {
+				degraded: true,
+				reason: `redis maxmemory_policy incompatible with BullMQ: ${inspection.policy}`,
+			};
+		}
+		return {
+			degraded: true,
+			reason: `redis maxmemory_policy unknown: ${inspection.reason}`,
+		};
 	}
 }

--- a/apps/api/src/health/indicators/redis-eviction-policy.probe.spec.ts
+++ b/apps/api/src/health/indicators/redis-eviction-policy.probe.spec.ts
@@ -1,0 +1,87 @@
+import {
+	RedisEvictionPolicyProbe,
+	type RedisInfoSource,
+} from "./redis-eviction-policy.probe";
+
+describe("RedisEvictionPolicyProbe — BullMQ Redis 정책 검사", () => {
+	function createProbe(info: jest.Mock): RedisEvictionPolicyProbe {
+		const redis: RedisInfoSource = { info };
+		return new RedisEvictionPolicyProbe(redis);
+	}
+
+	it("maxmemory_policy가 noeviction이면 compatible을 반환한다", async () => {
+		// Given
+		const probe = createProbe(
+			jest
+				.fn()
+				.mockResolvedValue(
+					"# Memory\r\nused_memory_human:12.00M\r\nmaxmemory_policy:noeviction\r\n",
+				),
+		);
+
+		// When
+		const result = await probe.inspect();
+
+		// Then
+		expect(result).toEqual({ state: "compatible", policy: "noeviction" });
+	});
+
+	it("maxmemory_policy가 volatile-lru이면 incompatible을 반환한다", async () => {
+		// Given
+		const probe = createProbe(
+			jest.fn().mockResolvedValue("maxmemory_policy:volatile-lru\n"),
+		);
+
+		// When
+		const result = await probe.inspect();
+
+		// Then
+		expect(result).toEqual({ state: "incompatible", policy: "volatile-lru" });
+	});
+
+	it("maxmemory_policy가 없으면 unknown을 반환한다", async () => {
+		// Given
+		const probe = createProbe(
+			jest.fn().mockResolvedValue("used_memory:1024\n"),
+		);
+
+		// When
+		const result = await probe.inspect();
+
+		// Then
+		expect(result).toEqual({
+			state: "unknown",
+			reason: "maxmemory_policy missing from INFO memory",
+		});
+	});
+
+	it("INFO 조회가 실패하면 예외 대신 unknown을 반환한다", async () => {
+		// Given
+		const probe = createProbe(
+			jest.fn().mockRejectedValue(new Error("NOPERM INFO denied")),
+		);
+
+		// When
+		const result = await probe.inspect();
+
+		// Then
+		expect(result).toEqual({
+			state: "unknown",
+			reason: "NOPERM INFO denied",
+		});
+	});
+
+	it("Redis command client가 없으면 명시적인 unknown을 반환한다", async () => {
+		// Given
+		const probe = new RedisEvictionPolicyProbe(null);
+
+		// When
+		const result = await probe.inspect();
+
+		// Then
+		expect(result).toEqual({
+			state: "unknown",
+			reason: "Redis command client unavailable",
+		});
+	});
+});

--- a/apps/api/src/health/indicators/redis-eviction-policy.probe.ts
+++ b/apps/api/src/health/indicators/redis-eviction-policy.probe.ts
@@ -1,0 +1,59 @@
+import { Inject, Injectable, Optional } from "@nestjs/common";
+import { toErrorMessage } from "@/shared/application/utils/error-message.util";
+import { REDIS_COMMAND_CLIENT } from "@/shared/infrastructure/redis/redis.constants";
+
+export interface RedisInfoSource {
+	info(section: "memory"): Promise<string>;
+}
+
+export type RedisEvictionPolicyInspection =
+	| { state: "compatible"; policy: "noeviction" }
+	| { state: "incompatible"; policy: string }
+	| { state: "unknown"; reason: string };
+
+/** BullMQ가 요구하는 Redis noeviction 정책을 읽기 전용 INFO로 검사한다. */
+@Injectable()
+export class RedisEvictionPolicyProbe {
+	constructor(
+		@Optional()
+		@Inject(REDIS_COMMAND_CLIENT)
+		private readonly redis: RedisInfoSource | null = null,
+	) {}
+
+	async inspect(): Promise<RedisEvictionPolicyInspection> {
+		if (!this.redis) {
+			return {
+				state: "unknown",
+				reason: "Redis command client unavailable",
+			};
+		}
+
+		try {
+			const memoryInfo = await this.redis.info("memory");
+			const policyLine = memoryInfo
+				.split(/\r?\n/)
+				.find((line) => line.startsWith("maxmemory_policy:"));
+			if (!policyLine) {
+				return {
+					state: "unknown",
+					reason: "maxmemory_policy missing from INFO memory",
+				};
+			}
+
+			const policy = policyLine.slice("maxmemory_policy:".length).trim();
+			if (!policy) {
+				return {
+					state: "unknown",
+					reason: "maxmemory_policy missing from INFO memory",
+				};
+			}
+
+			if (policy === "noeviction") {
+				return { state: "compatible", policy };
+			}
+			return { state: "incompatible", policy };
+		} catch (error) {
+			return { state: "unknown", reason: toErrorMessage(error) };
+		}
+	}
+}

--- a/apps/api/test/e2e/health-queue-policy.e2e-spec.ts
+++ b/apps/api/test/e2e/health-queue-policy.e2e-spec.ts
@@ -1,0 +1,56 @@
+import request from "supertest";
+import { RedisEvictionPolicyProbe } from "@/health/indicators/redis-eviction-policy.probe";
+import { createE2eApp, destroyE2eApp, type E2eTestContext } from "./helpers";
+
+describe("queue Redis policy health E2E", () => {
+	let ctx: E2eTestContext;
+	const inspect = jest.fn();
+
+	beforeAll(async () => {
+		ctx = await createE2eApp({
+			customizeBuilder: (builder) =>
+				builder
+					.overrideProvider(RedisEvictionPolicyProbe)
+					.useValue({ inspect }),
+		});
+	});
+
+	afterAll(async () => {
+		await destroyE2eApp(ctx);
+	});
+
+	it("noeviction이면 기존 health 성공 계약을 유지한다", async () => {
+		inspect.mockResolvedValue({ state: "compatible", policy: "noeviction" });
+
+		const response = await request(ctx.app.getHttpServer())
+			.get("/health")
+			.expect(200);
+
+		expect(response.body.data.status).toBe("ok");
+		expect(response.body.data.info.queues).toMatchObject({
+			status: "up",
+			"ai-suggestion": { active: 0, waiting: 0, failed: 0 },
+		});
+		expect(response.body.data.info.queues).not.toHaveProperty("degraded");
+		expect(response.body.data.info.queues).not.toHaveProperty("reason");
+	});
+
+	it("비호환 정책이어도 200/up을 유지하고 기존 degraded 필드로만 알린다", async () => {
+		inspect.mockResolvedValue({
+			state: "incompatible",
+			policy: "volatile-lru",
+		});
+
+		const response = await request(ctx.app.getHttpServer())
+			.get("/health")
+			.expect(200);
+
+		expect(response.body.data.status).toBe("ok");
+		expect(response.body.data.info.queues).toMatchObject({
+			status: "up",
+			degraded: true,
+			reason: "redis maxmemory_policy incompatible with BullMQ: volatile-lru",
+			"ai-suggestion": { active: 0, waiting: 0, failed: 0 },
+		});
+	});
+});

--- a/apps/api/test/integration/ai-suggestion-queue-maintenance.integration-spec.ts
+++ b/apps/api/test/integration/ai-suggestion-queue-maintenance.integration-spec.ts
@@ -1,0 +1,122 @@
+import { Queue, Worker } from "bullmq";
+import Redis from "ioredis";
+import {
+	GenericContainer,
+	type StartedTestContainer,
+	Wait,
+} from "testcontainers";
+import { AiSuggestionQueueMaintenanceService } from "@/ai-suggestion/infrastructure/queue/ai-suggestion-queue-maintenance.service";
+import { RedisEvictionPolicyProbe } from "@/health/indicators/redis-eviction-policy.probe";
+
+const REDIS_PORT = 6379;
+const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1_000;
+
+describe("AI suggestion BullMQ maintenance integration", () => {
+	let container: StartedTestContainer;
+	let host: string;
+	let port: number;
+	const closeables: Array<{ close(): Promise<void> }> = [];
+
+	beforeAll(async () => {
+		container = await new GenericContainer("redis:7-alpine")
+			.withExposedPorts(REDIS_PORT)
+			.withWaitStrategy(Wait.forLogMessage("Ready to accept connections"))
+			.start();
+		host = container.getHost();
+		port = container.getMappedPort(REDIS_PORT);
+	});
+
+	afterEach(async () => {
+		while (closeables.length > 0) {
+			await closeables.pop()?.close();
+		}
+	});
+
+	afterAll(async () => {
+		await container.stop();
+	});
+
+	function createQueue(): Queue {
+		const queue = new Queue(
+			`ai-suggestion-maintenance-${crypto.randomUUID()}`,
+			{
+				connection: { host, port },
+			},
+		);
+		closeables.push(queue);
+		return queue;
+	}
+
+	async function failOneJob(queue: Queue): Promise<void> {
+		const worker = new Worker(
+			queue.name,
+			async () => {
+				throw new Error("expected integration failure");
+			},
+			{ connection: { host, port } },
+		);
+		closeables.push(worker);
+
+		const failed = new Promise<void>((resolve) => {
+			worker.once("failed", () => resolve());
+		});
+		await queue.add("will-fail", {}, { attempts: 1 });
+		await failed;
+	}
+
+	it("7일이 지난 failed 잡은 실제 Redis에서 제거한다", async () => {
+		const queue = createQueue();
+		await failOneJob(queue);
+		expect(await queue.getJobCounts("failed")).toEqual({ failed: 1 });
+
+		const maintenance = new AiSuggestionQueueMaintenanceService(queue);
+		const now = Date.now();
+		const dateNow = jest
+			.spyOn(Date, "now")
+			.mockReturnValue(now + EIGHT_DAYS_MS);
+		const removed = await maintenance.cleanExpiredFailures();
+		dateNow.mockRestore();
+
+		expect(removed).toBe(1);
+		expect(await queue.getJobCounts("failed")).toEqual({ failed: 0 });
+	});
+
+	it("7일 이내 failed 잡은 원인 분석을 위해 보존한다", async () => {
+		const queue = createQueue();
+		await failOneJob(queue);
+
+		const maintenance = new AiSuggestionQueueMaintenanceService(queue);
+		expect(await maintenance.cleanExpiredFailures()).toBe(0);
+		expect(await queue.getJobCounts("failed")).toEqual({ failed: 1 });
+	});
+
+	it("정리 대상이 아닌 waiting/delayed 잡은 변경하지 않는다", async () => {
+		const queue = createQueue();
+		await queue.add("waiting", {});
+		await queue.add("delayed", {}, { delay: 60_000 });
+
+		const before = await queue.getJobCounts("waiting", "delayed");
+		const maintenance = new AiSuggestionQueueMaintenanceService(queue);
+
+		expect(await maintenance.cleanExpiredFailures()).toBe(0);
+		expect(await queue.getJobCounts("waiting", "delayed")).toEqual(before);
+	});
+
+	it("Redis INFO로 noeviction과 비호환 정책을 실제로 구분한다", async () => {
+		const redis = new Redis({ host, port });
+		closeables.push({ close: () => redis.quit().then(() => undefined) });
+		const probe = new RedisEvictionPolicyProbe(redis);
+
+		await redis.config("SET", "maxmemory-policy", "noeviction");
+		expect(await probe.inspect()).toEqual({
+			state: "compatible",
+			policy: "noeviction",
+		});
+
+		await redis.config("SET", "maxmemory-policy", "volatile-lru");
+		expect(await probe.inspect()).toEqual({
+			state: "incompatible",
+			policy: "volatile-lru",
+		});
+	});
+});


### PR DESCRIPTION
# AI 제안 큐 실패 보존 정책 안정화 서버 배포

> `develop` → `main`
>
> ⚠️ **서버 단독 배포** — BullMQ 큐 유지보수와 health 관측만 포함하며 API/클라이언트 계약, DB schema/data, 모바일 앱, 의존성 및 환경변수 변경은 없습니다.
>
> 🔀 **최종 merge는 `Create a merge commit` 필수** — squash/rebase merge하지 않습니다.

## 📋 개요

AI suggestion 실패 잡을 7일/최대 1,000건 보존하고, BullMQ의 lazy auto-removal 때문에 오래된 failed 기록이 남는 문제를 매일 dispatch 전 명시적 cleanup으로 해소합니다. cleanup은 Redis 오류 또는 2초 timeout에서도 fail-open하여 분석 dispatch를 중단하지 않습니다.

Redis eviction 정책은 `INFO memory`로만 읽고, `noeviction`이 아니면 기존 health의 `200/up + degraded` 계약으로 알립니다. 런타임 Redis 설정 변경은 하지 않습니다.

`main..develop`은 source PR #656의 squash commit `df4c53e1` 1개이며, 순 변경은 `apps/api` 13개 파일의 589 insertions / 9 deletions입니다.

## 📦 배포 범위

- [x] `apps/api/src/ai-suggestion` — failed 보존 정책, bounded cleanup, dispatcher 적용
- [x] `apps/api/src/health` — read-only eviction policy probe와 degraded 관측
- [x] `apps/api/test` — 실제 Redis integration 및 HTTP E2E
- [ ] API route / DTO / ErrorCode / 응답 계약 — 변경 없음
- [ ] Prisma schema / migration 파일 / SQL / DB table data — 변경 없음
- [ ] 서버 환경변수 / package dependency — 변경 없음
- [ ] `apps/mobile` / 모바일 배포 — 변경 없음

## 🔄 Before / After

| 구분 | Before | After |
|---|---|---|
| failed 보존 | 글로벌 기본 1일/100, lazy removal | AI suggestion 전 잡 7일/1,000 |
| 오래된 failed 정리 | 새 잡 완료 시점에만 lazy | 매일 dispatch 전 failed만 명시 정리 |
| cleanup 장애 | 별도 유지보수 경계 없음 | 오류·2초 timeout 시 0 반환 후 dispatch 지속 |
| Redis eviction 관측 | BullMQ warning 로그만 확인 가능 | health에서 read-only 검사, up + degraded |
| Redis 설정 변경 | 없음 | 동일 — 앱은 `CONFIG SET`하지 않음 |

## 🛡️ DB·클라이언트 영향

- Prisma schema/migration/SQL diff가 없고 애플리케이션 테이블과 데이터 변경이 없습니다.
- 배포 workflow의 기존 migration gate는 실행되지만 적용할 schema 변경은 0건입니다.
- endpoint, request/response DTO, HTTP status, ErrorCode 및 OpenAPI snapshot이 동일합니다.
- health는 비호환 Redis 정책에서도 HTTP 200과 `status: up`을 유지하고 이미 존재하는 `degraded/reason` 필드만 사용합니다.
- 기존/현재 모든 모바일 클라이언트의 요청·응답과 AI suggestion job payload/schedule/retry 계약이 동일합니다.

## 🧪 검증

| 항목 | 결과 |
|---|---|
| root Biome / lint / typecheck / build | pass |
| 전체 unit test | API 2,286 passed / 4 skipped, Mobile 전체 pass |
| 전체 integration | 28 suites / 334 passed |
| 전체 E2E | 26 suites / 393 passed, OpenAPI snapshots 2 pass |
| production Docker build | pass |
| architecture boundary / no-cast | pass |
| Source PR GitHub CI | Build · Lint & Type Check · Test 3/3 pass |
| Gemini review | optional Redis 경계 반영, reply·resolve, unresolved 0 |
| release diff scope | `apps/api` 13개 파일만 변경; Prisma/mobile/shared package 0 |

## 🚀 배포 순서 및 주의사항

1. 이 PR을 반드시 GitHub의 **Create a merge commit** 또는 `gh pr merge --merge`로 합칩니다.
2. main CI 통과 후 `Deploy to EC2` workflow가 실행되는지 확인합니다.
3. 새 API가 기동되고 container `healthy`, 내부·외부 `/health` HTTP 200, database/queues `up`을 확인합니다.
4. AI suggestion scheduler 등록과 최근 작업 성공 상태를 확인합니다.
5. 운영 ElastiCache parameter group을 `noeviction`으로 전환한 뒤 health의 queue degraded가 해제되는지 확인합니다.
6. 원격 `develop`을 main merge commit으로 fast-forward하고 SHA/tree diff 0을 확인합니다.

## 🔗 관련 작업

- Source PR: #656
- Issue: #655
- Source squash commit: `df4c53e1`

## 💬 추가 정보

- 운영 failed 4건의 직접 원인은 2026-06-10 Gemini prepayment credit 소진이며 현재 최근 잡은 정상 성공 중입니다.
- `volatile-lru`는 해당 4건의 직접 원인은 아니며, 큐 키 eviction 예방을 위한 별도 운영 설정입니다.
- 운영 DB·테이블·데이터에는 접근하거나 변경하지 않습니다.
