### PR TITLE
release: CI/CD 배포 파이프라인 안정화 (캐시 보존·자동 롤백·SHA 고정 배포)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,9 +4,10 @@ description: pnpm + Node.js + dependencies + Prisma Client
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    # 액션 런타임 Node24 정합 + 공급망 보안 위해 SHA 핀 (버전은 주석으로 관리 — dependabot이 갱신)
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 22
         cache: pnpm

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,10 +15,15 @@ runs:
       run: pnpm install --frozen-lockfile
       shell: bash
 
-    - name: Fetch main branch for turbo --affected
+    # PR base 브랜치를 turbo --affected 기준으로 명시 (develop 타겟 PR이 main과 diff되던 과잉 실행도 수정)
+    - name: Set turbo affected base (PR 전용)
       if: github.event_name == 'pull_request'
-      run: git fetch origin main:main
       shell: bash
+      env:
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        git fetch origin "$BASE_REF"
+        echo "TURBO_SCM_BASE=origin/$BASE_REF" >> "$GITHUB_ENV"
 
     - name: Generate Prisma Client
       run: pnpm db:generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -20,6 +23,7 @@ jobs:
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -27,15 +31,18 @@ jobs:
 
       - uses: ./.github/actions/setup
 
+      # PR: --affected로 변경된 패키지만 / push(main·develop): 전체 실행 — 배포 게이트
+      # (main 푸시는 로컬 main == HEAD라 --affected diff가 빈 집합이 되어 검증이 스킵되는 버그가 있었음)
       - name: Biome Check
-        run: pnpm turbo run check --affected
+        run: pnpm turbo run check ${{ github.event_name == 'pull_request' && '--affected' || '' }}
 
       - name: Type Check
-        run: pnpm turbo run typecheck --affected
+        run: pnpm turbo run typecheck ${{ github.event_name == 'pull_request' && '--affected' || '' }}
 
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7
@@ -45,10 +52,12 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Run unit tests
-        run: pnpm turbo run test --affected
+        run: pnpm turbo run test ${{ github.event_name == 'pull_request' && '--affected' || '' }}
 
+      # 통합/E2E 태스크는 @aido/api에만 존재 → PR에서 --affected만으로 자연 스코프됨
+      # (모바일/문서-only PR은 Testcontainers 스킵, api 영향 변경은 실행)
       - name: Run integration tests
-        run: pnpm turbo run test:integration --filter=@aido/api
+        run: pnpm turbo run test:integration ${{ github.event_name == 'pull_request' && '--affected' || '--filter=@aido/api' }}
 
       - name: Run E2E tests
         env:
@@ -60,11 +69,12 @@ jobs:
           EMAIL_FROM_NAME: Aido Test
           TOKEN_ENCRYPTION_KEY: test-token-encryption-key-for-ci-minimum-32-chars
           NODE_ENV: test
-        run: pnpm turbo run test:e2e --filter=@aido/api
+        run: pnpm turbo run test:e2e ${{ github.event_name == 'pull_request' && '--affected' || '--filter=@aido/api' }}
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,24 +5,84 @@ on:
     workflows: ["CI"]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "배포할 커밋 SHA (비우면 main의 최신 CI 성공 커밋)"
+        required: false
+        default: ""
+      force:
+        description: "이전 커밋으로의 배포 허용 (수동 롤백용)"
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    timeout-minutes: 25
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
 
     steps:
