### PR TITLE
fix(api): legacy Redis scheduler 중복 실행 방지

### DIFF
--- a/apps/api/src/shared/infrastructure/jobs/bullmq-job-runtime.adapter.spec.ts
+++ b/apps/api/src/shared/infrastructure/jobs/bullmq-job-runtime.adapter.spec.ts
@@ -7,7 +7,7 @@ import {
 	type BullWorkerClient,
 } from "./bullmq-job-runtime.adapter";
 
-const QUEUE = "document-generation";
+const QUEUE = "document-generation.v1";
 
 function options(
 	overrides: Partial<EnqueueJobOptions> = {},
@@ -210,6 +210,9 @@ describe("BullMqJobRuntimeAdapter — Redis rollback runtime", () => {
 				}),
 			},
 		]);
+		expect(
+			factory.queues.get("document-generation")?.removedScheduleKeys,
+		).toEqual(["weekly-document"]);
 	});
 
 	it("worker가 신규 wrapper와 기존 raw payload를 같은 envelope로 전달한다", async () => {

--- a/apps/api/src/shared/infrastructure/jobs/bullmq-job-runtime.adapter.ts
+++ b/apps/api/src/shared/infrastructure/jobs/bullmq-job-runtime.adapter.ts
@@ -19,6 +19,10 @@ import { REDIS_CLIENT } from "@/shared/infrastructure/redis";
 
 export const BULLMQ_CLIENT_FACTORY = Symbol("BULLMQ_CLIENT_FACTORY");
 
+export function legacyQueueName(queueName: string): string | null {
+	return queueName.endsWith(".v1") ? queueName.slice(0, -3) : null;
+}
+
 export interface BullJobClient {
 	readonly id?: string;
 	readonly name: string;
@@ -261,6 +265,10 @@ export class BullMqJobRuntimeAdapter implements JobRuntimePort {
 				opts: jobOptions,
 			},
 		);
+		const legacyQueue = legacyQueueName(queueName);
+		if (legacyQueue) {
+			await this.queue(legacyQueue).removeJobScheduler(scheduleKey);
+		}
 	}
 
 	async unschedule(scheduleKey: string, queueName: string): Promise<void> {

--- a/apps/api/src/shared/infrastructure/jobs/job-runtime.module.spec.ts
+++ b/apps/api/src/shared/infrastructure/jobs/job-runtime.module.spec.ts
@@ -78,6 +78,10 @@ describe("selectJobRuntime — backend 선택", () => {
 			"paid-document-daily",
 			"paid-document.v1",
 		);
+		expect(redis.unschedule).toHaveBeenCalledWith(
+			"paid-document-daily",
+			"paid-document",
+		);
 	});
 
 	it.each<JobBackend>(["postgres", "redis"])(

--- a/apps/api/src/shared/infrastructure/jobs/job-runtime.module.ts
+++ b/apps/api/src/shared/infrastructure/jobs/job-runtime.module.ts
@@ -22,6 +22,7 @@ import type { EnvConfig } from "@/shared/infrastructure/config";
 import {
 	BullMqJobRuntimeAdapter,
 	bullMqClientFactoryProvider,
+	legacyQueueName,
 } from "./bullmq-job-runtime.adapter";
 import {
 	PgBossJobRuntimeAdapter,
@@ -65,6 +66,10 @@ export class RedisDrainJobRuntime implements JobRuntimePort {
 		// BullMQ repeat metadata creates jobs independently of workers. Remove the
 		// Redis scheduler so the legacy queue can actually reach zero while draining.
 		await this.redis.unschedule(scheduleKey, queue);
+		const legacyQueue = legacyQueueName(queue);
+		if (legacyQueue) {
+			await this.redis.unschedule(scheduleKey, legacyQueue);
+		}
 	}
 
 	async unschedule(scheduleKey: string, queue: string): Promise<void> {


### PR DESCRIPTION
## 배경

PR #679의 첫 production 호환 배포는 의도대로 기존 Redis backend에서 정상 기동했습니다. 운영 Redis를 계수하는 과정에서 `.v1` scheduler와 과거 unversioned legacy scheduler metadata가 함께 존재하는 것을 확인했습니다. worker 호환만으로는 기존 repeat metadata가 계속 새 marker job을 생성하므로, drain이 끝나지 않거나 정기 작업이 중복 실행될 수 있습니다.

## 변경

- BullMQ rollback runtime이 `.v1` scheduler를 upsert할 때 동일 key의 unversioned legacy scheduler를 자동 제거
- PostgreSQL + Redis drain runtime도 새 scheduler 등록 시 `.v1`과 legacy Redis scheduler를 모두 제거
- 일반 queue 이름에는 적용하지 않고 `.v1` naming convention에만 제한

## 운영 조치

production에 이미 남아 있던 legacy scheduler 10개는 key를 정확히 지정해 제거했습니다. 대기 중인 마지막 delayed marker는 legacy worker가 정상 소진하며, 신규 작업은 계속 현재 backend에 기록됩니다.

## 안전성

- enqueue/worker/API/세션 동작 변경 없음
- `.v1` scheduler는 유지
- Redis rollback 시에도 신규 `.v1` scheduler는 정상 동작
- unit tests 13/13, API typecheck, full pre-commit typecheck/build 통과

Refs #678
