### PR TITLE
test(api): stabilize E2E and integration infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,29 +36,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: aido_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4
@@ -67,17 +44,14 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Run Prisma migrations
-        run: pnpm --filter @aido/api exec prisma migrate deploy
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/aido_test
-
       - name: Run unit tests
         run: pnpm turbo run test --affected
 
+      - name: Run integration tests
+        run: pnpm turbo run test:integration --filter=@aido/api
+
       - name: Run E2E tests
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/aido_test
           JWT_SECRET: test-jwt-secret-for-ci-minimum-32-characters-long
           JWT_REFRESH_SECRET: test-jwt-refresh-secret-for-ci-min-32-chars
           JWT_EXPIRES_IN: 15m

--- a/apps/api/.claude/e2e-test.md
+++ b/apps/api/.claude/e2e-test.md
@@ -1,6 +1,6 @@
 # E2E 테스트 가이드
 
-**Version**: 1.0.0 · **Last Updated**: 2026-04-23 · **Owner**: Aido Platform Team
+**Version**: 1.1.0 · **Last Updated**: 2026-07-17 · **Owner**: Aido Platform Team
 
 > `createE2eApp()` 팩토리 + `E2eHelpers`로 전체 API 흐름을 검증하는 테스트
 
@@ -23,7 +23,7 @@
 | **파일 위치** | `test/e2e/` |
 | **명명 규칙** | `{도메인}.e2e-spec.ts` |
 | **핵심 도구** | `createE2eApp()` + `E2eHelpers` + `supertest` |
-| **환경** | Testcontainers PostgreSQL + FakeService |
+| **환경** | Jest 실행당 Testcontainers PostgreSQL 1개 + FakeService |
 | **목적** | 사용자 관점에서 HTTP API 전체 흐름 검증 |
 
 ---
@@ -59,8 +59,10 @@ test/
 │   ├── fake-oauth-token-verifier.service.ts
 │   └── fake-logger.service.ts
 └── setup/
