### PR TITLE
release: E2E 플레이크 근본 원인 제거 - 도메인 이벤트 프라미스 소유권 정리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,15 @@ jobs:
 
       - uses: ./.github/actions/setup
 
+      # 각 테스트 출력을 파일로 남기고 실패 시 아티팩트 업로드 — 플레이크 재현용
+      # (jest-e2e는 showSeed로 랜덤 시드가 로그에 남으므로 --seed로 고정 재현 가능)
       - name: Run unit tests
-        run: pnpm turbo run test ${{ github.event_name == 'pull_request' && '--affected' || '' }}
+        run: pnpm turbo run test ${{ github.event_name == 'pull_request' && '--affected' || '' }} 2>&1 | tee /tmp/test-unit.log
 
       # 통합/E2E 태스크는 @aido/api에만 존재 → PR에서 --affected만으로 자연 스코프됨
       # (모바일/문서-only PR은 Testcontainers 스킵, api 영향 변경은 실행)
       - name: Run integration tests
-        run: pnpm turbo run test:integration ${{ github.event_name == 'pull_request' && '--affected' || '--filter=@aido/api' }}
+        run: pnpm turbo run test:integration ${{ github.event_name == 'pull_request' && '--affected' || '--filter=@aido/api' }} 2>&1 | tee /tmp/test-integration.log
 
       - name: Run E2E tests
         env:
@@ -69,7 +71,15 @@ jobs:
           EMAIL_FROM_NAME: Aido Test
           TOKEN_ENCRYPTION_KEY: test-token-encryption-key-for-ci-minimum-32-chars
           NODE_ENV: test
-        run: pnpm turbo run test:e2e ${{ github.event_name == 'pull_request' && '--affected' || '--filter=@aido/api' }}
+        run: pnpm turbo run test:e2e ${{ github.event_name == 'pull_request' && '--affected' || '--filter=@aido/api' }} 2>&1 | tee /tmp/test-e2e.log
+
+      - name: Upload test logs (failure only)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-logs-${{ github.run_id }}
+          path: /tmp/test-*.log
+          retention-days: 14
 
   build:
     name: Build

