### PR TITLE
fix(api): preserve managed DB startup errors

### DIFF
--- a/apps/api/test/setup/managed-test-database.spec.ts
+++ b/apps/api/test/setup/managed-test-database.spec.ts
@@ -66,27 +66,39 @@ describe("관리형 테스트 DB 수명주기", () => {
 	it("컨테이너 중지까지 실패해도 원래 migration 오류를 보존해야 한다", async () => {
 		// Given - migration과 실패 정리를 위한 컨테이너 중지가 모두 실패
 		const migrationError = new Error("migration failed");
-		const stop = jest.fn().mockRejectedValue(new Error("stop failed"));
+		const stopError = new Error("stop failed");
+		const stop = jest.fn().mockRejectedValue(stopError);
 		const env: NodeJS.ProcessEnv = {};
+		const consoleError = jest
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
 
-		// When & Then - 정리 오류가 아니라 원래 시작 오류를 전파하고 환경을 복원
-		await expect(
-			startManagedTestDatabase({
-				env,
-				createRunId: () => "abc123",
-				startContainer: async () => ({
-					getConnectionUri: () =>
-						"postgresql://test:test@localhost:5432/aido_test_abc123",
-					stop,
+		try {
+			// When & Then - 원래 오류를 전파하고 정리 오류는 진단 가능하게 기록
+			await expect(
+				startManagedTestDatabase({
+					env,
+					createRunId: () => "abc123",
+					startContainer: async () => ({
+						getConnectionUri: () =>
+							"postgresql://test:test@localhost:5432/aido_test_abc123",
+						stop,
+					}),
+					migrate: async () => {
+						throw migrationError;
+					},
 				}),
-				migrate: async () => {
-					throw migrationError;
-				},
-			}),
-		).rejects.toBe(migrationError);
-		expect(stop).toHaveBeenCalledTimes(1);
-		expect(env.DATABASE_URL).toBeUndefined();
-		expect(env.AIDO_TEST_DB_MANAGED).toBeUndefined();
+			).rejects.toBe(migrationError);
+			expect(stop).toHaveBeenCalledTimes(1);
+			expect(consoleError).toHaveBeenCalledWith(
+				"Failed to stop managed test database container during cleanup:",
+				stopError,
+			);
+			expect(env.DATABASE_URL).toBeUndefined();
+			expect(env.AIDO_TEST_DB_MANAGED).toBeUndefined();
+		} finally {
+			consoleError.mockRestore();
+		}
 	});
 
 	it("Jest 실행당 migration을 한 번만 적용해야 한다", async () => {

--- a/apps/api/test/setup/managed-test-database.spec.ts
+++ b/apps/api/test/setup/managed-test-database.spec.ts
@@ -63,6 +63,32 @@ describe("관리형 테스트 DB 수명주기", () => {
 		expect(env.AIDO_TEST_DB_MANAGED).toBeUndefined();
 	});
 
+	it("컨테이너 중지까지 실패해도 원래 migration 오류를 보존해야 한다", async () => {
+		// Given - migration과 실패 정리를 위한 컨테이너 중지가 모두 실패
+		const migrationError = new Error("migration failed");
+		const stop = jest.fn().mockRejectedValue(new Error("stop failed"));
+		const env: NodeJS.ProcessEnv = {};
+
+		// When & Then - 정리 오류가 아니라 원래 시작 오류를 전파하고 환경을 복원
+		await expect(
+			startManagedTestDatabase({
+				env,
+				createRunId: () => "abc123",
+				startContainer: async () => ({
+					getConnectionUri: () =>
+						"postgresql://test:test@localhost:5432/aido_test_abc123",
+					stop,
+				}),
+				migrate: async () => {
+					throw migrationError;
+				},
+			}),
+		).rejects.toBe(migrationError);
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(env.DATABASE_URL).toBeUndefined();
+		expect(env.AIDO_TEST_DB_MANAGED).toBeUndefined();
+	});
+
 	it("Jest 실행당 migration을 한 번만 적용해야 한다", async () => {
 		// Given - 정상 시작되는 관리형 컨테이너
 		const stop = jest.fn().mockResolvedValue(undefined);

--- a/apps/api/test/setup/managed-test-database.ts
+++ b/apps/api/test/setup/managed-test-database.ts
@@ -161,6 +161,8 @@ export async function startManagedTestDatabase(
 	} catch (error) {
 		try {
 			await container?.stop();
+		} catch {
+			// Preserve the original startup or migration error.
 		} finally {
 			restoreEnvironment();
 		}

--- a/apps/api/test/setup/managed-test-database.ts
+++ b/apps/api/test/setup/managed-test-database.ts
@@ -161,8 +161,11 @@ export async function startManagedTestDatabase(
 	} catch (error) {
 		try {
 			await container?.stop();
-		} catch {
-			// Preserve the original startup or migration error.
+		} catch (stopError) {
+			console.error(
+				"Failed to stop managed test database container during cleanup:",
+				stopError,
+			);
 		} finally {
 			restoreEnvironment();
 		}


### PR DESCRIPTION
## 변경 사항

- startManagedTestDatabase의 시작·migration 실패 정리 중 container.stop()까지 실패해도 원래 오류를 보존합니다.
- 정리 실패 여부와 무관하게 DATABASE_URL 및 AIDO_TEST_DB_MANAGED 환경을 복원합니다.
- migration 오류와 stop 오류가 동시에 발생하는 회귀 테스트를 추가했습니다.

## 검증

- 관리형 테스트 DB 수명주기 단위 테스트: 8/8 통과
- pnpm typecheck
- pnpm lint
- 변경 파일 Biome 검사
- git diff --check

## 영향 범위

- apps/api/test 아래 테스트 인프라 코드와 단위 테스트만 변경합니다.
- 프로덕션 API, Prisma schema·migration, 응답 payload에는 영향이 없습니다.

## 관련

- #659 Gemini Code Assist review follow-up