### PR TITLE
release: 빌드 컨텍스트 위생 - CI/배포 파일의 이미지 캐시 무효화 차단

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,12 @@ dist/
 # Mobile app (API 빌드에 불필요)
 apps/mobile/
 
+# CI/배포 오케스트레이션 (이미지 빌드에 불필요 — 변경 시 COPY . . 레이어 캐시 무효화 방지)
+.github/
+scripts/
+docker-compose*.yml
+backups/
+
 # Environment
 .env*
 !.env.docker.dev.example

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ apps/mobile/
 .github/
 scripts/
 docker-compose*.yml
+docker-compose*.yaml
 backups/
 
 # Environment


### PR DESCRIPTION
## 문제

`.dockerignore`가 `.github/`, `scripts/`, `docker-compose*.yml`을 제외하지 않아, **이미지 빌드가 전혀 읽지 않는 파일들이 빌드 컨텍스트에 포함**되어 있었다. 빌드 컨텍스트가 루트(`context: .`)이므로 builder 스테이지의 `COPY . .`가 이들을 포함하고, 결과적으로 **워크플로우·배포 스크립트·compose 파일만 변경한 릴리스도 api 이미지 캐시가 무효화되어 ~10분 재빌드**를 유발한다. `scripts/deploy.sh`가 레포로 들어온 #669 이후 이 비용이 반복될 상황.

## 수정 (클라이언트 영향 0)

`.dockerignore`에 4줄 추가: `.github/`, `scripts/`, `docker-compose*.yml`, `backups/`

**이미지 비트 불변 근거**: Dockerfile의 모든 COPY 소스(락파일·워크스페이스 package.json·turbo.json·apps/api·packages·tooling·prisma)와 빌드 스텝(pnpm install·tsc·prisma generate·nest build·pnpm deploy)은 제외 경로를 읽지 않는다. turbo.json `globalDependencies`에도 없음. 런타임·API 계약 무변경.

## 이 배포 자체가 측정 실험

- 이번 배포: 컨텍스트 정의가 바뀌므로 `COPY . .` 레이어가 1회 무효화 → **deps 캐시 유지 + builder 재빌드** = "일반 코드 변경 티어" 실측 (예상 3~6분, 기존 베이스라인 ~11분 대비)
- 이후: 워크플로우/배포 스크립트/compose 변경 릴리스는 이미지 캐시에 영향 없음 → ~1분대 티어로 이동

## 머지 시 유의

`--merge` 필수 (§3.7), 머지 후 develop ff-only 동기화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)