-    ├── test-database.ts             # TestDatabase (Testcontainers)
-    └── global-setup.ts
+    ├── managed-test-database.ts     # 컨테이너 + migration 수명주기
+    ├── test-database.ts             # Prisma 연결 + 데이터 초기화
+    ├── global-setup.ts
+    └── global-teardown.ts
 ```
 
 ---
@@ -70,11 +72,12 @@ test/
 ### `createE2eApp()` / `destroyE2eApp()`
 
 모든 E2E 테스트는 이 팩토리를 사용합니다. 내부에서 자동으로 처리하는 것:
-- `TestDatabase` (Testcontainers PostgreSQL) 시작
-- `FakeEmailService` / `FakeOAuthTokenVerifierService` 주입
+- global setup이 준비한 PostgreSQL에 `TestDatabase` 연결
+- `FakeEmailService` / OAuth provider registry / `FakeOAuthTokenVerifierService` 주입
 - `PinoLogger` → `FakeLogger` 교체
 - `ZodValidationPipe` 설정
 - `E2eHelpers` 인스턴스 생성
+- DB, cache, Redis mock, 공용 fake를 한 번에 초기화하는 `ctx.reset()` 제공
 
 ```typescript
 import {
@@ -96,8 +99,7 @@ describe("Todo E2E", () => {
   });
 
   beforeEach(async () => {
-    await ctx.testDatabase.cleanup();
-    ctx.fakeEmailService.clear();
+    await ctx.reset();
   });
 
   describe("Todo 생성", () => {
@@ -124,7 +126,8 @@ describe("Todo E2E", () => {
 
 모든 E2E 테스트는 **매 테스트마다 clean state**에서 시작합니다.
 
-- `beforeEach`에서 `ctx.testDatabase.cleanup()` + `ctx.fakeEmailService.clear()` **필수 호출**
+- `beforeEach`에서 `await ctx.reset()` **필수 호출**
+- suite 전용 fake는 `additionalResetters`로 등록하여 동일 reset 경로에 포함
 - 각 `it` 블록이 필요한 유저/데이터를 **자체적으로 생성** (shared state 없음)
 - 순차 의존성이 있는 테스트(CRUD 플로우 등)는 **하나의 `it` 블록으로 합침**
 - `describe` 스코프의 `let` 변수로 상태 공유 금지 (`ctx` 제외)
@@ -168,7 +171,9 @@ interface E2eTestContext {
   testDatabase: TestDatabase;
   fakeEmailService: FakeEmailService;
   fakeOAuthTokenVerifierService: FakeOAuthTokenVerifierService;
+  fakeOAuthProviderRegistry: FakeOAuthProviderRegistry;
   helpers: E2eHelpers;
+  reset(): Promise<void>;
 }
 ```
 
@@ -182,6 +187,7 @@ const ctx = await createE2eApp({
     builder
       .overrideProvider(SomeService)
       .useValue(mockSomeService),
+  additionalResetters: [() => mockSomeService.clear()],
 });
 ```
 
@@ -403,7 +409,8 @@ pnpm --filter @aido/api test:e2e -- -t "회원가입"
 
 | 변수 | 설명 | 비고 |
 |------|------|------|
-| `DATABASE_URL` | Testcontainers가 자동 설정 | 로컬에선 불필요 |
+| `DATABASE_URL` | global setup이 Testcontainers URL로 자동 설정 | 직접 설정 금지 |
+| `AIDO_TEST_DB_MANAGED` | 관리형 테스트 DB 안전 마커 (`1`) | global setup 전용 |
 | `JWT_SECRET` | JWT 서명 키 | CI에서 필요 |
 | `JWT_REFRESH_SECRET` | Refresh 토큰 키 (32자 이상) | CI에서 필요 |
 | `TOKEN_ENCRYPTION_KEY` | 암호화 키 (32자 이상) | CI에서 필요 |
@@ -416,14 +423,15 @@ pnpm --filter @aido/api test:e2e -- -t "회원가입"
 
 - ✅ `createE2eApp()` / `destroyE2eApp()` 팩토리 사용
 - ✅ `E2eHelpers`의 `createVerifiedUser()` 등 공유 헬퍼 사용
-- ✅ **`beforeEach`에서 `ctx.testDatabase.cleanup()` + `ctx.fakeEmailService.clear()` 필수 호출**
+- ✅ **`beforeEach`에서 `await ctx.reset()` 필수 호출**
+- ✅ suite 전용 fake는 `additionalResetters`에 등록
 - ✅ 각 `it` 블록에서 필요한 데이터를 자체적으로 생성 (per-test isolation)
 - ✅ 순차 의존 테스트(CRUD 등)는 하나의 `it` 블록으로 합침
 - ✅ GWT 주석으로 테스트 의도 표현
 - ✅ `supertest`로 HTTP 요청
 - ✅ 응답 구조 (`success`, `data`, `error.code`) 검증
 - ✅ 상태 코드 검증 (200, 201, 400, 401, 404, 409 등)
-- ✅ `beforeAll` 60초 타임아웃 설정 (Testcontainers 시작 대기)
+- ✅ `beforeAll` 60초 타임아웃 설정 (Nest 앱 초기화 대기)
 
 ### DON'T
 
@@ -434,6 +442,7 @@ pnpm --filter @aido/api test:e2e -- -t "회원가입"
 - ❌ Service/Repository 직접 호출 (HTTP 요청으로 테스트)
 - ❌ 테스트 간 데이터 의존성
 - ❌ 외부 API 직접 호출 (FakeService 사용)
+- ❌ `DATABASE_URL` fallback 또는 `USE_EXTERNAL_DB`로 비관리 DB 연결
 - ❌ `describe` 스코프 `let` 변수로 테스트 간 상태 공유 (`ctx` 제외)
 - ❌ nested `beforeAll`에서 공유 데이터 생성 (각 `it`에서 직접 생성)
 

--- a/apps/api/.claude/integration-test.md
+++ b/apps/api/.claude/integration-test.md
@@ -23,7 +23,7 @@
 | 유형 | DB | 도구 | 목적 | 예시 |
 |------|-----|------|------|------|
 | **Mock DB** | `createMockDatabaseService()` | NestJS `TestingModule` | Service → Repository DI 검증 | cheer, follow, nudge, todo 등 |
-| **실제 DB** | Testcontainers PostgreSQL | `TestDatabase` + 모듈 팩토리 | 전체 DB 트랜잭션 검증 | auth, oauth, account-deletion |
+| **실제 DB** | Jest 실행당 Testcontainers PostgreSQL 1개 | `TestDatabase` + 모듈 팩토리 | 전체 DB 트랜잭션 검증 | auth, oauth, account-deletion |
 
 ### 파일 위치 및 명명
 
@@ -41,7 +41,8 @@ test/
 │   └── mock-database.factory.ts          # createMockDatabaseService
 └── setup/
     ├── suppress-logger.ts                # suppressLogger()
-    └── test-database.ts                  # TestDatabase (Testcontainers)
+    ├── managed-test-database.ts          # global container + migration
+    └── test-database.ts                  # Prisma 연결 + 데이터 초기화
 ```
 
 ---
@@ -180,7 +181,7 @@ const mockDb = createMockDatabaseService({
 
 | 도구 | import | 역할 |
 |------|--------|------|
-| `TestDatabase` | `@test/setup/test-database` | Testcontainers PostgreSQL 관리 |
+| `TestDatabase` | `@test/setup/test-database` | global setup DB에 Prisma 연결 및 데이터 초기화 |
 | `createAuthTestModule()` | `@test/integration/helpers/auth-test-module.factory` | Auth 관련 TestingModule 팩토리 |
 | `suppressLogger()` | `@test/setup/suppress-logger` | Logger 출력 억제 |
 | `FakeEmailService` | `@test/mocks/fake-email.service` | 이메일 발송 Mock |
@@ -216,8 +217,11 @@ describe("{Feature} 통합 테스트 (실제 DB)", () => {
   });
 
   afterAll(async () => {
-    if (testDb) await testDb.stop();
-    if (module) await module.close();
+    try {
+      if (module) await module.close();
+    } finally {
+      if (testDb) await testDb.stop();
+    }
   });
 
   // 테스트 케이스들...
@@ -228,6 +232,10 @@ describe("{Feature} 통합 테스트 (실제 DB)", () => {
 
 Auth 팩토리에 포함되지 않는 서비스(OAuth, AccountPurge)는 자체 모듈을 구성합니다.
 공통 패턴은 동일합니다:
+
+컨테이너 생성과 migration은 Jest `globalSetup`이 suite 전체에서 한 번만 수행합니다.
+각 spec의 `TestDatabase.start()`는 이미 관리 중인 `aido_test_<run-id>` DB에 연결만 하며,
+`cleanup()`은 `_prisma_migrations`를 제외한 `public` 테이블을 동적으로 truncate합니다.
 
 ```typescript
 beforeAll(async () => {

--- a/apps/api/.claude/testing-guide.md
+++ b/apps/api/.claude/testing-guide.md
@@ -112,7 +112,8 @@ eventPublisher = unitRef.get<DomainEventPublisherPort>(DOMAIN_EVENT_PUBLISHER);
 | `test/mocks/mock-database.factory.ts` | `createMockDatabaseService()` — DB Mock + `$transaction` 자동 설정 | Integration (Mock DB) |
 | `test/e2e/helpers/e2e-app-factory.ts` | `createE2eApp()` / `destroyE2eApp()` | E2E |
 | `test/e2e/helpers/e2e-helpers.ts` | `E2eHelpers` — `createVerifiedUser()` 등 | E2E |
-| `test/setup/test-database.ts` | `TestDatabase` (Testcontainers PostgreSQL) | Integration (실제 DB) + E2E |
+| `test/setup/managed-test-database.ts` | Jest 실행당 Testcontainers PostgreSQL + migration 수명주기 | Integration (실제 DB) + E2E |
+| `test/setup/test-database.ts` | 관리형 테스트 DB의 Prisma 연결 + 안전한 truncate | Integration (실제 DB) + E2E |
 | `test/integration/helpers/auth-test-module.factory.ts` | `createAuthTestModule()` | Integration (실제 DB, Auth) |
 
 ### 4.2 FakeService 목록

--- a/apps/api/jest.config.cjs
+++ b/apps/api/jest.config.cjs
@@ -33,9 +33,9 @@ module.exports = {
     ],
   },
 
-  // 루트 디렉토리 - unit test는 src 내부에서만 실행
+  // 루트 디렉토리 - unit test + 테스트 인프라 안전장치 spec
   rootDir: '.',
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/test/setup'],
 
   // 테스트 패턴 - unit test만 (e2e, integration은 별도 설정)
   testMatch: undefined,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
 		"test:cov": "jest --coverage",
 		"test:coverage": "jest --coverage",
 		"test:e2e": "jest --config ./test/jest-e2e.json",
+		"test:e2e:diagnose": "jest --config ./test/jest-e2e.json --runInBand --detectOpenHandles --randomize --showSeed",
 		"test:integration": "jest --config ./test/jest-integration.json",
 		"test:watch": "jest --watch",
 		"typecheck": "tsc --noEmit"

--- a/apps/api/src/auth/application/ports/oauth-identity-provider.port.ts
+++ b/apps/api/src/auth/application/ports/oauth-identity-provider.port.ts
@@ -27,6 +27,13 @@ export interface VerifiedProfile {
 	picture?: string;
 }
 
+export interface OAuthTokenVerifier {
+	verifyAppleToken(token: string, nonce?: string): Promise<VerifiedProfile>;
+	verifyGoogleToken(token: string): Promise<VerifiedProfile>;
+	verifyKakaoToken(token: string): Promise<VerifiedProfile>;
+	verifyNaverToken(token: string): Promise<VerifiedProfile>;
+}
+
 export interface GenerateAuthUrlParams {
 	state: string;
 	validatedRedirectUri: string;

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,5 +1,5 @@
 import { BullModule } from "@nestjs/bullmq";
-import { Logger, Module } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { JwtModule, type JwtSignOptions } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import {
@@ -7,7 +7,6 @@ import {
 	AdminNotificationModule,
 } from "@/admin-notification";
 import { EmailFacade, EmailModule } from "@/email";
-import type { AccountProvider } from "@/generated/prisma/client";
 import { RetentionModule } from "@/retention";
 import { CacheService } from "@/shared/infrastructure/cache/cache.service";
 import { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";
@@ -35,11 +34,7 @@ import {
 	AUTH_USER_REPOSITORY,
 	AUTH_VERIFICATION_REPOSITORY,
 } from "./application/ports";
-import {
-	OAUTH_IDENTITY_PROVIDER_REGISTRY,
-	type OAuthIdentityProvider,
-	type OAuthIdentityProviderRegistry,
-} from "./application/ports/oauth-identity-provider.port";
+import { OAUTH_IDENTITY_PROVIDER_REGISTRY } from "./application/ports/oauth-identity-provider.port";
 import { RETENTION_ENROLLER } from "./application/ports/retention-enroller.port";
 import { USER_PROVISIONING_SEEDER } from "./application/ports/user-provisioning-seeder.port";
 import { SessionService, VerificationService } from "./application/services";
@@ -83,12 +78,7 @@ import { RetentionEnrollerAdapter } from "./infrastructure/adapters/retention-en
 import { TokenService } from "./infrastructure/adapters/token.service";
 import { UserProvisioningSeederAdapter } from "./infrastructure/adapters/user-provisioning-seeder.adapter";
 import { JwtAuthGuard, JwtRefreshGuard } from "./infrastructure/guards";
-import {
-	AppleOAuthProvider,
-	GoogleOAuthProvider,
-	KakaoOAuthProvider,
-	NaverOAuthProvider,
-} from "./infrastructure/oauth/adapters";
+import { createOAuthProviderRegistry } from "./infrastructure/oauth/adapters";
 import { OAuthTokenVerifierService } from "./infrastructure/oauth/verifier/oauth-token-verifier.service";
 import {
 	AccountRepository,
@@ -240,36 +230,7 @@ import { LastActiveInterceptor } from "./presentation/interceptors/last-active.i
 			useFactory: (
 				configService: TypedConfigService,
 				tokenVerifier: OAuthTokenVerifierService,
-			): OAuthIdentityProviderRegistry => {
-				const logger = new Logger("OAuthIdentityProvider");
-				return new Map<AccountProvider, OAuthIdentityProvider>([
-					["APPLE", new AppleOAuthProvider(tokenVerifier)],
-					[
-						"GOOGLE",
-						new GoogleOAuthProvider(
-							() => configService.googleOAuth,
-							tokenVerifier,
-							logger,
-						),
-					],
-					[
-						"KAKAO",
-						new KakaoOAuthProvider(
-							() => configService.kakaoOAuth,
-							tokenVerifier,
-							logger,
-						),
-					],
-					[
-						"NAVER",
-						new NaverOAuthProvider(
-							() => configService.naverOAuth,
-							tokenVerifier,
-							logger,
-						),
-					],
-				]);
-			},
+			) => createOAuthProviderRegistry(configService, tokenVerifier),
 		},
 		// Strategies
 		JwtStrategy,

--- a/apps/api/src/auth/infrastructure/oauth/adapters/apple.oauth-provider.ts
+++ b/apps/api/src/auth/infrastructure/oauth/adapters/apple.oauth-provider.ts
@@ -1,11 +1,9 @@
 import type {
 	OAuthIdentityProvider,
+	OAuthTokenVerifier,
 	SocialLoginOptions,
-} from "@/auth/application/ports/oauth-identity-provider.port";
-import type {
-	OAuthTokenVerifierService,
 	VerifiedProfile,
-} from "@/auth/infrastructure/oauth/verifier/oauth-token-verifier.service";
+} from "@/auth/application/ports/oauth-identity-provider.port";
 
 /**
  * Apple OAuth 전략
@@ -19,9 +17,9 @@ export class AppleOAuthProvider implements OAuthIdentityProvider {
 	readonly provider = "APPLE" as const;
 	readonly failureEmail = "apple_unknown@social.aido.kr";
 
-	readonly #verifier: OAuthTokenVerifierService;
+	readonly #verifier: OAuthTokenVerifier;
 
-	constructor(verifier: OAuthTokenVerifierService) {
+	constructor(verifier: OAuthTokenVerifier) {
 		this.#verifier = verifier;
 	}
 

--- a/apps/api/src/auth/infrastructure/oauth/adapters/google.oauth-provider.ts
+++ b/apps/api/src/auth/infrastructure/oauth/adapters/google.oauth-provider.ts
@@ -4,12 +4,10 @@ import type {
 	ExchangedToken,
 	GenerateAuthUrlParams,
 	OAuthIdentityProvider,
+	OAuthTokenVerifier,
 	SocialLoginOptions,
-} from "@/auth/application/ports/oauth-identity-provider.port";
-import type {
-	OAuthTokenVerifierService,
 	VerifiedProfile,
-} from "@/auth/infrastructure/oauth/verifier/oauth-token-verifier.service";
+} from "@/auth/application/ports/oauth-identity-provider.port";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 import { readJson } from "@/shared/infrastructure/http/read-json";
 
@@ -32,12 +30,12 @@ export class GoogleOAuthProvider implements OAuthIdentityProvider {
 	readonly failureEmail = "google_unknown@social.aido.kr";
 
 	readonly #getConfig: () => OAuthConfig;
-	readonly #verifier: OAuthTokenVerifierService;
+	readonly #verifier: OAuthTokenVerifier;
 	readonly #logger: Logger;
 
 	constructor(
 		getConfig: () => OAuthConfig,
-		verifier: OAuthTokenVerifierService,
+		verifier: OAuthTokenVerifier,
 		logger: Logger,
 	) {
 		this.#getConfig = getConfig;

--- a/apps/api/src/auth/infrastructure/oauth/adapters/index.ts
+++ b/apps/api/src/auth/infrastructure/oauth/adapters/index.ts
@@ -2,3 +2,4 @@ export * from "./apple.oauth-provider";
 export * from "./google.oauth-provider";
 export * from "./kakao.oauth-provider";
 export * from "./naver.oauth-provider";
+export * from "./oauth-provider-registry.factory";

--- a/apps/api/src/auth/infrastructure/oauth/adapters/kakao.oauth-provider.ts
+++ b/apps/api/src/auth/infrastructure/oauth/adapters/kakao.oauth-provider.ts
@@ -4,12 +4,10 @@ import type {
 	ExchangedToken,
 	GenerateAuthUrlParams,
 	OAuthIdentityProvider,
+	OAuthTokenVerifier,
 	SocialLoginOptions,
-} from "@/auth/application/ports/oauth-identity-provider.port";
-import type {
-	OAuthTokenVerifierService,
 	VerifiedProfile,
-} from "@/auth/infrastructure/oauth/verifier/oauth-token-verifier.service";
+} from "@/auth/application/ports/oauth-identity-provider.port";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 import { readJson } from "@/shared/infrastructure/http/read-json";
 
@@ -32,12 +30,12 @@ export class KakaoOAuthProvider implements OAuthIdentityProvider {
 	readonly failureEmail = "kakao_unknown@social.aido.kr";
 
 	readonly #getConfig: () => OAuthConfig;
-	readonly #verifier: OAuthTokenVerifierService;
+	readonly #verifier: OAuthTokenVerifier;
 	readonly #logger: Logger;
 
 	constructor(
 		getConfig: () => OAuthConfig,
-		verifier: OAuthTokenVerifierService,
+		verifier: OAuthTokenVerifier,
 		logger: Logger,
 	) {
 		this.#getConfig = getConfig;

--- a/apps/api/src/auth/infrastructure/oauth/adapters/naver.oauth-provider.ts
+++ b/apps/api/src/auth/infrastructure/oauth/adapters/naver.oauth-provider.ts
@@ -4,12 +4,10 @@ import type {
 	ExchangedToken,
 	GenerateAuthUrlParams,
 	OAuthIdentityProvider,
+	OAuthTokenVerifier,
 	SocialLoginOptions,
-} from "@/auth/application/ports/oauth-identity-provider.port";
-import type {
-	OAuthTokenVerifierService,
 	VerifiedProfile,
-} from "@/auth/infrastructure/oauth/verifier/oauth-token-verifier.service";
+} from "@/auth/application/ports/oauth-identity-provider.port";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 import { readJson } from "@/shared/infrastructure/http/read-json";
 
@@ -32,12 +30,12 @@ export class NaverOAuthProvider implements OAuthIdentityProvider {
 	readonly failureEmail = "naver_unknown@social.aido.kr";
 
 	readonly #getConfig: () => OAuthConfig;
-	readonly #verifier: OAuthTokenVerifierService;
+	readonly #verifier: OAuthTokenVerifier;
 	readonly #logger: Logger;
 
 	constructor(
 		getConfig: () => OAuthConfig,
-		verifier: OAuthTokenVerifierService,
+		verifier: OAuthTokenVerifier,
 		logger: Logger,
 	) {
 		this.#getConfig = getConfig;

--- a/apps/api/src/auth/infrastructure/oauth/adapters/oauth-provider-registry.factory.ts
+++ b/apps/api/src/auth/infrastructure/oauth/adapters/oauth-provider-registry.factory.ts
@@ -1,0 +1,46 @@
+import { Logger } from "@nestjs/common";
+import type {
+	OAuthIdentityProvider,
+	OAuthIdentityProviderRegistry,
+	OAuthTokenVerifier,
+} from "@/auth/application/ports/oauth-identity-provider.port";
+import type { AccountProvider } from "@/auth/domain/types";
+import type { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";
+import { AppleOAuthProvider } from "./apple.oauth-provider";
+import { GoogleOAuthProvider } from "./google.oauth-provider";
+import { KakaoOAuthProvider } from "./kakao.oauth-provider";
+import { NaverOAuthProvider } from "./naver.oauth-provider";
+
+export function createOAuthProviderRegistry(
+	configService: TypedConfigService,
+	tokenVerifier: OAuthTokenVerifier,
+): OAuthIdentityProviderRegistry {
+	const logger = new Logger("OAuthIdentityProvider");
+	return new Map<AccountProvider, OAuthIdentityProvider>([
+		["APPLE", new AppleOAuthProvider(tokenVerifier)],
+		[
+			"GOOGLE",
+			new GoogleOAuthProvider(
+				() => configService.googleOAuth,
+				tokenVerifier,
+				logger,
+			),
+		],
+		[
+			"KAKAO",
+			new KakaoOAuthProvider(
+				() => configService.kakaoOAuth,
+				tokenVerifier,
+				logger,
+			),
+		],
+		[
+			"NAVER",
+			new NaverOAuthProvider(
+				() => configService.naverOAuth,
+				tokenVerifier,
+				logger,
+			),
+		],
+	]);
+}

--- a/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.spec.ts
+++ b/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.spec.ts
@@ -130,6 +130,17 @@ function makeConsent(userId: string): UserConsentRecordWithId {
 	};
 }
 
+function createDeferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+} {
+	let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+	const promise = new Promise<T>((resolver) => {
+		resolve = resolver;
+	});
+	return { promise, resolve };
+}
+
 describe("PushDispatcherAdapter", () => {
 	let adapter: PushDispatcherAdapter;
 	let userSettings: Mocked<UserNotificationSettingsPort>;
@@ -188,6 +199,59 @@ describe("PushDispatcherAdapter", () => {
 			userId: "user-1",
 			activeOnly: true,
 		});
+	});
+
+	it("drain 도중 추가된 push까지 모두 완료될 때까지 기다린다", async () => {
+		const releaseSecondPush = createDeferred<void>();
+		const secondPushStarted = createDeferred<void>();
+		userSettings.getPreferenceRecord.mockImplementation(async (userId) =>
+			makePreference(userId, "UTC"),
+		);
+		rateLimiter.isRateLimited.mockResolvedValue(false);
+		cacheService.wrapPushTokens.mockResolvedValue([]);
+		repository.recordPushDeliveryResults.mockResolvedValue(undefined);
+		repository.createPushDispatch.mockImplementation(async ({ userId }) => {
+			if (userId === "user-1") {
+				adapter.fireAndForgetPush(
+					{
+						userId: "user-2",
+						type: "NUDGE_RECEIVED",
+						title: "second",
+						body: "second",
+					},
+					2,
+				);
+				return { id: 1 };
+			}
+
+			secondPushStarted.resolve(undefined);
+			await releaseSecondPush.promise;
+			return { id: 2 };
+		});
+
+		adapter.fireAndForgetPush(
+			{
+				userId: "user-1",
+				type: "NUDGE_RECEIVED",
+				title: "first",
+				body: "first",
+			},
+			1,
+		);
+		const draining = adapter.drainPendingPushes();
+		await secondPushStarted.promise;
+
+		const drainState = await Promise.race([
+			draining.then(() => "completed" as const),
+			new Promise<"pending">((resolve) => {
+				setImmediate(() => resolve("pending"));
+			}),
+		]);
+		expect(drainState).toBe("pending");
+
+		releaseSecondPush.resolve(undefined);
+		await draining;
+		expect(repository.recordPushDeliveryResults).toHaveBeenCalledTimes(2);
 	});
 
 	it("배치 발송은 설정 필터 후 모든 사용자 제한을 한 번에 예약한다", async () => {

--- a/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
+++ b/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
@@ -645,7 +645,8 @@ export class PushDispatcherAdapter
 		promise.finally(() => this.#pendingPushes.delete(promise));
 	}
 
-	async beforeApplicationShutdown(): Promise<void> {
+	/** 진행 중인 fire-and-forget 발송을 모두 기다린다. */
+	async drainPendingPushes(): Promise<void> {
 		if (this.#pendingPushes.size > 0) {
 			this.#logger.log(
 				`Waiting for ${this.#pendingPushes.size} pending push(es)...`,
@@ -653,7 +654,10 @@ export class PushDispatcherAdapter
 			await Promise.allSettled([...this.#pendingPushes]);
 			this.#logger.log("All pending pushes completed");
 		}
+	}
 
+	async beforeApplicationShutdown(): Promise<void> {
+		await this.drainPendingPushes();
 		this.rateLimiter.destroy?.();
 	}
 }

--- a/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
+++ b/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
@@ -647,13 +647,15 @@ export class PushDispatcherAdapter
 
 	/** 진행 중인 fire-and-forget 발송을 모두 기다린다. */
 	async drainPendingPushes(): Promise<void> {
-		if (this.#pendingPushes.size > 0) {
-			this.#logger.log(
-				`Waiting for ${this.#pendingPushes.size} pending push(es)...`,
-			);
+		if (this.#pendingPushes.size === 0) return;
+
+		this.#logger.log(
+			`Waiting for ${this.#pendingPushes.size} pending push(es)...`,
+		);
+		while (this.#pendingPushes.size > 0) {
 			await Promise.allSettled([...this.#pendingPushes]);
-			this.#logger.log("All pending pushes completed");
 		}
+		this.#logger.log("All pending pushes completed");
 	}
 
 	async beforeApplicationShutdown(): Promise<void> {

--- a/apps/api/test/e2e/admin.e2e-spec.ts
+++ b/apps/api/test/e2e/admin.e2e-spec.ts
@@ -28,8 +28,7 @@ describe("관리자 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	/** 관리자 사용자를 생성하고 ADMIN role 토큰을 반환하는 헬퍼 */

--- a/apps/api/test/e2e/ai-report.e2e-spec.ts
+++ b/apps/api/test/e2e/ai-report.e2e-spec.ts
@@ -29,6 +29,7 @@ describe("AI 리포트 E2E", () => {
 		ctx = await createE2eApp({
 			customizeBuilder: (builder) =>
 				builder.overrideProvider(AI_PROVIDER).useValue(fakeAiProvider),
+			additionalResetters: [() => fakeAiProvider.clear()],
 		});
 	}, 60000);
 
@@ -37,9 +38,7 @@ describe("AI 리포트 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
-		fakeAiProvider.clear();
+		await ctx.reset();
 	});
 
 	/** 프리미엄 사용자를 생성하고 토큰을 반환하는 헬퍼 */

--- a/apps/api/test/e2e/ai-suggestion.e2e-spec.ts
+++ b/apps/api/test/e2e/ai-suggestion.e2e-spec.ts
@@ -28,6 +28,7 @@ describe("AI 제안 E2E", () => {
 		ctx = await createE2eApp({
 			customizeBuilder: (builder) =>
 				builder.overrideProvider(AI_PROVIDER).useValue(fakeAiProvider),
+			additionalResetters: [() => fakeAiProvider.clear()],
 		});
 	}, 60000);
 
@@ -36,9 +37,7 @@ describe("AI 제안 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
-		fakeAiProvider.clear();
+		await ctx.reset();
 	});
 
 	/** 프리미엄 사용자를 생성하고 토큰을 반환하는 헬퍼 */

--- a/apps/api/test/e2e/ai.e2e-spec.ts
+++ b/apps/api/test/e2e/ai.e2e-spec.ts
@@ -80,6 +80,7 @@ describe("AI E2E", () => {
 		ctx = await createE2eApp({
 			customizeBuilder: (builder) =>
 				builder.overrideProvider(AI_PROVIDER).useValue(fakeAiProvider),
+			additionalResetters: [() => fakeAiProvider.clear()],
 		});
 	}, 60000);
 
@@ -89,9 +90,7 @@ describe("AI E2E", () => {
 
 	beforeEach(async () => {
 		// 각 테스트 전에 DB 정리 및 사용자 재생성
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
-		fakeAiProvider.clear();
+		await ctx.reset();
 
 		// 테스트 사용자 생성 및 인증
 		const user = await ctx.helpers.createVerifiedUser(
@@ -326,9 +325,11 @@ describe("AI E2E", () => {
 					startDate: "2026-05-01",
 					isAllDay: true,
 				});
-				const lastMonth = new Date();
-				lastMonth.setMonth(lastMonth.getMonth() - 1);
-				await setUsageWithResetAt(testUserId, 5, lastMonth);
+				const now = new Date();
+				const previousMonthFirstDay = new Date(
+					Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1),
+				);
+				await setUsageWithResetAt(testUserId, 5, previousMonthFirstDay);
 
 				// When - 새 달 첫 요청
 				const parseResponse = await request(ctx.app.getHttpServer())

--- a/apps/api/test/e2e/app.e2e-spec.ts
+++ b/apps/api/test/e2e/app.e2e-spec.ts
@@ -20,6 +20,10 @@ describe("앱 컨트롤러 E2E", () => {
 		await destroyE2eApp(ctx);
 	});
 
+	beforeEach(async () => {
+		await ctx.reset();
+	});
+
 	it("/ (GET)", () => {
 		// Given - 애플리케이션이 초기화된 상태
 

--- a/apps/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/api/test/e2e/auth.e2e-spec.ts
@@ -33,8 +33,7 @@ describe("인증 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	describe("회원가입 플로우", () => {
@@ -876,8 +875,62 @@ describe("인증 E2E", () => {
 			expect(response.headers.location).toContain("response_type=code");
 		});
 
+		it("GET /auth/kakao/web-callback - 테스트 fake로 성공하며 외부 요청을 보내지 않는다", async () => {
+			// Given - start 단계에서 state와 redirect_uri를 저장
+			const state = "kakao-success-state";
+			const authorizationCode = "kakao-success-code";
+			const exchangedToken = "kakao-success-token";
+			const redirectUri = "aido://auth/kakao-success";
+			const fetchSpy = jest.spyOn(global, "fetch");
+
+			ctx.fakeOAuthProviderRegistry.setExchangeToken(
+				"KAKAO",
+				authorizationCode,
+				exchangedToken,
+			);
+			ctx.fakeOAuthTokenVerifierService.setCustomProfile(
+				"kakao",
+				exchangedToken,
+				{
+					id: "kakao-web-success-user",
+					email: "kakao-web-success@test.com",
+					emailVerified: true,
+					name: "웹 OAuth 사용자",
+				},
+			);
+
+			try {
+				await request(ctx.app.getHttpServer())
+					.get("/auth/kakao/start")
+					.query({ state, redirect_uri: redirectUri })
+					.expect(302);
+
+				// When - provider의 실제 token endpoint 대신 fake code exchange 실행
+				const response = await request(ctx.app.getHttpServer())
+					.get("/auth/kakao/web-callback")
+					.query({ code: authorizationCode, state })
+					.expect(302);
+
+				// Then - 일회용 교환 코드가 반환되고 외부 fetch는 호출되지 않음
+				expect(response.headers.location).toBeDefined();
+				const location = new URL(response.headers.location ?? "");
+				expect(
+					`${location.protocol}//${location.host}${location.pathname}`,
+				).toBe(redirectUri);
+				expect(location.searchParams.get("code")).toBeTruthy();
+				expect(location.searchParams.get("state")).toBe(state);
+				expect(fetchSpy).not.toHaveBeenCalled();
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
 		it("GET /auth/kakao/web-callback - 잘못된 code로 요청하면 딥링크로 에러 리다이렉트", async () => {
-			// Given - 잘못된 authorization code
+			// Given - 결정적으로 실패하도록 설정한 authorization code
+			ctx.fakeOAuthProviderRegistry.simulateExchangeFailure(
+				"KAKAO",
+				"invalid-auth-code",
+			);
 
 			// When - 카카오 콜백 API 호출
 			const response = await request(ctx.app.getHttpServer())

--- a/apps/api/test/e2e/cache-invalidation.e2e-spec.ts
+++ b/apps/api/test/e2e/cache-invalidation.e2e-spec.ts
@@ -12,7 +12,7 @@ import { Test, type TestingModule } from "@nestjs/testing";
 import { CacheModule } from "@/shared/infrastructure/cache/cache.module";
 import { CacheService } from "@/shared/infrastructure/cache/cache.service";
 import { CacheKeys } from "@/shared/infrastructure/cache/constants/cache-keys";
-import { createMockUserProfile, delay } from "../mocks/cache-test-utils";
+import { createMockUserProfile } from "../mocks/cache-test-utils";
 
 describe("캐시 무효화 E2E 테스트", () => {
 	let app: INestApplication;
@@ -76,6 +76,8 @@ describe("캐시 무효화 E2E 테스트", () => {
 
 		it("세션 TTL 만료 시 자동으로 삭제된다", async () => {
 			// Given - 짧은 TTL로 새 캐시 모듈 생성
+			const baseTime = Date.now();
+			const now = jest.spyOn(Date, "now").mockReturnValue(baseTime);
 			const shortTtlModule = await Test.createTestingModule({
 				imports: [
 					ConfigModule.forRoot({
@@ -93,28 +95,31 @@ describe("캐시 무효화 E2E 테스트", () => {
 			}).compile();
 
 			const shortTtlApp = shortTtlModule.createNestApplication();
-			await shortTtlApp.init();
-			const shortTtlCache = shortTtlModule.get<CacheService>(CacheService);
+			try {
+				await shortTtlApp.init();
+				const shortTtlCache = shortTtlModule.get<CacheService>(CacheService);
 
-			const sessionId = "sess_short_ttl";
-			const session = {
-				userId: "user_ttl",
-				expiresAt: new Date(),
-				revokedAt: null,
-			};
+				const sessionId = "sess_short_ttl";
+				const session = {
+					userId: "user_ttl",
+					expiresAt: new Date(),
+					revokedAt: null,
+				};
 
-			// When - 세션 저장 (setSession은 고정 TTL 30초를 쓰므로 짧은 TTL을 직접 지정)
-			await shortTtlCache.set(CacheKeys.session(sessionId), session, 50);
-			expect(await shortTtlCache.getSession(sessionId)).toEqual(session);
+				// When - 세션 저장 (setSession은 고정 TTL 30초를 쓰므로 짧은 TTL을 직접 지정)
+				await shortTtlCache.set(CacheKeys.session(sessionId), session, 50);
+				expect(await shortTtlCache.getSession(sessionId)).toEqual(session);
 
-			// When - TTL 만료 대기
-			await delay(100);
+				// When - 실제 대기 없이 TTL 이후로 시간 이동
+				now.mockReturnValue(baseTime + 100);
 
-			// Then - 세션 자동 삭제
-			const afterExpiry = await shortTtlCache.getSession(sessionId);
-			expect(afterExpiry).toBeUndefined();
-
-			await shortTtlApp.close();
+				// Then - 세션 자동 삭제
+				const afterExpiry = await shortTtlCache.getSession(sessionId);
+				expect(afterExpiry).toBeUndefined();
+			} finally {
+				now.mockRestore();
+				await shortTtlApp.close();
+			}
 		});
 	});
 
@@ -356,24 +361,26 @@ describe("캐시 무효화 E2E 테스트", () => {
 			await smallCacheApp.init();
 			const smallCache = smallCacheModule.get<CacheService>(CacheService);
 
-			// When - 5개 항목 저장
-			for (let i = 1; i <= 5; i++) {
-				await smallCache.set(`key_${i}`, `value_${i}`);
+			try {
+				// When - 5개 항목 저장
+				for (let i = 1; i <= 5; i++) {
+					await smallCache.set(`key_${i}`, `value_${i}`);
+				}
+
+				// Then - 5개 모두 존재
+				expect(smallCache.getStats().keys).toBe(5);
+				expect(await smallCache.get("key_1")).toBe("value_1");
+
+				// When - 6번째 항목 추가 (LRU로 key_1 퇴출)
+				await smallCache.set("key_6", "value_6");
+
+				// Then - key_1은 퇴출, key_6은 존재
+				expect(smallCache.getStats().keys).toBe(5);
+				expect(await smallCache.get("key_1")).toBeUndefined();
+				expect(await smallCache.get("key_6")).toBe("value_6");
+			} finally {
+				await smallCacheApp.close();
 			}
-
-			// Then - 5개 모두 존재
-			expect(smallCache.getStats().keys).toBe(5);
-			expect(await smallCache.get("key_1")).toBe("value_1");
-
-			// When - 6번째 항목 추가 (LRU로 key_1 퇴출)
-			await smallCache.set("key_6", "value_6");
-
-			// Then - key_1은 퇴출, key_6은 존재
-			expect(smallCache.getStats().keys).toBe(5);
-			expect(await smallCache.get("key_1")).toBeUndefined();
-			expect(await smallCache.get("key_6")).toBe("value_6");
-
-			await smallCacheApp.close();
 		});
 	});
 });

--- a/apps/api/test/e2e/cheer.e2e-spec.ts
+++ b/apps/api/test/e2e/cheer.e2e-spec.ts
@@ -27,8 +27,7 @@ describe("응원 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";

--- a/apps/api/test/e2e/daily-completion.e2e-spec.ts
+++ b/apps/api/test/e2e/daily-completion.e2e-spec.ts
@@ -71,8 +71,7 @@ describe("일일 달성 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";

--- a/apps/api/test/e2e/follow-resource-limit.e2e-spec.ts
+++ b/apps/api/test/e2e/follow-resource-limit.e2e-spec.ts
@@ -25,8 +25,7 @@ describe("팔로우 리소스 제한 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";

--- a/apps/api/test/e2e/follow.e2e-spec.ts
+++ b/apps/api/test/e2e/follow.e2e-spec.ts
@@ -33,8 +33,7 @@ describe("팔로우 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	describe("친구 요청 플로우", () => {
@@ -368,13 +367,21 @@ describe("팔로우 E2E", () => {
 			const categoryId = await ctx.helpers.getDefaultCategoryId(
 				userJ.accessToken,
 			);
+			const rangeStart = new Date();
+			rangeStart.setUTCDate(rangeStart.getUTCDate() - 1);
+			const rangeEnd = new Date();
+			rangeEnd.setUTCDate(rangeEnd.getUTCDate() + 1);
+			const activeDateRange = {
+				startDate: rangeStart.toISOString().split("T")[0],
+				endDate: rangeEnd.toISOString().split("T")[0],
+			};
 
 			await request(ctx.app.getHttpServer())
 				.post("/todos")
 				.set("Authorization", `Bearer ${userJ.accessToken}`)
 				.send({
 					title: "J의 공개 할 일",
-					startDate: new Date().toISOString().split("T")[0],
+					...activeDateRange,
 					visibility: "PUBLIC",
 					categoryId,
 				})
@@ -385,7 +392,7 @@ describe("팔로우 E2E", () => {
 				.set("Authorization", `Bearer ${userJ.accessToken}`)
 				.send({
 					title: "J의 비공개 할 일",
-					startDate: new Date().toISOString().split("T")[0],
+					...activeDateRange,
 					visibility: "PRIVATE",
 					categoryId,
 				})

--- a/apps/api/test/e2e/health-queue-policy.e2e-spec.ts
+++ b/apps/api/test/e2e/health-queue-policy.e2e-spec.ts
@@ -12,11 +12,16 @@ describe("queue Redis policy health E2E", () => {
 				builder
 					.overrideProvider(RedisEvictionPolicyProbe)
 					.useValue({ inspect }),
+			additionalResetters: [() => inspect.mockReset()],
 		});
 	});
 
 	afterAll(async () => {
 		await destroyE2eApp(ctx);
+	});
+
+	beforeEach(async () => {
+		await ctx.reset();
 	});
 
 	it("noeviction이면 기존 health 성공 계약을 유지한다", async () => {

--- a/apps/api/test/e2e/helpers/e2e-app-factory.ts
+++ b/apps/api/test/e2e/helpers/e2e-app-factory.ts
@@ -31,6 +31,8 @@ import { AI_SUGGESTION_QUEUE } from "@/ai-suggestion";
 import { SuggestionAnalysisJob } from "@/ai-suggestion/infrastructure/jobs/suggestion-analysis.job";
 import { SuggestionAnalysisProcessor } from "@/ai-suggestion/infrastructure/processors/suggestion-analysis.processor";
 import { AppModule } from "@/app.module";
+import { OAUTH_IDENTITY_PROVIDER_REGISTRY } from "@/auth/application/ports/oauth-identity-provider.port";
+import { createOAuthProviderRegistry } from "@/auth/infrastructure/oauth/adapters";
 import { OAuthTokenVerifierService } from "@/auth/infrastructure/oauth/verifier/oauth-token-verifier.service";
 import {
 	ACCOUNT_PURGE_QUEUE,
@@ -43,6 +45,8 @@ import {
 	NotificationQueueProcessor,
 	PUSH_PROVIDER,
 } from "@/notification";
+import { PUSH_DISPATCHER } from "@/notification/application/ports/push-dispatcher.port";
+import { PushDispatcherAdapter } from "@/notification/infrastructure/adapters/push-dispatcher.adapter";
 import { RETENTION_QUEUE } from "@/retention/infrastructure/queue/retention-queue.constants";
 import { RetentionQueueProcessor } from "@/retention/infrastructure/queue/retention-queue.processor";
 import { RetentionQueueService } from "@/retention/infrastructure/queue/retention-queue.service";
@@ -55,6 +59,7 @@ import {
 } from "@/scheduler";
 import { InMemoryCacheAdapter } from "@/shared/infrastructure/cache/adapters/in-memory-cache.adapter";
 import { CACHE_SERVICE } from "@/shared/infrastructure/cache/interfaces/cache.interface";
+import { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";
 import { DatabaseService } from "@/shared/infrastructure/database";
 import {
 	REDIS_CLIENT,
@@ -71,12 +76,17 @@ import { createMockBullQueue } from "../../mocks/fake-bull-queue";
 import { FakeEmailService } from "../../mocks/fake-email.service";
 import { FakeLifestyleIndexProvider } from "../../mocks/fake-lifestyle-index.provider";
 import { FakeLogger } from "../../mocks/fake-logger.service";
+import { FakeOAuthProviderRegistry } from "../../mocks/fake-oauth-provider-registry";
 import { FakeOAuthTokenVerifierService } from "../../mocks/fake-oauth-token-verifier.service";
 import { FakePushProvider } from "../../mocks/fake-push.provider";
 import { FakeSunTimeProvider } from "../../mocks/fake-sun-time.provider";
 import { FakeWeatherProvider } from "../../mocks/fake-weather.provider";
 import { TestDatabase } from "../../setup/test-database";
 import { E2eHelpers } from "./e2e-helpers";
+import {
+	createE2eTestStateResetter,
+	type TestStateResetter,
+} from "./e2e-test-state";
 
 /* ── BullMQ 격리 대상 ─────────────────────────────────── */
 
@@ -117,7 +127,11 @@ export interface E2eTestContext {
 	testDatabase: TestDatabase;
 	fakeEmailService: FakeEmailService;
 	fakeOAuthTokenVerifierService: FakeOAuthTokenVerifierService;
+	fakeOAuthProviderRegistry: FakeOAuthProviderRegistry;
 	helpers: E2eHelpers;
+	reset(): Promise<void>;
+	/** @internal destroyE2eApp 전용 */
+	closeTestResources(): Promise<void>;
 }
 
 export interface E2eAppOptions {
@@ -125,6 +139,8 @@ export interface E2eAppOptions {
 	customizeBuilder?: (
 		builder: ReturnType<typeof Test.createTestingModule>,
 	) => ReturnType<typeof Test.createTestingModule>;
+	/** suite에서 추가로 override한 fake의 상태 초기화 함수 */
+	additionalResetters?: readonly TestStateResetter[];
 }
 
 export async function createE2eApp(
@@ -145,6 +161,38 @@ export async function createE2eApp(
 	const fakeSunTimeProvider = new FakeSunTimeProvider();
 
 	const redisMock = new RedisMock();
+	const cacheAdapter = new InMemoryCacheAdapter({
+		defaultTtlMs: 60000,
+		maxItems: 1000,
+		cleanupIntervalMs: 30000,
+	});
+	let fakeOAuthProviderRegistry: FakeOAuthProviderRegistry | undefined;
+	let pushDispatcher: PushDispatcherAdapter | undefined;
+	let module: TestingModule | undefined;
+	let app: INestApplication<App> | undefined;
+
+	const closeTestResources = async (): Promise<void> => {
+		const errors: unknown[] = [];
+		try {
+			await app?.close();
+		} catch (error) {
+			errors.push(error);
+		}
+
+		const results = await Promise.allSettled([
+			Promise.resolve().then(() => redisMock.disconnect()),
+			Promise.resolve().then(() => cacheAdapter.onModuleDestroy()),
+			testDatabase.stop(),
+		]);
+		errors.push(
+			...results.flatMap((result) =>
+				result.status === "rejected" ? [result.reason] : [],
+			),
+		);
+		if (errors.length > 0) {
+			throw new AggregateError(errors, "Failed to close E2E test resources");
+		}
+	};
 
 	let builder = Test.createTestingModule({
 		imports: [AppModule],
@@ -154,19 +202,25 @@ export async function createE2eApp(
 		.overrideProvider(REDIS_COMMAND_CLIENT)
 		.useValue(redisMock)
 		.overrideProvider(CACHE_SERVICE)
-		.useValue(
-			new InMemoryCacheAdapter({
-				defaultTtlMs: 60000,
-				maxItems: 1000,
-				cleanupIntervalMs: 30000,
-			}),
-		)
+		.useValue(cacheAdapter)
 		.overrideProvider(DatabaseService)
 		.useValue(testDatabase.getPrisma())
 		.overrideProvider(EmailFacade)
 		.useValue(fakeEmailService)
 		.overrideProvider(OAuthTokenVerifierService)
 		.useValue(fakeOAuthTokenVerifierService)
+		.overrideProvider(OAUTH_IDENTITY_PROVIDER_REGISTRY)
+		.useFactory({
+			inject: [TypedConfigService],
+			factory: (configService: TypedConfigService) => {
+				const delegates = createOAuthProviderRegistry(
+					configService,
+					fakeOAuthTokenVerifierService,
+				);
+				fakeOAuthProviderRegistry = new FakeOAuthProviderRegistry(delegates);
+				return fakeOAuthProviderRegistry.registry;
+			},
+		})
 		.overrideProvider(ADMIN_NOTIFIER)
 		.useValue(fakeAdminNotifier)
 		.overrideProvider(PAYMENT_NOTIFIER)
@@ -207,25 +261,56 @@ export async function createE2eApp(
 		builder = options.customizeBuilder(builder);
 	}
 
-	const module = await builder.compile();
+	try {
+		module = await builder.compile();
+		app = module.createNestApplication();
+		app.useGlobalPipes(new ZodValidationPipe());
+		await app.init();
+		pushDispatcher = module.get<PushDispatcherAdapter>(PUSH_DISPATCHER);
 
-	const app = module.createNestApplication();
-	app.useGlobalPipes(new ZodValidationPipe());
-	await app.init();
+		if (!fakeOAuthProviderRegistry) {
+			throw new Error("Fake OAuth provider registry was not initialized");
+		}
 
-	const helpers = new E2eHelpers(app, fakeEmailService);
+		const helpers = new E2eHelpers(app, fakeEmailService);
+		const reset = createE2eTestStateResetter({
+			drainBackgroundWork: () => pushDispatcher?.drainPendingPushes(),
+			cleanupDatabase: () => testDatabase.cleanup(),
+			resetCache: () => cacheAdapter.reset(),
+			flushRedis: () => redisMock.flushall(),
+			sharedResetters: [
+				() => fakeEmailService.clear(),
+				() => fakeOAuthTokenVerifierService.clear(),
+				() => fakeOAuthProviderRegistry?.clear(),
+				() => fakeAdminNotifier.clear(),
+				() => fakePaymentNotifier.clear(),
+				() => fakePushProvider.clear(),
+				() => fakeAiProvider.clear(),
+				() => fakeWeatherProvider.clear(),
+				() => fakeAirQualityProvider.clear(),
+				() => fakeLifestyleIndexProvider.clear(),
+				() => fakeSunTimeProvider.clear(),
+			],
+			additionalResetters: options?.additionalResetters,
+		});
 
-	return {
-		app,
-		module,
-		testDatabase,
-		fakeEmailService,
-		fakeOAuthTokenVerifierService,
-		helpers,
-	};
+		return {
+			app,
+			module,
+			testDatabase,
+			fakeEmailService,
+			fakeOAuthTokenVerifierService,
+			fakeOAuthProviderRegistry,
+			helpers,
+			reset,
+			closeTestResources,
+		};
+	} catch (error) {
+		await closeTestResources();
+		throw error;
+	}
 }
 
 export async function destroyE2eApp(ctx: E2eTestContext): Promise<void> {
-	await ctx.app.close();
-	await ctx.testDatabase.stop();
+	await ctx.closeTestResources();
 }

--- a/apps/api/test/e2e/helpers/e2e-test-state.ts
+++ b/apps/api/test/e2e/helpers/e2e-test-state.ts
@@ -1,5 +1,9 @@
 export type TestStateResetter = () => Promise<unknown> | unknown;
 
+function normalizeError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
 interface E2eTestStateDependencies {
 	drainBackgroundWork?: TestStateResetter;
 	cleanupDatabase: TestStateResetter;
@@ -17,8 +21,7 @@ export function createE2eTestStateResetter({
 	sharedResetters,
 	additionalResetters = [],
 }: E2eTestStateDependencies): () => Promise<void> {
-	const resetters = [
-		cleanupDatabase,
+	const nonDatabaseResetters = [
 		resetCache,
 		flushRedis,
 		...sharedResetters,
@@ -26,22 +29,28 @@ export function createE2eTestStateResetter({
 	];
 
 	return async () => {
+		const errors: Error[] = [];
+		let backgroundWorkDrained = true;
 		if (drainBackgroundWork) {
 			try {
 				await drainBackgroundWork();
 			} catch (error) {
-				throw new AggregateError(
-					[error],
-					"Failed to drain E2E background work",
-				);
+				backgroundWorkDrained = false;
+				errors.push(normalizeError(error));
 			}
 		}
 
+		const resetters = [
+			...(backgroundWorkDrained ? [cleanupDatabase] : []),
+			...nonDatabaseResetters,
+		];
 		const results = await Promise.allSettled(
 			resetters.map(async (resetter) => resetter()),
 		);
-		const errors = results.flatMap((result) =>
-			result.status === "rejected" ? [result.reason] : [],
+		errors.push(
+			...results.flatMap((result) =>
+				result.status === "rejected" ? [normalizeError(result.reason)] : [],
+			),
 		);
 
 		if (errors.length > 0) {

--- a/apps/api/test/e2e/helpers/e2e-test-state.ts
+++ b/apps/api/test/e2e/helpers/e2e-test-state.ts
@@ -1,0 +1,51 @@
+export type TestStateResetter = () => Promise<unknown> | unknown;
+
+interface E2eTestStateDependencies {
+	drainBackgroundWork?: TestStateResetter;
+	cleanupDatabase: TestStateResetter;
+	resetCache: TestStateResetter;
+	flushRedis: TestStateResetter;
+	sharedResetters: readonly TestStateResetter[];
+	additionalResetters?: readonly TestStateResetter[];
+}
+
+export function createE2eTestStateResetter({
+	drainBackgroundWork,
+	cleanupDatabase,
+	resetCache,
+	flushRedis,
+	sharedResetters,
+	additionalResetters = [],
+}: E2eTestStateDependencies): () => Promise<void> {
+	const resetters = [
+		cleanupDatabase,
+		resetCache,
+		flushRedis,
+		...sharedResetters,
+		...additionalResetters,
+	];
+
+	return async () => {
+		if (drainBackgroundWork) {
+			try {
+				await drainBackgroundWork();
+			} catch (error) {
+				throw new AggregateError(
+					[error],
+					"Failed to drain E2E background work",
+				);
+			}
+		}
+
+		const results = await Promise.allSettled(
+			resetters.map(async (resetter) => resetter()),
+		);
+		const errors = results.flatMap((result) =>
+			result.status === "rejected" ? [result.reason] : [],
+		);
+
+		if (errors.length > 0) {
+			throw new AggregateError(errors, "Failed to reset E2E test state");
+		}
+	};
+}

--- a/apps/api/test/e2e/inquiry.e2e-spec.ts
+++ b/apps/api/test/e2e/inquiry.e2e-spec.ts
@@ -28,8 +28,7 @@ describe("문의 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	describe("POST /inquiries - 문의 접수", () => {

--- a/apps/api/test/e2e/notification.e2e-spec.ts
+++ b/apps/api/test/e2e/notification.e2e-spec.ts
@@ -31,8 +31,7 @@ describe("알림 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";

--- a/apps/api/test/e2e/nudge.e2e-spec.ts
+++ b/apps/api/test/e2e/nudge.e2e-spec.ts
@@ -27,20 +27,28 @@ describe("찔러보기 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";
+	function activeDateRange(): { startDate: string; endDate: string } {
+		const start = new Date();
+		start.setUTCDate(start.getUTCDate() - 1);
+		const end = new Date();
+		end.setUTCDate(end.getUTCDate() + 1);
+		return {
+			startDate: start.toISOString().split("T")[0] ?? "",
+			endDate: end.toISOString().split("T")[0] ?? "",
+		};
+	}
 
 	/** receiver의 오늘 Todo 생성 헬퍼 */
 	async function createReceiverTodo(receiverToken: string): Promise<number> {
-		const today = new Date().toISOString().split("T")[0];
 		const categoryId = await ctx.helpers.getDefaultCategoryId(receiverToken);
 		const todoResponse = await request(ctx.app.getHttpServer())
 			.post("/todos")
 			.set("Authorization", `Bearer ${receiverToken}`)
-			.send({ title: "테스트 할일", startDate: today, categoryId });
+			.send({ title: "테스트 할일", ...activeDateRange(), categoryId });
 		return todoResponse.body.data?.todo?.id;
 	}
 
@@ -115,14 +123,13 @@ describe("찔러보기 E2E", () => {
 					"nudge-self@test.com",
 					password,
 				);
-				const today = new Date().toISOString().split("T")[0];
 				const categoryId = await ctx.helpers.getDefaultCategoryId(
 					sender.accessToken,
 				);
 				const todoResponse = await request(ctx.app.getHttpServer())
 					.post("/todos")
 					.set("Authorization", `Bearer ${sender.accessToken}`)
-					.send({ title: "Self Todo", startDate: today, categoryId });
+					.send({ title: "Self Todo", ...activeDateRange(), categoryId });
 				const selfTodoId = todoResponse.body.data?.todo?.id;
 
 				// When - 자기 자신에게 콕 찌르기 API 호출
@@ -149,7 +156,6 @@ describe("찔러보기 E2E", () => {
 				);
 				await ctx.helpers.createFriendship(sender, receiver);
 
-				const today = new Date().toISOString().split("T")[0];
 				const categoryId = await ctx.helpers.getDefaultCategoryId(
 					receiver.accessToken,
 				);
@@ -158,7 +164,7 @@ describe("찔러보기 E2E", () => {
 					.set("Authorization", `Bearer ${receiver.accessToken}`)
 					.send({
 						title: "Private Todo",
-						startDate: today,
+						...activeDateRange(),
 						categoryId,
 						visibility: "PRIVATE",
 					});

--- a/apps/api/test/e2e/openapi-contract.e2e-spec.ts
+++ b/apps/api/test/e2e/openapi-contract.e2e-spec.ts
@@ -48,6 +48,10 @@ describe("OpenAPI 계약 (e2e)", () => {
 		await destroyE2eApp(ctx);
 	});
 
+	beforeEach(async () => {
+		await ctx.reset();
+	});
+
 	it("OpenAPI 문서가 스냅샷과 일치한다 (클라이언트 계약 무변경)", () => {
 		// Given - main.ts와 동일한 기본 문서 설정 (paths/schemas는 컨트롤러에서 파생)
 		const config = new DocumentBuilder()

--- a/apps/api/test/e2e/retention.e2e-spec.ts
+++ b/apps/api/test/e2e/retention.e2e-spec.ts
@@ -20,8 +20,7 @@ describe("신규 사용자 리텐션 V2 E2E", () => {
 	}, 60_000);
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	afterAll(async () => {

--- a/apps/api/test/e2e/todo-category-resource-limit.e2e-spec.ts
+++ b/apps/api/test/e2e/todo-category-resource-limit.e2e-spec.ts
@@ -28,8 +28,7 @@ describe("할 일 카테고리 리소스 제한 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";

--- a/apps/api/test/e2e/todo-category.e2e-spec.ts
+++ b/apps/api/test/e2e/todo-category.e2e-spec.ts
@@ -21,8 +21,7 @@ describe("할 일 카테고리 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	/**

--- a/apps/api/test/e2e/todo-resource-limit.e2e-spec.ts
+++ b/apps/api/test/e2e/todo-resource-limit.e2e-spec.ts
@@ -25,8 +25,7 @@ describe("할 일 리소스 제한 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";

--- a/apps/api/test/e2e/todo-summary.e2e-spec.ts
+++ b/apps/api/test/e2e/todo-summary.e2e-spec.ts
@@ -24,12 +24,19 @@ describe("오늘의 할 일 요약 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	const password = "Test1234!";
 	const timezone = "Asia/Seoul";
+	const activeDateRange = () => {
+		const today = todayInTimezone(timezone);
+		return {
+			today,
+			startDate: new Date(today.getTime() - 24 * 60 * 60 * 1000),
+			endDate: new Date(today.getTime() + 24 * 60 * 60 * 1000),
+		};
+	};
 
 	describe("GET /todos/summary", () => {
 		it("오늘 진행률·스트릭·상위 할 일을 요약으로 반환한다", async () => {
@@ -42,7 +49,7 @@ describe("오늘의 할 일 요약 E2E", () => {
 				user.accessToken,
 			);
 
-			const today = todayInTimezone(timezone);
+			const { startDate, endDate } = activeDateRange();
 			const prisma = ctx.testDatabase.getPrisma();
 			await prisma.todo.createMany({
 				data: [
@@ -50,7 +57,8 @@ describe("오늘의 할 일 요약 E2E", () => {
 						userId: user.userId,
 						title: "완료한 할 일",
 						categoryId,
-						startDate: today,
+						startDate,
+						endDate,
 						sortOrder: 0,
 						completed: true,
 						completedAt: new Date(),
@@ -59,7 +67,8 @@ describe("오늘의 할 일 요약 E2E", () => {
 						userId: user.userId,
 						title: "남은 할 일 1",
 						categoryId,
-						startDate: today,
+						startDate,
+						endDate,
 						sortOrder: 1,
 						completed: false,
 					},
@@ -67,7 +76,8 @@ describe("오늘의 할 일 요약 E2E", () => {
 						userId: user.userId,
 						title: "남은 할 일 2",
 						categoryId,
-						startDate: today,
+						startDate,
+						endDate,
 						sortOrder: 2,
 						completed: false,
 					},
@@ -83,7 +93,7 @@ describe("오늘의 할 일 요약 E2E", () => {
 			// Then
 			expect(response.status).toBe(200);
 			expect(response.body.data).toEqual({
-				date: toDateString(today),
+				date: toDateString(todayInTimezone(timezone)),
 				totalTodos: 3,
 				completedTodos: 1,
 				completionRate: 33,
@@ -143,14 +153,15 @@ describe("오늘의 할 일 요약 E2E", () => {
 			const categoryId = await ctx.helpers.getDefaultCategoryId(
 				user.accessToken,
 			);
-			const today = todayInTimezone(timezone);
+			const { startDate, endDate } = activeDateRange();
 			const prisma = ctx.testDatabase.getPrisma();
 			await prisma.todo.createMany({
 				data: Array.from({ length: 12 }, (_, i) => ({
 					userId: user.userId,
 					title: `할 일 ${i + 1}`,
 					categoryId,
-					startDate: today,
+					startDate,
+					endDate,
 					sortOrder: i,
 					completed: i < 6,
 					...(i < 6 && { completedAt: new Date() }),

--- a/apps/api/test/e2e/todo.e2e-spec.ts
+++ b/apps/api/test/e2e/todo.e2e-spec.ts
@@ -22,8 +22,7 @@ describe("할 일 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	describe("Todo CRUD 플로우", () => {

--- a/apps/api/test/e2e/user-search.e2e-spec.ts
+++ b/apps/api/test/e2e/user-search.e2e-spec.ts
@@ -32,8 +32,7 @@ describe("사용자 검색 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	it("미인증 요청은 401을 반환한다", async () => {

--- a/apps/api/test/e2e/user-settings.e2e-spec.ts
+++ b/apps/api/test/e2e/user-settings.e2e-spec.ts
@@ -29,8 +29,7 @@ describe("사용자 설정 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	describe("알림 환경설정", () => {

--- a/apps/api/test/e2e/weather.e2e-spec.ts
+++ b/apps/api/test/e2e/weather.e2e-spec.ts
@@ -29,8 +29,7 @@ describe("날씨 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	describe("위치 등록", () => {

--- a/apps/api/test/e2e/weekly-achievement.e2e-spec.ts
+++ b/apps/api/test/e2e/weekly-achievement.e2e-spec.ts
@@ -28,8 +28,7 @@ describe("주간 성취 E2E", () => {
 	});
 
 	beforeEach(async () => {
-		await ctx.testDatabase.cleanup();
-		ctx.fakeEmailService.clear();
+		await ctx.reset();
 	});
 
 	describe("주간 달성 현황 조회", () => {

--- a/apps/api/test/integration/account-deletion.integration-spec.ts
+++ b/apps/api/test/integration/account-deletion.integration-spec.ts
@@ -292,8 +292,11 @@ describe("회원 탈퇴 통합 테스트 (실제 DB)", () => {
 	});
 
 	afterAll(async () => {
-		if (testDb) await testDb.stop();
-		if (module) await module.close();
+		try {
+			if (module) await module.close();
+		} finally {
+			if (testDb) await testDb.stop();
+		}
 	});
 
 	/**

--- a/apps/api/test/integration/admin-notification.integration-spec.ts
+++ b/apps/api/test/integration/admin-notification.integration-spec.ts
@@ -99,7 +99,16 @@ describe("AdminNotificationProcessor 통합 테스트 (Mock DB)", () => {
 	});
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		jest.resetAllMocks();
+		mockAdminNotifier.send.mockResolvedValue({ success: true });
+		mockAdminNotifier.isConfigured.mockReturnValue(true);
+		mockPaymentNotifier.send.mockResolvedValue({ success: true });
+		mockPaymentNotifier.isConfigured.mockReturnValue(true);
+		mockSignupStatsReader.getSignupStats.mockResolvedValue({
+			signupsByProvider: [{ provider: "CREDENTIAL", count: 3 }],
+			totalUsers: 100,
+		});
+		mockQueuePort.enqueueSend.mockResolvedValue(undefined);
 	});
 
 	describe("SEND 잡 처리 통합 테스트", () => {

--- a/apps/api/test/integration/auth-password-change.integration-spec.ts
+++ b/apps/api/test/integration/auth-password-change.integration-spec.ts
@@ -57,8 +57,11 @@ describe("비밀번호 변경 통합 테스트 (실제 DB)", () => {
 	});
 
 	afterAll(async () => {
-		if (testDb) await testDb.stop();
-		if (module) await module.close();
+		try {
+			if (module) await module.close();
+		} finally {
+			if (testDb) await testDb.stop();
+		}
 	});
 
 	/**

--- a/apps/api/test/integration/auth-password-reset.integration-spec.ts
+++ b/apps/api/test/integration/auth-password-reset.integration-spec.ts
@@ -57,8 +57,11 @@ describe("비밀번호 재설정 통합 테스트 (실제 DB)", () => {
 	});
 
 	afterAll(async () => {
-		if (testDb) await testDb.stop();
-		if (module) await module.close();
+		try {
+			if (module) await module.close();
+		} finally {
+			if (testDb) await testDb.stop();
+		}
 	});
 
 	/**

--- a/apps/api/test/integration/auth-password-setup.integration-spec.ts
+++ b/apps/api/test/integration/auth-password-setup.integration-spec.ts
@@ -57,8 +57,11 @@ describe("비밀번호 설정 통합 테스트 (실제 DB)", () => {
 	});
 
 	afterAll(async () => {
-		if (testDb) await testDb.stop();
-		if (module) await module.close();
+		try {
+			if (module) await module.close();
+		} finally {
+			if (testDb) await testDb.stop();
+		}
 	});
 
 	/**

--- a/apps/api/test/integration/cache.integration-spec.ts
+++ b/apps/api/test/integration/cache.integration-spec.ts
@@ -19,7 +19,6 @@ import {
 } from "@/shared/infrastructure/cache/interfaces/cache.interface";
 import {
 	createMockUserProfile,
-	delay,
 	MockCacheAdapter,
 } from "../mocks/cache-test-utils";
 
@@ -109,6 +108,8 @@ describe("CacheModule 통합 테스트", () => {
 
 			it("TTL이 만료되면 캐시가 삭제된다", async () => {
 				// Given
+				const baseTime = Date.now();
+				const now = jest.spyOn(Date, "now").mockReturnValue(baseTime);
 				const shortTtlModule = await Test.createTestingModule({
 					imports: [
 						ConfigModule.forRoot({
@@ -125,21 +126,25 @@ describe("CacheModule 통합 테스트", () => {
 					],
 				}).compile();
 
-				const shortTtlService = shortTtlModule.get<CacheService>(CacheService);
-				await shortTtlService.set("test-key", "test-value");
+				try {
+					const shortTtlService =
+						shortTtlModule.get<CacheService>(CacheService);
+					await shortTtlService.set("test-key", "test-value");
 
-				// When - 값이 설정됨을 확인
-				const beforeExpiry = await shortTtlService.get("test-key");
-				expect(beforeExpiry).toBe("test-value");
+					// When - 값이 설정됨을 확인
+					const beforeExpiry = await shortTtlService.get("test-key");
+					expect(beforeExpiry).toBe("test-value");
 
-				// When - TTL 만료 대기
-				await delay(100);
+					// When - 실제 대기 없이 TTL 이후로 시간 이동
+					now.mockReturnValue(baseTime + 100);
 
-				// Then
-				const afterExpiry = await shortTtlService.get("test-key");
-				expect(afterExpiry).toBeUndefined();
-
-				await shortTtlModule.close();
+					// Then
+					const afterExpiry = await shortTtlService.get("test-key");
+					expect(afterExpiry).toBeUndefined();
+				} finally {
+					now.mockRestore();
+					await shortTtlModule.close();
+				}
 			});
 		});
 
@@ -358,20 +363,26 @@ describe("CacheModule 통합 테스트", () => {
 
 			it("TTL shorthand를 지원한다", async () => {
 				// Given
+				const baseTime = Date.now();
+				const now = jest.spyOn(Date, "now").mockReturnValue(baseTime);
 				const key = "wrap-ttl-test";
 				const factory = jest.fn().mockResolvedValue("value");
 
-				// When
-				await cacheService.wrap(key, factory, "1s");
+				try {
+					// When
+					await cacheService.wrap(key, factory, "1s");
 
-				// Then - 즉시 조회
-				const beforeExpiry = await cacheService.get(key);
-				expect(beforeExpiry).toBe("value");
+					// Then - 즉시 조회
+					const beforeExpiry = await cacheService.get(key);
+					expect(beforeExpiry).toBe("value");
 
-				// TTL 만료 후
-				await delay(1100);
-				const afterExpiry = await cacheService.get(key);
-				expect(afterExpiry).toBeUndefined();
+					// TTL 만료 후로 시간 이동
+					now.mockReturnValue(baseTime + 1100);
+					const afterExpiry = await cacheService.get(key);
+					expect(afterExpiry).toBeUndefined();
+				} finally {
+					now.mockRestore();
+				}
 			});
 
 			it("wrapSession이 실제로 캐시에 저장한다", async () => {
@@ -478,28 +489,34 @@ describe("CacheModule 통합 테스트", () => {
 
 			it("mset에서 TTL shorthand를 지원한다", async () => {
 				// Given
+				const baseTime = Date.now();
+				const now = jest.spyOn(Date, "now").mockReturnValue(baseTime);
 				const entries = [
 					{ key: "mset-ttl-1", value: "value-1", ttl: "1s" as const },
 					{ key: "mset-ttl-2", value: "value-2", ttl: "1s" as const },
 				];
 
-				// When
-				await cacheService.mset(entries);
+				try {
+					// When
+					await cacheService.mset(entries);
 
-				// Then - 즉시 조회
-				const beforeExpiry = await cacheService.mget([
-					"mset-ttl-1",
-					"mset-ttl-2",
-				]);
-				expect(beforeExpiry).toEqual(["value-1", "value-2"]);
+					// Then - 즉시 조회
+					const beforeExpiry = await cacheService.mget([
+						"mset-ttl-1",
+						"mset-ttl-2",
+					]);
+					expect(beforeExpiry).toEqual(["value-1", "value-2"]);
 
-				// TTL 만료 후
-				await delay(1100);
-				const afterExpiry = await cacheService.mget([
-					"mset-ttl-1",
-					"mset-ttl-2",
-				]);
-				expect(afterExpiry).toEqual([undefined, undefined]);
+					// TTL 만료 후로 시간 이동
+					now.mockReturnValue(baseTime + 1100);
+					const afterExpiry = await cacheService.mget([
+						"mset-ttl-1",
+						"mset-ttl-2",
+					]);
+					expect(afterExpiry).toEqual([undefined, undefined]);
+				} finally {
+					now.mockRestore();
+				}
 			});
 		});
 
@@ -578,15 +595,17 @@ describe("CacheModule 통합 테스트", () => {
 			}).compile();
 			const service = module.get<CacheService>(CacheService);
 
-			// When
-			await service.set("key", "value");
-			const result = await service.get("key");
+			try {
+				// When
+				await service.set("key", "value");
+				const result = await service.get("key");
 
-			// Then
-			expect(result).toBe("value");
-			expect(mockAdapter.hasKey("key")).toBe(true);
-
-			await module.close();
+				// Then
+				expect(result).toBe("value");
+				expect(mockAdapter.hasKey("key")).toBe(true);
+			} finally {
+				await module.close();
+			}
 		});
 
 		it("Jest 모킹된 어댑터를 사용할 수 있다", async () => {
@@ -610,14 +629,16 @@ describe("CacheModule 통합 테스트", () => {
 			}).compile();
 			const service = module.get<CacheService>(CacheService);
 
-			// When
-			const result = await service.get("any");
+			try {
+				// When
+				const result = await service.get("any");
 
-			// Then
-			expect(result).toBe("mocked-value");
-			expect(mockAdapter.get).toHaveBeenCalledWith("any");
-
-			await module.close();
+				// Then
+				expect(result).toBe("mocked-value");
+				expect(mockAdapter.get).toHaveBeenCalledWith("any");
+			} finally {
+				await module.close();
+			}
 		});
 
 		it("모킹된 wrap 메서드를 사용할 수 있다", async () => {
@@ -641,15 +662,17 @@ describe("CacheModule 통합 테스트", () => {
 			}).compile();
 			const service = module.get<CacheService>(CacheService);
 
-			// When
-			const factory = jest.fn();
-			const result = await service.wrap("key", factory, "5m");
+			try {
+				// When
+				const factory = jest.fn();
+				const result = await service.wrap("key", factory, "5m");
 
-			// Then
-			expect(result).toBe("wrapped-value");
-			expect(mockAdapter.wrap).toHaveBeenCalledWith("key", factory, "5m");
-
-			await module.close();
+				// Then
+				expect(result).toBe("wrapped-value");
+				expect(mockAdapter.wrap).toHaveBeenCalledWith("key", factory, "5m");
+			} finally {
+				await module.close();
+			}
 		});
 	});
 
@@ -667,14 +690,16 @@ describe("CacheModule 통합 테스트", () => {
 			}).compile();
 			const service = module.get<CacheService>(CacheService);
 
-			// When
-			await service.set("key", "value");
-			const result = await service.get("key");
+			try {
+				// When
+				await service.set("key", "value");
+				const result = await service.get("key");
 
-			// Then
-			expect(result).toBe("value");
-
-			await module.close();
+				// Then
+				expect(result).toBe("value");
+			} finally {
+				await module.close();
+			}
 		});
 
 		it("커스텀 설정을 적용한다", async () => {
@@ -696,16 +721,18 @@ describe("CacheModule 통합 테스트", () => {
 			}).compile();
 			const service = module.get<CacheService>(CacheService);
 
-			// When - 최대 항목 수를 초과하여 저장
-			for (let i = 0; i < 10; i++) {
-				await service.set(`key_${i}`, `value_${i}`);
+			try {
+				// When - 최대 항목 수를 초과하여 저장
+				for (let i = 0; i < 10; i++) {
+					await service.set(`key_${i}`, `value_${i}`);
+				}
+
+				// Then - LRU로 인해 최대 5개만 유지
+				const stats = service.getStats();
+				expect(stats.keys).toBeLessThanOrEqual(5);
+			} finally {
+				await module.close();
 			}
-
-			// Then - LRU로 인해 최대 5개만 유지
-			const stats = service.getStats();
-			expect(stats.keys).toBeLessThanOrEqual(5);
-
-			await module.close();
 		});
 	});
 
@@ -722,15 +749,17 @@ describe("CacheModule 통합 테스트", () => {
 				],
 			}).compile();
 
-			// When
-			const service = module.get<CacheService>(CacheService);
-			const adapter = module.get<ICacheService>(CACHE_SERVICE);
+			try {
+				// When
+				const service = module.get<CacheService>(CacheService);
+				const adapter = module.get<ICacheService>(CACHE_SERVICE);
 
-			// Then
-			expect(service).toBeDefined();
-			expect(adapter).toBeDefined();
-
-			await module.close();
+				// Then
+				expect(service).toBeDefined();
+				expect(adapter).toBeDefined();
+			} finally {
+				await module.close();
+			}
 		});
 	});
 });

--- a/apps/api/test/integration/daily-completion.integration-spec.ts
+++ b/apps/api/test/integration/daily-completion.integration-spec.ts
@@ -87,11 +87,14 @@ describe("DailyCompletion 통합 테스트 (실제 DB)", () => {
 
 	// 테스트 스위트 종료 시 정리
 	afterAll(async () => {
-		if (testDb) {
-			await testDb.stop();
-		}
-		if (module) {
-			await module.close();
+		try {
+			if (module) {
+				await module.close();
+			}
+		} finally {
+			if (testDb) {
+				await testDb.stop();
+			}
 		}
 	});
 

--- a/apps/api/test/integration/oauth.integration-spec.ts
+++ b/apps/api/test/integration/oauth.integration-spec.ts
@@ -315,11 +315,14 @@ describe("OAuth 통합 테스트 (실제 DB)", () => {
 
 	// 테스트 스위트 종료 시 정리
 	afterAll(async () => {
-		if (testDb) {
-			await testDb.stop();
-		}
-		if (module) {
-			await module.close();
+		try {
+			if (module) {
+				await module.close();
+			}
+		} finally {
+			if (testDb) {
+				await testDb.stop();
+			}
 		}
 	});
 

--- a/apps/api/test/integration/report-aggregator.integration-spec.ts
+++ b/apps/api/test/integration/report-aggregator.integration-spec.ts
@@ -124,11 +124,14 @@ describe("ReportAggregator 통합 테스트 (실제 DB)", () => {
 
 	// 테스트 스위트 종료 시 정리
 	afterAll(async () => {
-		if (testDb) {
-			await testDb.stop();
-		}
-		if (module) {
-			await module.close();
+		try {
+			if (module) {
+				await module.close();
+			}
+		} finally {
+			if (testDb) {
+				await testDb.stop();
+			}
 		}
 	});
 

--- a/apps/api/test/integration/test-database.integration-spec.ts
+++ b/apps/api/test/integration/test-database.integration-spec.ts
@@ -1,0 +1,58 @@
+import { TestDatabase } from "../setup/test-database";
+
+describe("TestDatabase 통합 테스트 (실제 DB)", () => {
+	let testDatabase: TestDatabase;
+
+	beforeAll(async () => {
+		testDatabase = new TestDatabase();
+		await testDatabase.start();
+	});
+
+	afterAll(async () => {
+		await testDatabase.stop();
+	});
+
+	it("globalSetup에서 Prisma migration이 적용되어 있어야 한다", async () => {
+		// Given - globalSetup이 완료된 관리형 테스트 DB
+		const prisma = testDatabase.getPrisma();
+
+		// When - 성공한 migration 수 조회
+		const migrations = await prisma.$queryRaw<Array<{ count: bigint }>>`
+			SELECT COUNT(*) AS count
+			FROM "_prisma_migrations"
+			WHERE finished_at IS NOT NULL
+				AND rolled_back_at IS NULL
+		`;
+
+		// Then - 최소 하나 이상의 migration이 적용됨
+		expect(Number(migrations[0]?.count)).toBeGreaterThan(0);
+	});
+
+	it("cleanup이 public 데이터와 sequence를 초기화해야 한다", async () => {
+		// Given - 독립 컨테이너에 sequence 검증용 임시 테이블 생성
+		const prisma = testDatabase.getPrisma();
+		await prisma.$executeRawUnsafe(
+			'CREATE TABLE "TestSequenceReset" ("id" SERIAL PRIMARY KEY)',
+		);
+
+		try {
+			const first = await prisma.$queryRawUnsafe<Array<{ id: number }>>(
+				'INSERT INTO "TestSequenceReset" DEFAULT VALUES RETURNING "id"',
+			);
+			expect(first[0]?.id).toBe(1);
+
+			// When - 공용 cleanup 후 다시 insert
+			await testDatabase.cleanup();
+			const second = await prisma.$queryRawUnsafe<Array<{ id: number }>>(
+				'INSERT INTO "TestSequenceReset" DEFAULT VALUES RETURNING "id"',
+			);
+
+			// Then - 데이터와 sequence가 모두 초기화됨
+			expect(second[0]?.id).toBe(1);
+		} finally {
+			await prisma.$executeRawUnsafe(
+				'DROP TABLE IF EXISTS "TestSequenceReset"',
+			);
+		}
+	});
+});

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -5,8 +5,12 @@
 	"testEnvironment": "node",
 	"testRegex": ".e2e-spec.ts$",
 	"setupFiles": ["<rootDir>/setup-env.ts"],
+	"globalSetup": "<rootDir>/setup/global-setup.ts",
+	"globalTeardown": "<rootDir>/setup/global-teardown.ts",
 	"testTimeout": 60000,
 	"maxWorkers": 1,
+	"randomize": true,
+	"showSeed": true,
 	"transform": {
 		"^.+\\.(t|j)s$": [
 			"@swc/jest",

--- a/apps/api/test/jest-integration.json
+++ b/apps/api/test/jest-integration.json
@@ -5,6 +5,8 @@
 	"testRegex": ".integration-spec.ts$",
 	"roots": ["<rootDir>/integration"],
 	"setupFiles": ["<rootDir>/setup-env.ts"],
+	"globalSetup": "<rootDir>/setup/global-setup.ts",
+	"globalTeardown": "<rootDir>/setup/global-teardown.ts",
 	"transform": {
 		"^.+\\.ts$": [
 			"@swc/jest",
@@ -35,5 +37,7 @@
 		"^expo-server-sdk$": "<rootDir>/mocks/expo-server-sdk.mock.ts"
 	},
 	"testTimeout": 60000,
-	"maxWorkers": 1
+	"maxWorkers": 1,
+	"randomize": true,
+	"showSeed": true
 }

--- a/apps/api/test/mocks/fake-oauth-provider-registry.ts
+++ b/apps/api/test/mocks/fake-oauth-provider-registry.ts
@@ -1,0 +1,111 @@
+import { ErrorCode } from "@aido/errors";
+import type {
+	ExchangedToken,
+	GenerateAuthUrlParams,
+	OAuthIdentityProvider,
+	OAuthIdentityProviderRegistry,
+	SocialLoginOptions,
+	VerifiedProfile,
+} from "@/auth/application/ports/oauth-identity-provider.port";
+import type { AccountProvider } from "@/auth/domain/types";
+import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
+
+function exchangeKey(provider: AccountProvider, code: string): string {
+	return `${provider}:${code}`;
+}
+
+class FakeOAuthIdentityProvider implements OAuthIdentityProvider {
+	readonly provider: AccountProvider;
+	readonly failureEmail: string;
+
+	constructor(
+		private readonly delegate: OAuthIdentityProvider,
+		private readonly exchange: (
+			provider: AccountProvider,
+			code: string,
+		) => Promise<ExchangedToken>,
+	) {
+		this.provider = delegate.provider;
+		this.failureEmail = delegate.failureEmail;
+	}
+
+	generateAuthUrl(params: GenerateAuthUrlParams): Promise<string | null> {
+		return this.delegate.generateAuthUrl(params);
+	}
+
+	exchangeCode(code: string): Promise<ExchangedToken> {
+		return this.exchange(this.provider, code);
+	}
+
+	verifyToken(token: string, nonce?: string): Promise<VerifiedProfile> {
+		return this.delegate.verifyToken(token, nonce);
+	}
+
+	buildLoginOptions(
+		verifiedProfile: VerifiedProfile,
+		userName?: string,
+	): SocialLoginOptions {
+		return this.delegate.buildLoginOptions(verifiedProfile, userName);
+	}
+}
+
+export class FakeOAuthProviderRegistry {
+	readonly registry: OAuthIdentityProviderRegistry;
+	readonly #exchangeTokens = new Map<string, string>();
+	readonly #exchangeFailures = new Map<string, Error>();
+
+	constructor(delegates: OAuthIdentityProviderRegistry) {
+		this.registry = new Map(
+			[...delegates].map(([provider, delegate]) => [
+				provider,
+				new FakeOAuthIdentityProvider(delegate, (currentProvider, code) =>
+					this.#exchangeCode(currentProvider, code),
+				),
+			]),
+		);
+	}
+
+	setExchangeToken(
+		provider: AccountProvider,
+		code: string,
+		token: string,
+	): void {
+		const key = exchangeKey(provider, code);
+		this.#exchangeFailures.delete(key);
+		this.#exchangeTokens.set(key, token);
+	}
+
+	simulateExchangeFailure(
+		provider: AccountProvider,
+		code: string,
+		error: Error = new ApplicationException(ErrorCode.USER_0602),
+	): void {
+		const key = exchangeKey(provider, code);
+		this.#exchangeTokens.delete(key);
+		this.#exchangeFailures.set(key, error);
+	}
+
+	clear(): void {
+		this.#exchangeTokens.clear();
+		this.#exchangeFailures.clear();
+	}
+
+	async #exchangeCode(
+		provider: AccountProvider,
+		code: string,
+	): Promise<ExchangedToken> {
+		const key = exchangeKey(provider, code);
+		const failure = this.#exchangeFailures.get(key);
+		if (failure) throw failure;
+
+		if (code.startsWith("invalid")) {
+			throw new ApplicationException(ErrorCode.USER_0602);
+		}
+
+		return {
+			token:
+				this.#exchangeTokens.get(key) ??
+				`fake-${provider.toLowerCase()}-${code}`,
+		};
+	}
+}

--- a/apps/api/test/setup-env.ts
+++ b/apps/api/test/setup-env.ts
@@ -21,8 +21,3 @@ ThrottlerGuard.prototype.canActivate = () => true;
 
 // NODE_ENV=test 보장 (.env.test 로드 전에 설정되어야 config.module.ts가 올바른 파일 선택)
 process.env.NODE_ENV = "test";
-
-// Testcontainers fallback (환경변수 미설정 시)
-process.env.DATABASE_URL =
-	process.env.DATABASE_URL ||
-	"postgresql://postgres:postgres@localhost:5432/aido_test";

--- a/apps/api/test/setup/e2e-test-state.spec.ts
+++ b/apps/api/test/setup/e2e-test-state.spec.ts
@@ -1,0 +1,59 @@
+import { createE2eTestStateResetter } from "../e2e/helpers/e2e-test-state";
+
+describe("E2E 테스트 상태 reset", () => {
+	it("DB, cache, Redis, 공용 fake와 suite fake를 모두 초기화해야 한다", async () => {
+		// Given - 상태를 가진 모든 테스트 의존성
+		const cleanupDatabase = jest.fn().mockResolvedValue(undefined);
+		const resetCache = jest.fn().mockResolvedValue(undefined);
+		const flushRedis = jest.fn().mockResolvedValue("OK");
+		const clearEmail = jest.fn();
+		const clearOAuth = jest.fn();
+		const clearPush = jest.fn();
+		const clearSuiteFake = jest.fn();
+		const reset = createE2eTestStateResetter({
+			cleanupDatabase,
+			resetCache,
+			flushRedis,
+			sharedResetters: [clearEmail, clearOAuth, clearPush],
+			additionalResetters: [clearSuiteFake],
+		});
+
+		// When - 단일 reset 진입점 호출
+		await reset();
+
+		// Then - 모든 상태 저장소가 정확히 한 번 초기화
+		expect(cleanupDatabase).toHaveBeenCalledTimes(1);
+		expect(resetCache).toHaveBeenCalledTimes(1);
+		expect(flushRedis).toHaveBeenCalledTimes(1);
+		expect(clearEmail).toHaveBeenCalledTimes(1);
+		expect(clearOAuth).toHaveBeenCalledTimes(1);
+		expect(clearPush).toHaveBeenCalledTimes(1);
+		expect(clearSuiteFake).toHaveBeenCalledTimes(1);
+	});
+
+	it("백그라운드 작업을 모두 기다린 뒤 DB를 초기화해야 한다", async () => {
+		// Given - push 저장 작업이 아직 진행 중인 상태
+		let backgroundWorkCompleted = false;
+		const drainBackgroundWork = jest.fn(async () => {
+			await Promise.resolve();
+			backgroundWorkCompleted = true;
+		});
+		const cleanupDatabase = jest.fn(() => {
+			expect(backgroundWorkCompleted).toBe(true);
+		});
+		const reset = createE2eTestStateResetter({
+			drainBackgroundWork,
+			cleanupDatabase,
+			resetCache: jest.fn(),
+			flushRedis: jest.fn(),
+			sharedResetters: [],
+		});
+
+		// When
+		await reset();
+
+		// Then - truncate보다 drain이 항상 선행
+		expect(drainBackgroundWork).toHaveBeenCalledTimes(1);
+		expect(cleanupDatabase).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/test/setup/e2e-test-state.spec.ts
+++ b/apps/api/test/setup/e2e-test-state.spec.ts
@@ -56,4 +56,31 @@ describe("E2E 테스트 상태 reset", () => {
 		expect(drainBackgroundWork).toHaveBeenCalledTimes(1);
 		expect(cleanupDatabase).toHaveBeenCalledTimes(1);
 	});
+
+	it("백그라운드 drain 실패 시 DB는 보호하고 나머지 상태를 초기화해야 한다", async () => {
+		const drainError = new Error("drain failed");
+		const drainBackgroundWork = jest.fn().mockRejectedValue(drainError);
+		const cleanupDatabase = jest.fn();
+		const resetCache = jest.fn().mockRejectedValue("cache failed");
+		const flushRedis = jest.fn().mockResolvedValue("OK");
+		const clearFake = jest.fn();
+		const reset = createE2eTestStateResetter({
+			drainBackgroundWork,
+			cleanupDatabase,
+			resetCache,
+			flushRedis,
+			sharedResetters: [clearFake],
+		});
+
+		await expect(reset()).rejects.toMatchObject({
+			errors: [
+				drainError,
+				expect.objectContaining({ message: "cache failed" }),
+			],
+		});
+		expect(cleanupDatabase).not.toHaveBeenCalled();
+		expect(resetCache).toHaveBeenCalledTimes(1);
+		expect(flushRedis).toHaveBeenCalledTimes(1);
+		expect(clearFake).toHaveBeenCalledTimes(1);
+	});
 });

--- a/apps/api/test/setup/fake-oauth-provider-registry.spec.ts
+++ b/apps/api/test/setup/fake-oauth-provider-registry.spec.ts
@@ -1,0 +1,59 @@
+import type {
+	OAuthIdentityProvider,
+	OAuthIdentityProviderRegistry,
+} from "@/auth/application/ports/oauth-identity-provider.port";
+import { FakeOAuthProviderRegistry } from "../mocks/fake-oauth-provider-registry";
+
+function createGoogleProvider(): OAuthIdentityProvider {
+	return {
+		provider: "GOOGLE",
+		failureEmail: "google_unknown@social.aido.kr",
+		generateAuthUrl: jest.fn().mockResolvedValue("https://accounts.google.com"),
+		exchangeCode: jest
+			.fn()
+			.mockRejectedValue(new Error("real exchange called")),
+		verifyToken: jest.fn().mockResolvedValue({
+			id: "google-user",
+			emailVerified: true,
+		}),
+		buildLoginOptions: jest.fn().mockReturnValue({ emailVerified: true }),
+	};
+}
+
+describe("FakeOAuthProviderRegistry", () => {
+	it("설정한 authorization code를 외부 호출 없이 token으로 교환해야 한다", async () => {
+		// Given - 실제 exchangeCode가 호출되면 실패하는 delegate
+		const delegate = createGoogleProvider();
+		const delegates: OAuthIdentityProviderRegistry = new Map([
+			["GOOGLE", delegate],
+		]);
+		const fakeRegistry = new FakeOAuthProviderRegistry(delegates);
+		fakeRegistry.setExchangeToken("GOOGLE", "success-code", "fake-id-token");
+
+		// When - fake registry에서 code 교환
+		const result = await fakeRegistry.registry
+			.get("GOOGLE")
+			?.exchangeCode("success-code");
+
+		// Then - 결정적인 token을 반환하고 delegate의 네트워크 경로는 미호출
+		expect(result).toEqual({ token: "fake-id-token" });
+		expect(delegate.exchangeCode).not.toHaveBeenCalled();
+	});
+
+	it("설정한 authorization code 실패를 결정적으로 반환해야 한다", async () => {
+		// Given - 실패하도록 설정한 code
+		const fakeRegistry = new FakeOAuthProviderRegistry(
+			new Map([["GOOGLE", createGoogleProvider()]]),
+		);
+		fakeRegistry.simulateExchangeFailure(
+			"GOOGLE",
+			"invalid-code",
+			new Error("exchange rejected"),
+		);
+
+		// When & Then - 벤더 호출 없이 설정한 실패 반환
+		await expect(
+			fakeRegistry.registry.get("GOOGLE")?.exchangeCode("invalid-code"),
+		).rejects.toThrow("exchange rejected");
+	});
+});

--- a/apps/api/test/setup/global-setup.ts
+++ b/apps/api/test/setup/global-setup.ts
@@ -1,0 +1,16 @@
+import {
+	type ManagedTestDatabaseHandle,
+	startManagedTestDatabase,
+} from "./managed-test-database";
+
+type TestDatabaseGlobal = typeof globalThis & {
+	__AIDO_TEST_DATABASE__?: ManagedTestDatabaseHandle;
+};
+
+export default async function globalSetup(): Promise<void> {
+	const globalState: TestDatabaseGlobal = globalThis;
+	globalState.__AIDO_TEST_DATABASE__ = await startManagedTestDatabase();
+	console.log(
+		`[test-db] started ${globalState.__AIDO_TEST_DATABASE__.databaseName}`,
+	);
+}

--- a/apps/api/test/setup/global-teardown.ts
+++ b/apps/api/test/setup/global-teardown.ts
@@ -1,0 +1,14 @@
+import type { ManagedTestDatabaseHandle } from "./managed-test-database";
+
+type TestDatabaseGlobal = typeof globalThis & {
+	__AIDO_TEST_DATABASE__?: ManagedTestDatabaseHandle;
+};
+
+export default async function globalTeardown(): Promise<void> {
+	const globalState: TestDatabaseGlobal = globalThis;
+	try {
+		await globalState.__AIDO_TEST_DATABASE__?.stop();
+	} finally {
+		delete globalState.__AIDO_TEST_DATABASE__;
+	}
+}

--- a/apps/api/test/setup/managed-test-database.spec.ts
+++ b/apps/api/test/setup/managed-test-database.spec.ts
@@ -1,0 +1,83 @@
+import {
+	assertManagedTestDatabaseEnvironment,
+	startManagedTestDatabase,
+} from "./managed-test-database";
+
+describe("관리형 테스트 DB 수명주기", () => {
+	it("관리 마커가 없는 DATABASE_URL을 거부해야 한다", () => {
+		// Given - 이름만 테스트 DB처럼 보이는 비관리 URL
+		const env = {
+			DATABASE_URL:
+				"postgresql://postgres:postgres@localhost:5432/aido_test_local",
+		};
+
+		// When & Then - 명시적인 관리 마커가 없으면 거부
+		expect(() => assertManagedTestDatabaseEnvironment(env)).toThrow(
+			"AIDO_TEST_DB_MANAGED=1",
+		);
+	});
+
+	it("허용된 이름이 아닌 DATABASE_URL을 거부해야 한다", () => {
+		// Given - 관리 마커는 있지만 개발 DB를 가리키는 URL
+		const env = {
+			AIDO_TEST_DB_MANAGED: "1",
+			DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/aido",
+		};
+
+		// When & Then - aido_test_<run-id> 규칙을 만족하지 않으면 거부
+		expect(() => assertManagedTestDatabaseEnvironment(env)).toThrow(
+			"aido_test_<run-id>",
+		);
+	});
+
+	it("migration 실패 시 시작한 컨테이너를 중지해야 한다", async () => {
+		// Given - migration이 실패하는 관리형 컨테이너
+		const stop = jest.fn().mockResolvedValue(undefined);
+		const env: NodeJS.ProcessEnv = {};
+		const migrate = jest.fn().mockRejectedValue(new Error("migration failed"));
+
+		// When & Then - 시작 실패를 전파하면서 컨테이너를 정리
+		await expect(
+			startManagedTestDatabase({
+				env,
+				createRunId: () => "abc123",
+				startContainer: async () => ({
+					getConnectionUri: () =>
+						"postgresql://test:test@localhost:5432/aido_test_abc123",
+					stop,
+				}),
+				migrate,
+			}),
+		).rejects.toThrow("migration failed");
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(env.DATABASE_URL).toBeUndefined();
+		expect(env.AIDO_TEST_DB_MANAGED).toBeUndefined();
+	});
+
+	it("Jest 실행당 migration을 한 번만 적용해야 한다", async () => {
+		// Given - 정상 시작되는 관리형 컨테이너
+		const stop = jest.fn().mockResolvedValue(undefined);
+		const migrate = jest.fn().mockResolvedValue(undefined);
+		const env: NodeJS.ProcessEnv = {};
+
+		// When - 관리형 테스트 DB 시작
+		const handle = await startManagedTestDatabase({
+			env,
+			createRunId: () => "def456",
+			startContainer: async () => ({
+				getConnectionUri: () =>
+					"postgresql://test:test@localhost:5432/aido_test_def456",
+				stop,
+			}),
+			migrate,
+		});
+
+		// Then - migration은 한 번만 실행되고 teardown에서 컨테이너 종료
+		expect(migrate).toHaveBeenCalledTimes(1);
+		expect(migrate).toHaveBeenCalledWith(
+			"postgresql://test:test@localhost:5432/aido_test_def456",
+		);
+		await handle.stop();
+		expect(stop).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/test/setup/managed-test-database.spec.ts
+++ b/apps/api/test/setup/managed-test-database.spec.ts
@@ -1,9 +1,18 @@
 import {
 	assertManagedTestDatabaseEnvironment,
+	resolvePnpmCommand,
 	startManagedTestDatabase,
 } from "./managed-test-database";
 
 describe("관리형 테스트 DB 수명주기", () => {
+	it.each([
+		["win32", "pnpm.cmd"],
+		["darwin", "pnpm"],
+		["linux", "pnpm"],
+	] as const)("%s에서는 migration 실행 파일로 %s을 사용해야 한다", (platform, expected) => {
+		expect(resolvePnpmCommand(platform)).toBe(expected);
+	});
+
 	it("관리 마커가 없는 DATABASE_URL을 거부해야 한다", () => {
 		// Given - 이름만 테스트 DB처럼 보이는 비관리 URL
 		const env = {

--- a/apps/api/test/setup/managed-test-database.ts
+++ b/apps/api/test/setup/managed-test-database.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
+
+const TEST_DATABASE_NAME_PATTERN = /^aido_test_[a-z0-9]{6,32}$/;
+
+export type ManagedTestDatabaseEnvironment = Readonly<
+	Record<string, string | undefined>
+>;
+
+export interface ManagedTestDatabaseContainer {
+	getConnectionUri(): string;
+	stop(): Promise<unknown>;
+}
+
+interface StartManagedTestDatabaseDependencies {
+	env: NodeJS.ProcessEnv;
+	createRunId: () => string;
+	startContainer: (
+		databaseName: string,
+	) => Promise<ManagedTestDatabaseContainer>;
+	migrate: (connectionUri: string) => Promise<void> | void;
+}
+
+export interface ManagedTestDatabaseHandle {
+	readonly connectionUri: string;
+	readonly databaseName: string;
+	stop(): Promise<void>;
+}
+
+function getDatabaseName(connectionUri: string): string {
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(connectionUri);
+	} catch {
+		throw new Error("DATABASE_URL must be a valid PostgreSQL URL");
+	}
+
+	if (
+		parsedUrl.protocol !== "postgresql:" &&
+		parsedUrl.protocol !== "postgres:"
+	) {
+		throw new Error("DATABASE_URL must use the PostgreSQL protocol");
+	}
+
+	return decodeURIComponent(parsedUrl.pathname.replace(/^\//, ""));
+}
+
+export function assertManagedTestDatabaseEnvironment(
+	env: ManagedTestDatabaseEnvironment,
+): { connectionUri: string; databaseName: string } {
+	if (env.AIDO_TEST_DB_MANAGED !== "1") {
+		throw new Error(
+			"Refusing test database access without AIDO_TEST_DB_MANAGED=1",
+		);
+	}
+
+	if (!env.DATABASE_URL) {
+		throw new Error("DATABASE_URL is required for managed database tests");
+	}
+
+	const databaseName = getDatabaseName(env.DATABASE_URL);
+	if (!TEST_DATABASE_NAME_PATTERN.test(databaseName)) {
+		throw new Error(
+			"Refusing test database access: database name must match aido_test_<run-id>",
+		);
+	}
+
+	return { connectionUri: env.DATABASE_URL, databaseName };
+}
+
+const defaultDependencies: StartManagedTestDatabaseDependencies = {
+	env: process.env,
+	createRunId: () => randomBytes(8).toString("hex"),
+	startContainer: async (databaseName) => {
+		const container = await new PostgreSqlContainer("postgres:16-alpine")
+			.withDatabase(databaseName)
+			.withUsername("test_user")
+			.withPassword("test_password")
+			.start();
+
+		return {
+			getConnectionUri: () => container.getConnectionUri(),
+			stop: async () => container.stop(),
+		};
+	},
+	migrate: (connectionUri) => {
+		execFileSync("pnpm", ["exec", "prisma", "migrate", "deploy"], {
+			cwd: path.resolve(__dirname, "../.."),
+			env: { ...process.env, DATABASE_URL: connectionUri },
+			stdio: "inherit",
+		});
+	},
+};
+
+export async function startManagedTestDatabase(
+	overrides: Partial<StartManagedTestDatabaseDependencies> = {},
+): Promise<ManagedTestDatabaseHandle> {
+	const dependencies = { ...defaultDependencies, ...overrides };
+	const previousDatabaseUrl = dependencies.env.DATABASE_URL;
+	const previousManagedMarker = dependencies.env.AIDO_TEST_DB_MANAGED;
+	const databaseName = `aido_test_${dependencies.createRunId()}`;
+	let container: ManagedTestDatabaseContainer | undefined;
+	let stopped = false;
+
+	const restoreEnvironment = () => {
+		if (previousDatabaseUrl === undefined) {
+			delete dependencies.env.DATABASE_URL;
+		} else {
+			dependencies.env.DATABASE_URL = previousDatabaseUrl;
+		}
+
+		if (previousManagedMarker === undefined) {
+			delete dependencies.env.AIDO_TEST_DB_MANAGED;
+		} else {
+			dependencies.env.AIDO_TEST_DB_MANAGED = previousManagedMarker;
+		}
+	};
+
+	try {
+		container = await dependencies.startContainer(databaseName);
+		const connectionUri = container.getConnectionUri();
+		dependencies.env.DATABASE_URL = connectionUri;
+		dependencies.env.AIDO_TEST_DB_MANAGED = "1";
+
+		const managedDatabase = assertManagedTestDatabaseEnvironment(
+			dependencies.env,
+		);
+		if (managedDatabase.databaseName !== databaseName) {
+			throw new Error(
+				`Managed container database mismatch: expected ${databaseName}, received ${managedDatabase.databaseName}`,
+			);
+		}
+
+		await dependencies.migrate(connectionUri);
+
+		return {
+			connectionUri,
+			databaseName,
+			stop: async () => {
+				if (stopped) return;
+				stopped = true;
+				try {
+					await container?.stop();
+				} finally {
+					restoreEnvironment();
+				}
+			},
+		};
+	} catch (error) {
+		try {
+			await container?.stop();
+		} finally {
+			restoreEnvironment();
+		}
+		throw error;
+	}
+}

--- a/apps/api/test/setup/managed-test-database.ts
+++ b/apps/api/test/setup/managed-test-database.ts
@@ -29,6 +29,12 @@ export interface ManagedTestDatabaseHandle {
 	stop(): Promise<void>;
 }
 
+export function resolvePnpmCommand(
+	platform: NodeJS.Platform = process.platform,
+): "pnpm.cmd" | "pnpm" {
+	return platform === "win32" ? "pnpm.cmd" : "pnpm";
+}
+
 function getDatabaseName(connectionUri: string): string {
 	let parsedUrl: URL;
 	try {
@@ -86,11 +92,15 @@ const defaultDependencies: StartManagedTestDatabaseDependencies = {
 		};
 	},
 	migrate: (connectionUri) => {
-		execFileSync("pnpm", ["exec", "prisma", "migrate", "deploy"], {
-			cwd: path.resolve(__dirname, "../.."),
-			env: { ...process.env, DATABASE_URL: connectionUri },
-			stdio: "inherit",
-		});
+		execFileSync(
+			resolvePnpmCommand(),
+			["exec", "prisma", "migrate", "deploy"],
+			{
+				cwd: path.resolve(__dirname, "../.."),
+				env: { ...process.env, DATABASE_URL: connectionUri },
+				stdio: "inherit",
+			},
+		);
 	},
 };
 

--- a/apps/api/test/setup/test-database.spec.ts
+++ b/apps/api/test/setup/test-database.spec.ts
@@ -1,0 +1,20 @@
+import { TestDatabase } from "./test-database";
+
+describe("TestDatabase", () => {
+	it("비관리 DATABASE_URL에서 Prisma 연결을 시도하지 않아야 한다", async () => {
+		// Given - localhost fallback URL과 Prisma factory spy
+		const createPrismaClient = jest.fn();
+		const testDatabase = new TestDatabase({
+			env: {
+				DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/aido_test",
+			},
+			createPrismaClient,
+		});
+
+		// When & Then - marker/name 검증에서 즉시 중단
+		await expect(testDatabase.start()).rejects.toThrow(
+			"AIDO_TEST_DB_MANAGED=1",
+		);
+		expect(createPrismaClient).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/test/setup/test-database.ts
+++ b/apps/api/test/setup/test-database.ts
@@ -2,97 +2,49 @@
  * TestDatabase - 통합 테스트용 DB 헬퍼
  *
  * @description
- * 통합 테스트를 위한 PostgreSQL 데이터베이스를 관리합니다.
- * - Docker 사용 가능 시: Testcontainers로 독립적인 PostgreSQL 컨테이너 생성
- * - Docker 미사용 시: 기존 DATABASE_URL 사용 (fallback)
- * - 자동 마이그레이션 실행
- * - 테스트 종료 시 자동 정리
+ * Jest globalSetup이 준비한 관리형 PostgreSQL에 Prisma 연결을 제공합니다.
+ * 컨테이너와 migration 수명주기는 이 클래스가 소유하지 않습니다.
  * - Prisma 7+ Driver Adapter 패턴 사용
  */
 
-import { execSync } from "node:child_process";
 import { PrismaPg } from "@prisma/adapter-pg";
-import {
-	PostgreSqlContainer,
-	type StartedPostgreSqlContainer,
-} from "@testcontainers/postgresql";
 import { PrismaClient } from "../../src/generated/prisma/client";
+import { assertManagedTestDatabaseEnvironment } from "./managed-test-database";
+
+interface TestDatabaseOptions {
+	env?: NodeJS.ProcessEnv;
+	createPrismaClient?: (connectionUri: string) => PrismaClient;
+}
 
 export class TestDatabase {
-	private container: StartedPostgreSqlContainer | null = null;
 	private prisma: PrismaClient | null = null;
-	private originalDatabaseUrl: string | undefined;
-	private usingExternalDb = false;
+	private connectionUri: string | null = null;
+	private readonly env: NodeJS.ProcessEnv;
+	private readonly createPrismaClient: (connectionUri: string) => PrismaClient;
+
+	constructor(options: TestDatabaseOptions = {}) {
+		this.env = options.env ?? process.env;
+		this.createPrismaClient =
+			options.createPrismaClient ??
+			((connectionUri) => {
+				const adapter = new PrismaPg({ connectionString: connectionUri });
+				return new PrismaClient({ adapter });
+			});
+	}
 
 	/**
-	 * PostgreSQL 데이터베이스 시작 및 Prisma 클라이언트 초기화
-	 * Docker가 없는 경우 기존 DATABASE_URL 사용
+	 * globalSetup이 준비한 PostgreSQL에 Prisma 클라이언트 연결
 	 *
 	 * @returns PrismaClient 인스턴스
 	 */
 	async start(): Promise<PrismaClient> {
-		// 원본 DATABASE_URL 백업
-		this.originalDatabaseUrl = process.env.DATABASE_URL;
+		if (this.prisma) return this.prisma;
 
-		let connectionUri: string;
-
-		// USE_EXTERNAL_DB 환경변수가 있으면 외부 DB 사용
-		if (process.env.USE_EXTERNAL_DB === "true" && this.originalDatabaseUrl) {
-			console.log("📦 Using external database (USE_EXTERNAL_DB=true)");
-			connectionUri = this.originalDatabaseUrl;
-			this.usingExternalDb = true;
-		} else {
-			// Docker 컨테이너 시작 시도
-			try {
-				console.log("🐳 Starting PostgreSQL test container...");
-				this.container = await new PostgreSqlContainer("postgres:16-alpine")
-					.withDatabase("test_db")
-					.withUsername("test_user")
-					.withPassword("test_password")
-					.start();
-
-				connectionUri = this.container.getConnectionUri();
-				console.log(`📦 Container started: ${connectionUri}`);
-			} catch (error) {
-				// Docker가 없는 경우 기존 DATABASE_URL 사용
-				if (this.originalDatabaseUrl) {
-					console.warn("⚠️  Docker not available, falling back to DATABASE_URL");
-					console.warn("   To use Testcontainers, ensure Docker is running");
-					connectionUri = this.originalDatabaseUrl;
-					this.usingExternalDb = true;
-				} else {
-					console.error("❌ Docker not available and DATABASE_URL not set");
-					console.error(
-						"   Either start Docker or set DATABASE_URL environment variable",
-					);
-					throw error;
-				}
-			}
-		}
-
-		// 환경 변수 설정
-		process.env.DATABASE_URL = connectionUri;
-
-		// Prisma 마이그레이션 실행
-		console.log("🔄 Running Prisma migrations...");
-		try {
-			execSync("npx prisma migrate deploy", {
-				cwd: process.cwd(),
-				stdio: "pipe",
-				env: { ...process.env, DATABASE_URL: connectionUri },
-			});
-			console.log("✅ Migrations completed");
-		} catch (error) {
-			console.error("❌ Migration failed:", error);
-			throw error;
-		}
-
-		// Prisma 7+ Driver Adapter 패턴으로 클라이언트 초기화
-		const adapter = new PrismaPg({ connectionString: connectionUri });
-		this.prisma = new PrismaClient({ adapter });
+		const { connectionUri } = assertManagedTestDatabaseEnvironment(this.env);
+		this.connectionUri = connectionUri;
+		this.prisma = this.createPrismaClient(connectionUri);
 
 		await this.prisma.$connect();
-		console.log("✅ Prisma client connected");
 
 		return this.prisma;
 	}
@@ -108,13 +60,13 @@ export class TestDatabase {
 	}
 
 	/**
-	 * 컨테이너 연결 URI 반환
+	 * 관리형 테스트 DB 연결 URI 반환
 	 */
 	getConnectionUri(): string {
-		if (!this.container && !this.usingExternalDb) {
+		if (!this.connectionUri) {
 			throw new Error("TestDatabase not started. Call start() first.");
 		}
-		return this.container?.getConnectionUri() ?? process.env.DATABASE_URL ?? "";
+		return this.connectionUri;
 	}
 
 	/**
@@ -125,79 +77,35 @@ export class TestDatabase {
 			return;
 		}
 
-		console.log("🧹 Cleaning up test data...");
+		assertManagedTestDatabaseEnvironment(this.env);
+		const tables = await this.prisma.$queryRaw<Array<{ table_name: string }>>`
+			SELECT table_name
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+				AND table_type = 'BASE TABLE'
+				AND table_name <> '_prisma_migrations'
+			ORDER BY table_name
+		`;
 
-		// 트랜잭션으로 모든 테이블 데이터 삭제 (의존성 역순)
-		await this.prisma.$transaction([
-			// 알림/로그/기록 (자식 테이블)
-			this.prisma.retentionPushOutbox.deleteMany(),
-			this.prisma.retentionExperimentResult.deleteMany(),
-			this.prisma.retentionExperimentStage.deleteMany(),
-			this.prisma.retentionExperimentAssignment.deleteMany(),
-			this.prisma.pushDeliveryAttempt.deleteMany(),
-			this.prisma.pushDispatch.deleteMany(),
-			this.prisma.notification.deleteMany(),
-			this.prisma.weeklyAchievement.deleteMany(),
-			this.prisma.dailyCompletion.deleteMany(),
-			this.prisma.securityLog.deleteMany(),
-			this.prisma.loginAttempt.deleteMany(),
+		if (tables.length === 0) return;
 
-			// 소셜 기능
-			this.prisma.cheer.deleteMany(),
-			this.prisma.nudge.deleteMany(),
-			this.prisma.follow.deleteMany(),
-
-			// 인증
-			this.prisma.verification.deleteMany(),
-			this.prisma.session.deleteMany(),
-			this.prisma.oAuthState.deleteMany(),
-			this.prisma.account.deleteMany(),
-
-			// 구독
-			this.prisma.subscription.deleteMany(),
-
-			// Todo
-			this.prisma.todo.deleteMany(),
-			this.prisma.todoCategory.deleteMany(),
-			this.prisma.memo.deleteMany(),
-			this.prisma.pushToken.deleteMany(),
-
-			// 사용자 (부모 테이블)
-			this.prisma.userConsent.deleteMany(),
-			this.prisma.userPreference.deleteMany(),
-			this.prisma.userProfile.deleteMany(),
-			this.prisma.user.deleteMany(),
-		]);
-
-		console.log("✅ Test data cleaned");
+		const tableList = tables
+			.map(({ table_name }) => `"public"."${table_name.replaceAll('"', '""')}"`)
+			.join(", ");
+		await this.prisma.$executeRawUnsafe(
+			`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`,
+		);
 	}
 
 	/**
-	 * Prisma 클라이언트 연결 해제 및 컨테이너 중지
+	 * Prisma 클라이언트 연결 해제
 	 */
 	async stop(): Promise<void> {
-		console.log("🛑 Stopping test database...");
-
-		// Prisma 연결 해제
 		if (this.prisma) {
 			await this.prisma.$disconnect();
 			this.prisma = null;
-			console.log("✅ Prisma disconnected");
 		}
-
-		// 컨테이너 중지 (외부 DB 사용 시 스킵)
-		if (this.container) {
-			await this.container.stop();
-			this.container = null;
-			console.log("✅ Container stopped");
-		}
-
-		// 원본 DATABASE_URL 복원
-		if (this.originalDatabaseUrl) {
-			process.env.DATABASE_URL = this.originalDatabaseUrl;
-		} else {
-			delete process.env.DATABASE_URL;
-		}
+		this.connectionUri = null;
 	}
 }
 

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -15,6 +15,11 @@
 			"inputs": ["src/**", "test/**", "prisma/**", "jest.config.*"]
 		},
 		"test:e2e": {
+			"cache": false,
+			"inputs": ["src/**", "test/**", "prisma/**", "jest.config.*"]
+		},
+		"test:integration": {
+			"cache": false,
 			"inputs": ["src/**", "test/**", "prisma/**", "jest.config.*"]
 		},
 		"typecheck": {

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,7 @@
     },
     "test:e2e": {
       "dependsOn": ["^build"],
+      "cache": false,
       "inputs": ["src/**", "test/**", "jest.config.*"],
       "outputs": ["coverage/**"],
       "passThroughEnv": [
@@ -35,6 +36,19 @@
         "RESEND_API_KEY",
         "EMAIL_FROM",
         "EMAIL_FROM_NAME",
+        "TOKEN_ENCRYPTION_KEY",
+        "NODE_ENV"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "inputs": ["src/**", "test/**", "jest.config.*"],
+      "outputs": [],
+      "passThroughEnv": [
+        "DATABASE_URL",
+        "JWT_SECRET",
+        "JWT_REFRESH_SECRET",
         "TOKEN_ENCRYPTION_KEY",
         "NODE_ENV"
       ]


### PR DESCRIPTION
## 요약

- E2E와 integration 각각 Jest 실행당 `postgres:16-alpine` Testcontainer를 하나만 생성하고 migration을 한 번만 적용합니다.
- `TestDatabase`를 Prisma 연결·안전한 상태 초기화 전용으로 분리하고 localhost 또는 외부 DB fallback을 제거합니다.
- E2E 공용 reset으로 DB, cache, Redis mock, OAuth/Email/Push fake와 background push 작업을 테스트마다 격리합니다.
- OAuth code 교환과 TTL·날짜 테스트를 결정적으로 만들고 외부 OAuth 호출과 실제 시간 대기를 제거합니다.
- CI를 unit → integration → E2E 순서로 정리하고 상태 의존 테스트의 Turbo cache를 비활성화합니다.

## 원인

기존에는 테스트 파일마다 PostgreSQL 컨테이너 생성과 migration이 반복되었습니다. Integration과 E2E를 함께 실행하면 Docker·Postgres 자원 경합이 발생할 수 있었고, 컨테이너 시작 실패 시 localhost DB fallback으로 테스트 격리도 깨질 수 있었습니다. OAuth 외부 호출, 실제 TTL 대기, 공유 fake/cache 상태도 실행 순서에 따른 비결정성을 만들었습니다.

## 구현

- Jest `globalSetup/globalTeardown`이 컨테이너 수명주기를 소유합니다.
- `AIDO_TEST_DB_MANAGED=1`과 `aido_test_<run-id>` 이름을 검증하지 못하면 DB 접근을 즉시 거부합니다.
- 관리 컨테이너의 public 테이블만 동적으로 `TRUNCATE ... RESTART IDENTITY CASCADE`하며 `_prisma_migrations`는 제외합니다.
- 테스트 순서는 randomize하고 실패 seed를 출력합니다. 공유 DB 정리를 위해 `maxWorkers: 1`은 유지합니다.
- `test:e2e:diagnose`로 open handle과 재현 seed를 확인할 수 있습니다.

## 프로덕션 영향

일반 API 요청·응답, OpenAPI contract, Prisma schema/migration, 운영 DB 동작은 변경하지 않습니다.

프로덕션 코드 변경은 내부 조립과 종료 처리에 한정됩니다.

- OAuth provider registry 생성 코드를 factory로 추출했으며 기존 provider와 설정을 동일하게 조립합니다.
- 기존 push shutdown 대기 로직을 `drainPendingPushes()`로 분리해 테스트 reset에서도 재사용합니다. 정상 요청 경로의 발송 정책이나 payload는 변경하지 않습니다.

## 검증

- `pnpm typecheck`
- `pnpm lint`
- API unit: 286 suites, 2,296 passed, 4 skipped
- Integration: 29 suites, 336 passed
- E2E: seed 101/202/303/404/505 각각 26 suites, 394 tests, 2 snapshots 통과
- Integration과 E2E 동시 실행 통과 및 서로 다른 격리 DB 확인
- `test:e2e:diagnose`: 26 suites, 394 tests 통과, open handle 미검출
- CI workflow actionlint 통과
- OpenAPI snapshot 파일 변경 없음