--- a/apps/api/src/todo/application/events/todo-toggled.handler.ts
+++ b/apps/api/src/todo/application/events/todo-toggled.handler.ts
@@ -28,7 +28,10 @@ import {
  * - 스트릭 갱신은 양방향(완료/미완료)으로 수행합니다.
  * - 완료로 전환된 경우에만 리마인더 취소 + 친구 완료 알림 + 마일스톤 체크를 수행합니다.
  *
- * 모든 부수효과는 fire-and-forget이며 실패는 로깅만 합니다(기존 동작 보존).
+ * 모든 부수효과는 발행(emit) 관점에서 fire-and-forget이며 실패는 로깅만 합니다.
+ * 단, 핸들러 본문이 자기 부수효과를 끝까지 await로 소유합니다 — 떠다니는
+ * 프라미스를 남기면 완료 시점을 아무도 알 수 없어 테스트 격리(TRUNCATE)와
+ * 경합하고, 프로세스 종료 시 유실될 수 있습니다.
  * 크로스모듈 의존은 포트를 통해서만, 판단 규칙은 도메인 정책(completion-policy)을 통해 접근합니다.
  */
 @Injectable()
@@ -49,17 +52,35 @@ export class TodoToggledHandler {
 	) {}
 
 	@OnEvent(TODO_EVENTS.TOGGLED)
-	handle(event: TodoToggledEvent): void {
+	async handle(event: TodoToggledEvent): Promise<void> {
 		const { todoId, userId, completed, timezone } = event;
 
+		const sideEffects: Promise<void>[] = [];
 		if (completed) {
 			this.todoReminder.cancelReminder(todoId);
-			void this.#checkAndEnqueueFriendCompleted(userId, timezone);
-			void this.#checkAndEnqueueMilestone(userId);
+			sideEffects.push(this.#checkAndEnqueueFriendCompleted(userId, timezone));
+			sideEffects.push(this.#checkAndEnqueueMilestone(userId));
 		}
 
-		// 스트릭은 양방향 갱신 (fire-and-forget)
-		this.streakPort.recordTodoToggle(userId, completed, timezone);
+		// 스트릭은 양방향 갱신
+		sideEffects.push(this.#recordStreakSafely(userId, completed, timezone));
+
+		await Promise.allSettled(sideEffects);
+	}
+
+	async #recordStreakSafely(
+		userId: string,
+		completed: boolean,
+		timezone: string,
+	): Promise<void> {
+		try {
+			await this.streakPort.recordTodoToggle(userId, completed, timezone);
+		} catch (error) {
+			this.#logger.error(
+				`Failed to record streak toggle: userId=${userId}, ${error}`,
+				error instanceof Error ? error.stack : undefined,
+			);
+		}
 	}
 
 	/**

--- a/apps/api/src/todo/application/ports/streak.port.ts
+++ b/apps/api/src/todo/application/ports/streak.port.ts
@@ -3,11 +3,16 @@ export const STREAK_PORT = Symbol("STREAK_PORT");
 /**
  * 스트릭 갱신 포트 (user-settings 컨텍스트 경계)
  *
- * 완료/미완료 토글 시 스트릭을 갱신합니다(fire-and-forget).
+ * 완료/미완료 토글 시 스트릭을 갱신합니다. 실패 처리(로깅)는 호출자
+ * (이벤트 핸들러)가 소유합니다.
  */
 export interface StreakPort {
 	/** 완료/미완료 전이를 스트릭에 기록합니다. */
-	recordTodoToggle(userId: string, completed: boolean, timezone: string): void;
+	recordTodoToggle(
+		userId: string,
+		completed: boolean,
+		timezone: string,
+	): Promise<void>;
 
 	/**
 	 * 스트릭 판정 컨텍스트를 조회합니다 (기록 없으면 0/null).

--- a/apps/api/src/todo/infrastructure/adapters/streak.adapter.ts
+++ b/apps/api/src/todo/infrastructure/adapters/streak.adapter.ts
@@ -9,9 +9,12 @@ import type { StreakPort } from "../../application/ports/streak.port";
 export class StreakAdapter implements StreakPort {
 	constructor(private readonly userSettingsFacade: UserSettingsFacade) {}
 
-	recordTodoToggle(userId: string, completed: boolean, timezone: string): void {
-		// user-settings 파사드로 위임(fire-and-forget)
-		void this.userSettingsFacade.onTodoToggled(userId, completed, timezone);
+	async recordTodoToggle(
+		userId: string,
+		completed: boolean,
+		timezone: string,
+	): Promise<void> {
+		await this.userSettingsFacade.onTodoToggled(userId, completed, timezone);
 	}
 
 	async getStreakContext(userId: string): Promise<{

--- a/apps/api/test/e2e/helpers/e2e-app-factory.ts
+++ b/apps/api/test/e2e/helpers/e2e-app-factory.ts
@@ -11,6 +11,7 @@
 
 import { getQueueToken } from "@nestjs/bullmq";
 import type { INestApplication } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import { Test, type TestingModule } from "@nestjs/testing";
 import RedisMock from "ioredis-mock";
 import { PinoLogger } from "nestjs-pino";
@@ -57,6 +58,7 @@ import {
 	TODO_REMINDER_QUEUE,
 	TodoReminderProcessor,
 } from "@/scheduler";
+import { DOMAIN_EVENT_PUBLISHER } from "@/shared/application/ports";
 import { InMemoryCacheAdapter } from "@/shared/infrastructure/cache/adapters/in-memory-cache.adapter";
 import { CACHE_SERVICE } from "@/shared/infrastructure/cache/interfaces/cache.interface";
 import { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";
@@ -87,6 +89,7 @@ import {
 	createE2eTestStateResetter,
 	type TestStateResetter,
 } from "./e2e-test-state";
+import { TrackingDomainEventPublisher } from "./tracking-domain-event-publisher";
 
 /* ── BullMQ 격리 대상 ─────────────────────────────────── */
 
@@ -168,6 +171,7 @@ export async function createE2eApp(
 	});
 	let fakeOAuthProviderRegistry: FakeOAuthProviderRegistry | undefined;
 	let pushDispatcher: PushDispatcherAdapter | undefined;
+	let trackingEventPublisher: TrackingDomainEventPublisher | undefined;
 	let module: TestingModule | undefined;
 	let app: INestApplication<App> | undefined;
 
@@ -238,7 +242,16 @@ export async function createE2eApp(
 		.overrideProvider(SUN_TIME_PROVIDER)
 		.useValue(fakeSunTimeProvider)
 		.overrideProvider(PinoLogger)
-		.useClass(FakeLogger);
+		.useClass(FakeLogger)
+		// 도메인 이벤트 리스너의 잔류 작업을 reset이 drain할 수 있도록 추적 퍼블리셔로 교체
+		.overrideProvider(DOMAIN_EVENT_PUBLISHER)
+		.useFactory({
+			inject: [EventEmitter2],
+			factory: (eventEmitter: EventEmitter2) => {
+				trackingEventPublisher = new TrackingDomainEventPublisher(eventEmitter);
+				return trackingEventPublisher;
+			},
+		});
 
 	// BullMQ 격리: Queue 토큰 → mock queue
 	for (const queueName of BULL_QUEUES) {
@@ -274,7 +287,11 @@ export async function createE2eApp(
 
 		const helpers = new E2eHelpers(app, fakeEmailService);
 		const reset = createE2eTestStateResetter({
-			drainBackgroundWork: () => pushDispatcher?.drainPendingPushes(),
+			drainBackgroundWork: async () => {
+				// 이벤트 리스너(DB 쓰기 부수효과) → 푸시 순으로 drain 후에야 TRUNCATE
+				await trackingEventPublisher?.drainPendingEvents();
+				await pushDispatcher?.drainPendingPushes();
+			},
 			cleanupDatabase: () => testDatabase.cleanup(),
 			resetCache: () => cacheAdapter.reset(),
 			flushRedis: () => redisMock.flushall(),

--- a/apps/api/test/e2e/helpers/e2e-test-state.ts
+++ b/apps/api/test/e2e/helpers/e2e-test-state.ts
@@ -30,20 +30,18 @@ export function createE2eTestStateResetter({
 
 	return async () => {
 		const errors: Error[] = [];
-		let backgroundWorkDrained = true;
 		if (drainBackgroundWork) {
 			try {
 				await drainBackgroundWork();
 			} catch (error) {
-				backgroundWorkDrained = false;
 				errors.push(normalizeError(error));
 			}
 		}
 
-		const resetters = [
-			...(backgroundWorkDrained ? [cleanupDatabase] : []),
-			...nonDatabaseResetters,
-		];
+		// drain 실패 여부와 무관하게 DB는 항상 정리한다 — TRUNCATE를 건너뛰면
+		// 오염이 다음 테스트로 전파되어 실패가 연쇄된다. drain 에러는 아래
+		// AggregateError로 함께 보고되므로 은폐되지 않는다.
+		const resetters = [cleanupDatabase, ...nonDatabaseResetters];
 		const results = await Promise.allSettled(
 			resetters.map(async (resetter) => resetter()),
 		);

--- a/apps/api/test/e2e/helpers/tracking-domain-event-publisher.ts
+++ b/apps/api/test/e2e/helpers/tracking-domain-event-publisher.ts
@@ -1,0 +1,51 @@
+import { Logger } from "@nestjs/common";
+import type { EventEmitter2 } from "@nestjs/event-emitter";
+import type { DomainEventPublisherPort } from "@/shared/application/ports";
+import type { DomainEvent } from "@/shared/domain/aggregate-root";
+
+/**
+ * E2E 전용 도메인 이벤트 퍼블리셔 (추적 데코레이터)
+ *
+ * 프로덕션 퍼블리셔와 동일하게 커밋 후 fire-and-forget으로 발행하되,
+ * `emitAsync`가 반환하는 리스너 프라미스를 pending set에 등록해 테스트
+ * reset이 TRUNCATE 전에 잔류 이벤트 작업을 drain할 수 있게 한다.
+ * (미대기 이벤트 부수효과가 다음 테스트의 TRUNCATE와 경합하는 플레이크 방지.
+ *  inline await는 하지 않으므로 발행 시점의 타이밍 의미는 프로덕션과 동일.)
+ */
+export class TrackingDomainEventPublisher implements DomainEventPublisherPort {
+	readonly #logger = new Logger(TrackingDomainEventPublisher.name);
+	readonly #pending = new Set<Promise<unknown>>();
+
+	constructor(private readonly eventEmitter: EventEmitter2) {}
+
+	publishAll(events: readonly DomainEvent[]): void {
+		for (const event of events) {
+			const settled: Promise<unknown> = this.eventEmitter
+				.emitAsync(event.eventName, event)
+				.catch((error) => {
+					this.#logger.error(
+						`Failed to publish domain event ${event.eventName}: ${error}`,
+						error instanceof Error ? error.stack : undefined,
+					);
+				})
+				.finally(() => {
+					this.#pending.delete(settled);
+				});
+			this.#pending.add(settled);
+		}
+	}
+
+	/** 진행 중인 이벤트 리스너 작업이 전부 정착할 때까지 대기 (핸들러의 연쇄 발행 포함) */
+	async drainPendingEvents(): Promise<void> {
+		let rounds = 0;
+		while (this.#pending.size > 0) {
+			rounds += 1;
+			if (rounds > 25) {
+				throw new Error(
+					"Domain event drain exceeded 25 rounds — 이벤트 연쇄 루프 의심",
+				);
+			}
+			await Promise.allSettled([...this.#pending]);
+		}
+	}
+}

--- a/apps/api/test/setup/e2e-test-state.spec.ts
+++ b/apps/api/test/setup/e2e-test-state.spec.ts
@@ -57,7 +57,9 @@ describe("E2E 테스트 상태 reset", () => {
 		expect(cleanupDatabase).toHaveBeenCalledTimes(1);
 	});
 
-	it("백그라운드 drain 실패 시 DB는 보호하고 나머지 상태를 초기화해야 한다", async () => {
+	it("백그라운드 drain이 실패해도 DB를 포함한 모든 상태를 초기화하고 에러를 보고해야 한다", async () => {
+		// drain 실패 시 TRUNCATE를 건너뛰면 오염이 다음 테스트로 전파되므로
+		// DB 정리는 항상 수행하고, drain 에러는 AggregateError로 함께 드러낸다
 		const drainError = new Error("drain failed");
 		const drainBackgroundWork = jest.fn().mockRejectedValue(drainError);
 		const cleanupDatabase = jest.fn();
@@ -78,7 +80,7 @@ describe("E2E 테스트 상태 reset", () => {
 				expect.objectContaining({ message: "cache failed" }),
 			],
 		});
-		expect(cleanupDatabase).not.toHaveBeenCalled();
+		expect(cleanupDatabase).toHaveBeenCalledTimes(1);
 		expect(resetCache).toHaveBeenCalledTimes(1);
 		expect(flushRedis).toHaveBeenCalledTimes(1);
 		expect(clearFake).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 요약

간헐적 E2E 실패(1~2 테스트 실패 → 재실행 통과)의 **근본 원인을 특정하고 제거**합니다. 무차별 재시도(retryTimes) 같은 마스킹은 도입하지 않았습니다.

## 근본 원인 (코드 증거 기반)

`TodoToggled` 이벤트 핸들러가 커밋 후 `void`로 띄운 비동기 DB 쓰기(스트릭 갱신 → user_preference 등)를 **아무도 await하지 않아**, 다음 테스트의 `beforeEach` TRUNCATE와 경합했습니다. `jest randomize: true`라 피해 테스트가 시드마다 달라져 "간헐적 1~2건 실패"로 나타났습니다. (워커 병렬성·포트 경합·BullMQ·Redis는 전부 직렬/mock이라 구조적으로 배제 — 전수 조사 완료)

## 변경 (기존 유저 영향 0)

| 구분 | 내용 |
|---|---|
| 프로덕션 (동작 보존) | 핸들러의 `void` 발사 3건 → 본문이 `await Promise.allSettled`로 소유. **emit 관점 fire-and-forget·실패 로깅 그대로** — 응답 지연·에러 전파·순서 모두 불변. `StreakPort.recordTodoToggle`을 Promise 반환으로 정리 |
| 테스트 하니스 | `DOMAIN_EVENT_PUBLISHER`를 추적 데코레이터로 오버라이드 (`emitAsync` 공식 API + pending set) → reset이 **이벤트 작업까지 drain 후 TRUNCATE** |
| 격리 구멍 폐쇄 | drain 실패 시 TRUNCATE를 건너뛰어 오염이 전파되던 분기 제거 — DB 정리 항상 수행, 에러는 AggregateError로 보고 |
| CI 진단 가능성 | 테스트 실패 시 전체 로그 아티팩트 업로드 (`actions/upload-artifact` SHA 핀, 14일 보존) — `showSeed`로 시드가 남아 `--seed` 고정 재현 가능 |

## 검증

- **수정 후 E2E 스트레스 8회 (서로 다른 랜덤 시드 8종): 394/394 전부 그린, FAIL 0**
- `openapi-contract` 스냅샷 **diff 0** (API 계약 불변 — 기존 클라 영향 0 증명)
- 통합 336/336 · 유닛 2,305 통과 · `lint:boundaries`/`lint:no-cast` 클린아키 게이트 통과
- 수정 전 4회 재현 시도는 전부 그린(저빈도 특성) — 원인은 코드 레벨 증거로 확정

## 머지 시 유의

`--merge` 필수 (§3.7), 머지 후 develop ff-only 동기화. api 소스 변경이라 배포 ~7분(builder 재빌드 티어) 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)