+      - name: Resolve deploy SHA
+        id: sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # [보안] 입력을 run에 직접 보간하지 않고 env 경유 (셸 인젝션 방지)
+          WF_SHA: ${{ github.event.workflow_run.head_sha }}
+          INPUT_SHA: ${{ inputs.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            SHA="$WF_SHA"
+          elif [[ -n "$INPUT_SHA" ]]; then
+            SHA="$INPUT_SHA"
+          else
+            SHA="$(gh api 'repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=main&status=success&per_page=1' \
+                    --jq '.workflow_runs[0].head_sha')"
+            [[ -n "$SHA" ]] || { echo "::error::main의 성공한 CI run이 없습니다"; exit 1; }
+          fi
+          [[ "$SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::유효한 커밋 SHA(40자 hex)가 아닙니다: $SHA"; exit 1; }
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "배포 대상 SHA: $SHA"
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          DEPLOY_SHA: ${{ steps.sha.outputs.sha }}
+          FORCE_DEPLOY: ${{ (github.event_name == 'workflow_dispatch' && inputs.force) && '1' || '0' }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           command_timeout: 20m
+          envs: DEPLOY_SHA,FORCE_DEPLOY
           script: |
-            bash -e ~/apps/deploy.sh
+            set -euo pipefail
+            mkdir -p "$HOME/apps/deploy-state"
+            exec 9>"$HOME/apps/deploy-state/deploy.lock"
+            flock -n 9 || { echo "다른 배포가 진행 중 — 중단"; exit 1; }
+            export DEPLOY_LOCK_HELD=1
+            cd "$HOME/apps/Aido-platform"
+            git fetch origin main
+            git rev-parse --verify "${DEPLOY_SHA}^{commit}" >/dev/null
+            git merge-base --is-ancestor "$DEPLOY_SHA" origin/main \
+              || { echo "::error::DEPLOY_SHA가 origin/main 이력에 없습니다"; exit 1; }
+            git reset --hard "$DEPLOY_SHA"
+            [[ -f scripts/deploy.sh ]] \
+              || { echo "::error::scripts/deploy.sh 없음 — 스크립트 포함 커밋 이후로만 배포 가능"; exit 1; }
+            bash scripts/deploy.sh
+
+      - name: Verify public health endpoint
+        run: |
+          sleep 5
+          curl -fsS --retry 6 --retry-delay 10 --retry-all-errors --max-time 10 \
+            https://api.aido.kr/health

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ pnpm dev
 
 ## 배포
 
-- **API**: AWS ECS + ECR 기반. [apps/api/DEPLOYMENT.md](./apps/api/DEPLOYMENT.md)
+- **API**: AWS EC2 + Docker Compose (GitHub Actions SSH 배포). [apps/api/DEPLOYMENT.md](./apps/api/DEPLOYMENT.md)
 - **Mobile**: Expo EAS 빌드. [apps/mobile/DEPLOYMENT.md](./apps/mobile/DEPLOYMENT.md)
 
 ## 라이선스

--- a/apps/api/DEPLOYMENT.md
+++ b/apps/api/DEPLOYMENT.md
@@ -1,13 +1,13 @@
 # Aido API 배포 가이드
 
-> **Version**: 1.0.0 · **Last Updated**: 2026-04-23 · **Owner**: Aido Platform Team
+> **Version**: 1.1.0 · **Last Updated**: 2026-07-19 · **Owner**: Aido Platform Team
 
 ## 목차
 
 - [Prerequisites](#prerequisites)
 - [1. Local Development](#1-local-development)
 - [2. Production Docker (로컬 테스트)](#2-production-docker-로컬-테스트)
-- [3. AWS ECS + ECR 배포](#3-aws-ecs--ecr-배포)
+- [3. 프로덕션 배포 (GitHub Actions → EC2)](#3-프로덕션-배포-github-actions--ec2)
 - [4. 환경변수 레퍼런스](#4-환경변수-레퍼런스)
 - [5. 트러블슈팅](#5-트러블슈팅)
 
@@ -15,7 +15,6 @@
 
 - Docker 24+ / Docker Compose V2
 - Node.js 20+ / pnpm 10.29+
-- AWS CLI v2 (AWS 배포 시)
 
 ---
 
@@ -84,89 +83,95 @@ pnpm docker:prod:down
 
 ---
 
-## 3. AWS ECS + ECR 배포
+## 3. 프로덕션 배포 (GitHub Actions → EC2)
 
-### 3.1 ECR 리포지토리 생성
+> 실제 운영 파이프라인. ECS/ECR을 사용하지 않는다 — EC2 한 대(t4g.small)에서 `docker compose`로 빌드·기동하며, DB(RDS)/Redis(ElastiCache)는 외부 관리형 서비스다.
+
+### 3.1 파이프라인 개요
+
+```
+push(main) ─→ CI (lint / test / build)
+                 │ 성공 시 (workflow_run)
+                 ▼
+        Deploy to EC2 (.github/workflows/deploy.yml)
+                 ├─ CI가 검증한 커밋 SHA 해석·검증 (40자 hex + origin/main ancestor)
+                 ├─ SSH 부트스트랩: flock 락 → git reset --hard $SHA
+                 ├─ scripts/deploy.sh: 디스크 점검 → 롤백 태깅 → 빌드 → 기동 → 헬스 게이트
+                 └─ 러너에서 외부 검증: https://api.aido.kr/health
+```
+
+- 배포 대상은 **CI가 검증한 SHA로 고정**된다 (`workflow_run.head_sha`) — 배포 시점의 `origin/main` HEAD가 아니다.
+- `workflow_run` 트리거 특성상 `deploy.yml`은 **기본 브랜치(develop)의 파일**이 실행된다. 배포 로직 본체는 배포 대상 SHA의 `scripts/deploy.sh`.
+- 수동 배포/롤백: GitHub Actions → **Deploy to EC2 → Run workflow**. `sha` 비우면 main의 최신 CI 성공 커밋, 이전 커밋으로 되돌릴 땐 `sha` 입력 + `force` 체크.
+
+### 3.2 배포 단계 (`scripts/deploy.sh`)
+
+서버 레이아웃: 레포 `~/apps/Aido-platform` · 배포 상태 `~/apps/deploy-state/{deploy.lock, last_deployed_sha, history.log}`
+
+| 단계 | 동작 |
+|------|------|
+| 락 | `flock` — 동시 배포 차단 (GH concurrency + 서버 락 이중 방어) |
+| SHA 검증 | 작업트리 == `DEPLOY_SHA`, 마지막 배포 커밋의 후손인지 확인 (역행 배포 차단, `FORCE_DEPLOY=1`로 우회) |
+| 디스크 점검 | §3.3 참조 — 부족하면 빌드 시작 전 중단 |
+| 롤백 태깅 | 현재 `latest` → `:rollback` (자동 롤백 지점, 첫 실행 시 자동 시드) |
+| 빌드 | `compose build migrate` → `compose build api` 순차 (메모리 피크 분산, BuildKit 캐시 재사용) |
+| 기동 | `compose up -d` — migrate 완료 대기 후 api 재생성 |
+| 헬스 게이트 | 90초 내 Docker HEALTHCHECK `healthy` **AND** `/health` 연속 3회 성공, 실패 시 자동 롤백 |
+| 정리 | dangling 이미지 + 캐시 6GB 초과분만 (**`-a` prune 금지** — 롤백 이미지가 삭제됨) |
+
+### 3.3 디스크·캐시 관리
+
+모든 성장 벡터에 상한을 걸어 "디스크 꽉 참" 자체를 방지한다:
+
+| 성장 벡터 | 상한 장치 |
+|-----------|-----------|
+| BuildKit 빌드 캐시 | 매 배포 성공 후 6GB 초과분 LRU 정리 (`docker builder prune --max-used-space`) |
+| Docker 이미지 | `latest` + `rollback` 2세대만 유지, dangling 매회 정리 |
+| 컨테이너 로그 | json-file 20m × 5 로테이션 (compose 설정) |
+| DB 백업 | 로컬 7일 보존 + S3 업로드 (서버 cron) |
+
+- 용량 예산: 29GB 디스크 기준 정상 상태 ≈ 15GB (기본 ~8 + 캐시 ≤6 + 빌드 중 임시 1세대).
+- 빌드 전 사전 점검: 여유 <3GB → 캐시 전체 정리 → 재확인 → **그래도 부족하면 빌드를 시작하지 않고 중단** (서비스 무영향).
+- 점검 명령: `df -h /`, `docker system df` (매 배포의 GH Actions 로그에도 `df` 출력됨).
+
+### 3.4 장애 대응 런북
+
+| 시나리오 | 자동 동작 | 서비스 영향 | 운영자 조치 |
+|----------|-----------|-------------|-------------|
+| 디스크 <3GB (빌드 전) | 전체 정리 → 재확인 → 부족 시 빌드 미시작 중단 | 없음 | `df -h`/`docker system df`로 원인 확인 후 재배포 |
+| 빌드 실패 (ENOSPC 포함) | `latest` 태그 불변 → 서비스 유지, run 실패(red) | 없음 | 원인 수정 후 재배포 |
+| migrate 실패 | 구 api 유지된 채 compose 비정상 종료 → 롤백 경로 | 없음 | 마이그레이션 수정 후 재배포 |
+| 헬스 게이트 실패 | `:rollback` → `latest` retag + `up -d --no-deps api` | 수십 초 내 자동 복구 | 원인 수정 후 재배포 |
+| 롤백마저 실패 | FATAL 로그 + exit 2 | 장애 | 아래 수동 복구 |
+| 동시 배포 | flock으로 후발 즉시 중단 | 없음 | 선행 완료 후 재시도 |
+| 구 SHA 배포 시도 | ancestor 검사로 중단 | 없음 | 의도적 롤백이면 `force` 체크 |
 
 ```bash
-aws ecr create-repository --repository-name aido/api --image-scanning-configuration scanOnPush=true
-aws ecr create-repository --repository-name aido/migrate --image-scanning-configuration scanOnPush=true
+# 수동 재배포 (GitHub UI): Actions → Deploy to EC2 → Run workflow (sha 비움)
+# 특정 SHA 배포: sha 입력 / 이전 커밋 롤백: sha + force 체크
+
+# 서버에서 직접 (SSH):
+cd ~/apps/Aido-platform
+bash scripts/deploy.sh --rollback                        # 이전 이미지로 즉시 롤백
+DEPLOY_SHA=$(git rev-parse HEAD) bash scripts/deploy.sh  # 현재 커밋 재배포
+
+# 롤백마저 실패했을 때 수동 복구:
+docker images | grep rollback                            # 롤백 이미지 존재 확인
+docker tag aido-platform-api:rollback aido-platform-api:latest
+docker compose -f docker-compose.prod.yml up -d --no-deps api
+docker logs --tail 100 aido-prod-api                     # 원인 확인
 ```
 
-### 3.2 이미지 빌드 & Push
+### 3.5 DB 마이그레이션 규율
 
-```bash
-# ECR 로그인
-AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-AWS_REGION=ap-northeast-2
-ECR_URL=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+- 마이그레이션은 **forward-only** — 자동 롤백은 API 컨테이너만 되돌리고 DB는 이미 신 스키마다.
+- 따라서 모든 마이그레이션은 **직전 릴리스의 API와 호환**되어야 한다 (expand → contract: 먼저 추가만 하는 릴리스, 구 컬럼 제거는 다음 릴리스에서).
 
-aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_URL
+### 3.6 보안 수칙
 
-# Production 이미지 빌드
-docker build --target production -t aido/api:latest -f apps/api/Dockerfile .
-docker build --target migrate -t aido/migrate:latest -f apps/api/Dockerfile .
-
-# 태그 & Push
-docker tag aido/api:latest $ECR_URL/aido/api:latest
-docker tag aido/migrate:latest $ECR_URL/aido/migrate:latest
-
-docker push $ECR_URL/aido/api:latest
-docker push $ECR_URL/aido/migrate:latest
-```
-
-### 3.3 ECS Task Definition
-
-**API 서비스** (long-running):
-- Image: `aido/api:latest`
-- CPU: 256 / Memory: 512
-- Port mapping: 8080
-- Health check: `/health`
-
-**Migration 태스크** (one-shot):
-- Image: `aido/migrate:latest`
-- CPU: 256 / Memory: 512
-- 배포 전 `aws ecs run-task`로 실행
-
-### 3.4 RDS PostgreSQL
-
-```bash
-aws rds create-db-instance \
-  --db-instance-identifier aido-db \
-  --db-instance-class db.t4g.micro \
-  --engine postgres \
-  --engine-version 16 \
-  --master-username postgres \
-  --master-user-password <password> \
-  --allocated-storage 20
-```
-
-### 3.5 Secrets Manager
-
-```bash
-aws secretsmanager create-secret \
-  --name aido/api/env \
-  --secret-string '{
-    "JWT_SECRET": "...",
-    "JWT_REFRESH_SECRET": "...",
-    "TOKEN_ENCRYPTION_KEY": "...",
-    "DATABASE_URL": "postgresql://..."
-  }'
-```
-
-ECS Task Definition에서 `secrets` 필드로 참조합니다.
-
-### 3.6 CI/CD 파이프라인
-
-```
-Build → Push to ECR → Run Migration Task → Deploy API Service
-```
-
-1. 코드 Push 또는 PR 머지 트리거
-2. Docker 이미지 빌드 (production + migrate)
-3. ECR에 Push
-4. Migration 태스크 실행 및 완료 대기
-5. ECS 서비스 업데이트 (롤링 배포)
+- `.env.docker.prod`는 **서버 전용** (레포 미포함, `.gitignore` 제외 유지). 시크릿 로테이션 = 서버에서 파일 수정 후 재배포.
+- 배포 디렉터리(`~/apps/Aido-platform`)에서 **`git clean` 금지** — untracked인 `.env.docker.prod`가 삭제된다. (`git reset --hard`는 untracked를 건드리지 않아 안전.)
+- GH Secrets: `EC2_HOST` / `EC2_USER` / `EC2_SSH_PRIVATE_KEY` (배포 SSH), `TURBO_TOKEN` (Turbo 원격 캐시). 시크릿은 이미지 빌드에 유입되지 않는다 (`env_file`은 런타임 주입만, build args 없음).
 
 ### 3.7 `develop` → `main` 릴리스 브랜치 정합
 
@@ -280,7 +285,7 @@ docker exec aido-prod-api wget -qO- http://localhost:8080/health
 
 ```bash
 # 이미지 크기 확인
-docker images aido/api
+docker images aido-platform-api
 ```
 
 Production 이미지는 `node:22-alpine` + production deps만 포함하여 경량화됩니다.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -52,7 +52,8 @@ COPY apps/api/prisma ./prisma
 COPY apps/api/prisma.config.ts ./
 
 # 빈 프로젝트에 prisma CLI만 설치 (workspace/catalog 의존 회피)
-RUN pnpm init && pnpm add prisma@latest
+# apps/api/package.json의 prisma 버전(^7.8.0)과 함께 올릴 것 — silent major 업그레이드 방지
+RUN pnpm init && pnpm add prisma@7.8.0
 
 # RDS CA 인증서
 ADD --chmod=644 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/certs/rds-ca.pem

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,6 +26,9 @@ services:
       - "${PORT:-8080}:8080"
     environment:
       TZ: Asia/Seoul
+      # 컨테이너 내부 포트는 8080 불변 — Dockerfile HEALTHCHECK·서버 nginx proxy_pass가 8080 전제
+      # (env_file의 PORT 정의가 컨테이너에 주입되어 미스매치 나는 것을 차단)
+      PORT: "8080"
     env_file:
       - .env.docker.prod
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: apps/api/Dockerfile
       target: migrate
+    image: aido-platform-migrate:latest
     container_name: aido-prod-migrate
     env_file:
       - .env.docker.prod
@@ -19,6 +20,7 @@ services:
       context: .
       dockerfile: apps/api/Dockerfile
       target: production
+    image: aido-platform-api:latest
     container_name: aido-prod-api
     ports:
       - "${PORT:-8080}:8080"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,7 +25,9 @@ BUILD_CACHE_LIMIT="${BUILD_CACHE_LIMIT:-6GB}"        # BuildKit 캐시 상한 (�
 MIN_FREE_KB="${MIN_FREE_KB:-$((3 * 1024 * 1024))}"   # 빌드 전 최소 디스크 여유 3GB (드릴 시 env로 상향 가능)
 export BUILDKIT_PROGRESS=plain
 
-compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+# --env-file: compose 변수 보간(${PORT:-8080} 등)은 서비스 env_file이 아닌 이 플래그/호스트 env만 읽음
+#             — 루트 package.json의 docker:prod:* 스크립트와 동일 형태로 통일
+compose() { docker compose --env-file .env.docker.prod -f "$COMPOSE_FILE" "$@"; }
 log()  { printf '\n[deploy] %s\n' "$*"; }
 fail() { printf '\n[deploy][ERROR] %s\n' "$*" >&2; exit 1; }
 disk_avail_kb() { df -k --output=avail / | tail -1 | tr -d '[:space:]'; }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Aido 프로덕션 배포 스크립트 (버전 관리: scripts/deploy.sh)
+# 호출: .github/workflows/deploy.yml → SSH 부트스트랩(락 획득 + git reset) → 이 스크립트
+# 전제: 실행 시점에 레포는 이미 DEPLOY_SHA로 reset --hard 된 상태
+#
+# 수동 배포: cd ~/apps/Aido-platform && DEPLOY_SHA=$(git rev-parse HEAD) bash scripts/deploy.sh
+# 수동 롤백: cd ~/apps/Aido-platform && bash scripts/deploy.sh --rollback
+# [보안] 이 디렉터리에서 git clean 절대 금지 — .env.docker.prod(untracked 시크릿)가 삭제됨
+# [보안] set -x 금지 — 환경변수 노출 방지
+# =============================================================================
+set -Eeuo pipefail
+
+STATE_DIR="${STATE_DIR:-$HOME/apps/deploy-state}"
+COMPOSE_FILE="docker-compose.prod.yml"
+API_IMAGE="aido-platform-api"
+MIGRATE_IMAGE="aido-platform-migrate"
+API_CONTAINER="aido-prod-api"
+MIGRATE_CONTAINER="aido-prod-migrate"
+HEALTH_URL="${HEALTH_URL:-http://localhost:8080/health}"   # 드릴 시 env로 교체 가능
+HEALTH_TIMEOUT_S=90
+HEALTH_INTERVAL_S=5
+HEALTH_CONSECUTIVE_OK=3
+BUILD_CACHE_LIMIT="${BUILD_CACHE_LIMIT:-6GB}"        # BuildKit 캐시 상한 (성공 후 초과분만 LRU 정리)
+MIN_FREE_KB="${MIN_FREE_KB:-$((3 * 1024 * 1024))}"   # 빌드 전 최소 디스크 여유 3GB (드릴 시 env로 상향 가능)
+export BUILDKIT_PROGRESS=plain
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+log()  { printf '\n[deploy] %s\n' "$*"; }
+fail() { printf '\n[deploy][ERROR] %s\n' "$*" >&2; exit 1; }
+disk_avail_kb() { df -k --output=avail / | tail -1 | tr -d '[:space:]'; }
+
+acquire_lock() {
+  # 부트스트랩이 이미 락(fd 9)을 잡고 넘어온 경우 재획득 금지 (재-open 시 락 해제됨)
+  if [[ "${DEPLOY_LOCK_HELD:-0}" != "1" ]]; then
+    mkdir -p "$STATE_DIR"
+    exec 9>"$STATE_DIR/deploy.lock"
+    flock -n 9 || fail "다른 배포가 진행 중입니다 ($STATE_DIR/deploy.lock)"
+  fi
+}
+
+dump_logs() {
+  log "── migrate 로그 (마지막 50줄) ──"
+  docker logs --tail 50 "$MIGRATE_CONTAINER" 2>&1 || true
+  log "── api 로그 (마지막 50줄) ──"
+  docker logs --tail 50 "$API_CONTAINER" 2>&1 || true
+  docker ps -a --filter "name=aido-prod" || true
+}
+
+wait_healthy() {
+  local deadline=$((SECONDS + HEALTH_TIMEOUT_S)) ok=0 status
+  while (( SECONDS < deadline )); do
+    status="$(docker inspect --format '{{.State.Health.Status}}' "$API_CONTAINER" 2>/dev/null || echo missing)"
+    if [[ "$status" == "healthy" ]] && curl -fsS -m 5 "$HEALTH_URL" >/dev/null 2>&1; then
+      ok=$((ok + 1))
+      (( ok >= HEALTH_CONSECUTIVE_OK )) && { log "헬스체크 통과 (연속 ${ok}회)"; return 0; }
+    else
+      ok=0
+    fi
+    sleep "$HEALTH_INTERVAL_S"
+  done
+  return 1
+}
+
+restore_previous_images() {
+  docker image inspect "$API_IMAGE:rollback" >/dev/null 2>&1 \
+    || fail "롤백 이미지($API_IMAGE:rollback) 없음 — 수동 개입 필요"
+  docker tag "$API_IMAGE:rollback" "$API_IMAGE:latest"
+  if docker image inspect "$MIGRATE_IMAGE:rollback" >/dev/null 2>&1; then
+    docker tag "$MIGRATE_IMAGE:rollback" "$MIGRATE_IMAGE:latest"
+  fi
+}
+
+rollback() {
+  trap - ERR
+  log "배포 실패 — 이전 이미지로 롤백 시도"
+  dump_logs
+  restore_previous_images
+  compose up -d --no-deps api   # migrate 재실행 없이 api만 복구 (--no-deps 필수)
+  if wait_healthy; then
+    log "롤백 성공 — 이전 버전으로 서비스 중 (이번 배포는 실패 처리)"
+    exit 1
+  fi
+  printf '\n[deploy][FATAL] 롤백 후에도 unhealthy — 즉시 수동 개입 필요\n' >&2
+  dump_logs
+  exit 2
+}
+
+main() {
+  cd "$(dirname "$0")/.."
+  mkdir -p "$STATE_DIR"
+  acquire_lock
+
+  if [[ "${1:-}" == "--rollback" ]]; then
+    restore_previous_images
+    compose up -d --no-deps api
+    wait_healthy || { dump_logs; fail "수동 롤백 후에도 unhealthy"; }
+    log "수동 롤백 완료"
+    exit 0
+  fi
+
+  # 0. 배포 대상 검증
+  DEPLOY_SHA="${DEPLOY_SHA:-$(git rev-parse HEAD)}"
+  [[ "$(git rev-parse HEAD)" == "$(git rev-parse "${DEPLOY_SHA}^{commit}")" ]] \
+    || fail "작업트리가 DEPLOY_SHA(${DEPLOY_SHA}) 상태가 아닙니다"
+
+  local last_sha_file="$STATE_DIR/last_deployed_sha"
+  if [[ "${FORCE_DEPLOY:-0}" != "1" && -f "$last_sha_file" ]]; then
+    local last; last="$(cat "$last_sha_file")"
+    if git cat-file -e "${last}^{commit}" 2>/dev/null; then
+      git merge-base --is-ancestor "$last" "$DEPLOY_SHA" \
+        || fail "마지막 배포($last)보다 오래된 커밋 — 의도적이면 FORCE_DEPLOY=1"
+    fi
+  fi
+  log "배포 대상: $(git log -1 --oneline HEAD)"
+
+  # 1. 디스크 사전 점검: 부족 → 전체 정리 → 재확인 → 그래도 부족하면 빌드 시작 전 중단
+  #    (도중 ENOSPC로 죽는 빌드를 만들지 않는다 — 서비스는 구 버전으로 무영향)
+  local avail_kb; avail_kb="$(disk_avail_kb)"
+  log "디스크 여유: $(( avail_kb / 1024 / 1024 ))GB"
+  if (( avail_kb < MIN_FREE_KB )); then
+    log "여유 부족 — 빌드 캐시 전체 + dangling 이미지 정리 (이번 빌드는 콜드 빌드)"
+    docker builder prune -af
+    docker image prune -f
+    avail_kb="$(disk_avail_kb)"
+    (( avail_kb >= MIN_FREE_KB )) \
+      || fail "정리 후에도 디스크 여유 부족($(( avail_kb / 1024 / 1024 ))GB) — 빌드 미시작, 서비스는 구 버전으로 계속 동작 중. df -h / docker system df로 원인 확인"
+  fi
+
+  # 2. 현재 이미지를 롤백 지점으로 태깅 (첫 실행 시 자동 시드)
+  if docker image inspect "$API_IMAGE:latest" >/dev/null 2>&1; then
+    docker tag "$API_IMAGE:latest" "$API_IMAGE:rollback"
+    docker image inspect "$MIGRATE_IMAGE:latest" >/dev/null 2>&1 \
+      && docker tag "$MIGRATE_IMAGE:latest" "$MIGRATE_IMAGE:rollback"
+    log "롤백 태그 갱신 완료"
+  else
+    log "기존 latest 없음(첫 배포) — 롤백 태그 생략"
+  fi
+
+  # 3. 빌드 (캐시 유지, t4g.small 메모리 피크 분산 위해 순차)
+  trap rollback ERR
+  log "이미지 빌드: migrate"
+  compose build migrate
+  log "이미지 빌드: api"
+  compose build api
+
+  # 4. 기동 (migrate 완료 대기 후 api 재생성; migrate 실패 시 구 api 유지된 채 비정상 종료 → 롤백 경로)
+  log "컨테이너 기동 (migrate → api)"
+  compose up -d
+
+  # 5. 헬스 게이트
+  wait_healthy || rollback
+  trap - ERR
+
+  # 6. 성공 처리: 상태 기록 + 안전한 정리 (정리 실패가 성공한 배포를 실패로 만들지 않도록 비치명 처리)
+  git rev-parse HEAD > "$last_sha_file"
+  printf '%s %s deployed\n' "$(date -Is)" "$(git rev-parse --short HEAD)" >> "$STATE_DIR/history.log"
+  docker image prune -f || log "경고: dangling 이미지 정리 실패 (배포는 성공)"   # dangling만 — :rollback 보존 위해 -a 절대 금지
+  docker builder prune -f --max-used-space="$BUILD_CACHE_LIMIT" 2>/dev/null \
+    || docker builder prune -f --keep-storage="$BUILD_CACHE_LIMIT" \
+    || log "경고: 빌드 캐시 정리 실패 (배포는 성공)"
+  log "배포 완료: $(git rev-parse --short HEAD)"
+  df -h / | tail -1
+}
+
+main "$@"


### PR DESCRIPTION
## 요약

`ssh aido` 서버 실사 + GH Actions 실측(최근 배포 8회 평균 **~11분**)을 바탕으로, **현행 구조(GitHub Actions → SSH → EC2 docker compose build)를 유지**하면서 배포 속도·안정성·보안을 개선합니다.

---

## Before → After

### 배포 흐름

**Before**
```
push(main) → CI → SSH 접속
  → git reset --hard origin/main        # CI가 검증한 커밋이 아닐 수 있음 (커밋 레이스)
  → docker builder/image prune -a -f    # 캐시·이전 이미지 전부 삭제
  → 풀 콜드 빌드 (~10분, t4g.small 1.8GB RAM에서 라이브 API와 경쟁)
  → up -d → 헬스체크 30초 (실패 시 로그만 출력 — 복구 수단 없음, 이전 이미지는 이미 삭제됨)
```

**After**
```
push(main) → CI (main 게이트 복원: lint/test 실제 실행) → SSH 접속
  → flock 락 → CI 검증 SHA 검증(hex+ancestor) → git reset --hard $SHA
  → 디스크 점검 (<3GB: 정리→재확인→부족 시 빌드 미시작 중단)
  → 현재 이미지를 :rollback으로 태깅
  → 캐시 활용 빌드 (migrate → api 순차)
  → up -d → 헬스 게이트 90초 (HEALTHCHECK healthy AND /health 연속 3회)
  → 실패 시 자동 롤백 / 성공 시 상한 정리(캐시 6GB LRU, dangling만)
  → GH 러너에서 외부 검증 (https://api.aido.kr/health)
```

### 수치

| 지표 | Before | After |
|---|---|---|
| 배포 (일반 API 변경) | ~11분 | **~3–6분** |
| 배포 (문서/모바일-only 릴리스) | ~11분 | **~1–2분** |
| 배포 실패 복구 | **불가** (수동 콜드 재빌드 ~11분 장애) | **자동 롤백 ~1–2분** |
| 배포되는 커밋 | 배포 시점 origin/main HEAD | **CI가 검증한 SHA 고정** |
| main 푸시 CI | `--affected` 빈 diff로 lint/test 사실상 스킵 | 릴리스 diff 전체 검증 |
| 모바일/문서-only PR CI | ~4.5분 (Testcontainers 포함) | ~2–3분 (통합/E2E 스킵) |
| 수동 재배포/롤백 | 커밋 푸시 없이는 불가 | workflow_dispatch로 UI에서 가능 |
| 배포 스크립트 | 서버에만 존재 (리뷰 불가) | `scripts/deploy.sh` 버전 관리 |
| 디스크 관리 | 매번 전부 삭제 (콜드 빌드 비용) | 상한 관리 + 사전 점검 + 조기 중단 |

---

## 롤백 동작 방식

### 이미지 수명주기 (롤백 지점이 항상 존재하는 이유)

매 배포 **시작 시점**에 현재 서비스 중인 `latest`를 `:rollback`으로 태깅합니다. 즉 어느 시점이든 "직전 성공 버전" 1세대가 서버에 보관됩니다. 정리 단계는 dangling-only prune이라 `:rollback` 태그는 절대 삭제되지 않습니다 (`-a` prune 금지가 스크립트에 명문화됨).

```
배포 N 시작:  latest=vN-1  →  rollback=vN-1 태깅  →  빌드  →  latest=vN
                                                      (vN-2는 태그가 빠져 dangling → 자동 정리)
```

### 1. 자동 롤백 — 헬스 게이트 실패 시 (운영자 개입 불필요)

`compose up -d` 후 90초 내에 (a) Docker HEALTHCHECK `healthy` **AND** (b) `/health` curl **연속 3회** 성공을 요구합니다. 실패 시:

1. migrate/api 컨테이너 로그 50줄 덤프 (GH Actions 로그에서 바로 확인)
2. `:rollback` → `latest` retag
3. `compose up -d --no-deps api` — migrate 재실행 없이 api만 직전 이미지로 재기동
4. 재헬스체크 통과 확인 → **exit 1** (배포는 실패(red)로 기록, 서비스는 직전 버전으로 복구)

소요 약 1–2분. 빌드 실패·migrate 실패는 컨테이너 교체 전에 발생하므로 구 버전이 무중단으로 계속 서비스됩니다 (롤백 경로는 사실상 no-op).

### 2. 수동 롤백 — 3가지 방법

| 방법 | 명령 | 용도 |
|---|---|---|
| GitHub UI | Actions → **Deploy to EC2** → Run workflow → `sha`=이전 커밋 + `force` 체크 | 헬스체크는 통과했지만 버그가 뒤늦게 발견된 경우 (재빌드 포함) |
| 서버 즉시 롤백 | `cd ~/apps/Aido-platform && bash scripts/deploy.sh --rollback` | 빌드 없이 `:rollback` 이미지로 즉시 복귀 (수십 초) |
| 최후 수동 복구 | `docker tag aido-platform-api:rollback aido-platform-api:latest && docker compose --env-file .env.docker.prod -f docker-compose.prod.yml up -d --no-deps api` | 스크립트마저 실패한 상황 (런북 §3.4) |

### 3. 한계 — DB는 forward-only

자동 롤백은 **API 컨테이너만** 되돌립니다. DB 마이그레이션은 이미 적용된 상태이므로, 모든 마이그레이션은 직전 릴리스 API와 호환되어야 합니다 (expand → contract 규율, `DEPLOYMENT.md` §3.5에 명문화).

---

## Gemini 리뷰 반영 내역 (6건 검토: 반영 2 / 기각 4)

| 판정 | 내용 | 근거 (상세는 각 스레드) |
|---|---|---|
| ✅ 반영 | compose 변수 보간에 `--env-file` 명시 | 지적 정확 — 루트 `docker:prod:*` 스크립트와 동일 형태로 통일 (9d803b07) |
| ✅ 반영* | 포트 미스매치 방지 | 단, 제안(컨테이너 포트 가변화)과 **반대 방향** — nginx·HEALTHCHECK가 8080 전제이므로 컨테이너 PORT를 8080으로 명시 고정 (9d803b07) |
| ❌ 기각 | HEALTH_URL에 .env PORT 파싱 | 위 수정으로 시나리오 소멸 + 시크릿 파일 grep은 접근 표면 추가 |
| ❌ 기각 | DockerRootDir 기반 디스크 체크 | 단일 루트 파티션 확인됨 + non-root df는 항상 폴백만 타는 데드 코드 |
| ❌ 기각 | last_sha 공백 방어 | 기계 생성 40-hex + cat-file 가드로 이미 fail-safe |
| ❌ 기각 | `date -Is` 이식성 | 서버 전용 스크립트(GNU 확인) + 제안 코드에 이스케이프 버그 |

## 커밋 구성

1. `05ef9936` — 배포 파이프라인 안정화 본체 (deploy.sh·deploy.yml·ci.yml·Dockerfile·compose·docs)
2. `9d803b07` — 리뷰 반영 (compose env-file 보간 정합 + 컨테이너 포트 고정)
3. `6f48af0d` — 액션 런타임 Node24 정합 (setup-node v7·pnpm/action-setup v6, "Node 20 deprecated" 러너 경고 해소) + 전 액션 SHA 핀 (공급망 보안, appleboy 스타일 통일)

## 보안

- 신규 시크릿 없음, `.env.docker.prod` 서버 전용 유지 (+배포 경로 `git clean` 금지 명문화)
- 워크플로우 `permissions` 최소화, `workflow_dispatch` 입력 셸 인젝션 방지 (env 경유 + 40자 hex 검증 + 서버측 ancestor 검증)
- 전 액션 커밋 SHA 핀 (dependabot이 SHA 핀 갱신 지원), 시크릿은 이미지 빌드에 유입되지 않음

## 검증

- `bash -n` + `shellcheck` (deploy.sh) ✅ / `actionlint` (ci.yml·deploy.yml) ✅ / `docker compose config` ✅ / `pnpm typecheck` + `pnpm lint` ✅
- 액션 메이저 점프 호환성 확인: setup-node v7 `cache` 입력은 pnpm 명시 지원, pnpm/action-setup v6는 `packageManager`(pnpm@10.29.3) 필드 사용 — 러너 전용 변경으로 배포 산출물 영향 없음

## 머지 시 유의사항

- **`--merge` (merge commit) 필수** — §3.7 릴리스 규칙 (squash 금지). 머지 후 develop ff-only 동기화.
- 머지 → main CI (이제 lint/test 전체 실행) → 새 deploy.yml 자동 발동.
- **첫 배포는 콜드 빌드 ~11분** (기존 스크립트가 캐시를 지워둔 상태). **2회차부터 3–6분**으로 단축.
- 안정 확인 후 서버 정리(선택): `mv ~/apps/deploy.sh ~/apps/deploy.sh.retired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)