### PR TITLE
fix(api): pg-boss 정기 작업 전달 오류 수정

### DIFF
--- a/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.spec.ts
+++ b/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.spec.ts
@@ -211,6 +211,7 @@ describe("PgBossJobRuntimeAdapter — PostgreSQL durable runtime", () => {
 				tz: "Asia/Seoul",
 			},
 		});
+		expect(boss.scheduleCalls[0]?.options).not.toHaveProperty("db");
 	});
 
 	it("worker batch를 vendor-neutral envelope로 변환한다", async () => {

--- a/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.ts
+++ b/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.ts
@@ -249,8 +249,12 @@ export class PgBossJobRuntimeAdapter implements JobRuntimePort {
 			await this.ensureQueue(options.deadLetter);
 		}
 		await this.ensureQueue(queue);
+		const { db: _transactionDb, ...persistedOptions } = this.toPgBossOptions(
+			options,
+			this.transactionDatabase(),
+		);
 		await this.boss.schedule(queue, cron, data, {
-			...this.toPgBossOptions(options, this.transactionDatabase()),
+			...persistedOptions,
 			key: scheduleKey,
 			tz: options.timezone,
 		});


### PR DESCRIPTION
## 배경

PostgreSQL durable job runtime 운영 전환 후 API health는 정상이었지만, pg-boss가 주기적으로 `TypeError` 이벤트를 기록했습니다. 최근 30분의 업무 큐에는 retry/failed 작업이 없었고 일반 enqueue 및 worker 소비는 정상이어서 cron 전달 경로를 별도로 추적했습니다.

## 근본 원인

`PgBossJobRuntimeAdapter.schedule()`이 CLS 트랜잭션용 `db` 핸들을 `ScheduleOptions`에 포함했습니다.

- pg-boss는 schedule options를 JSONB에 영속화합니다.
- 함수인 `executeSql`은 직렬화되지 않아 운영 schedule에는 `db: {}`가 저장됐습니다.
- cron tick에서 pg-boss가 저장된 options로 실제 작업을 전달할 때 `{}`를 DB 객체로 오인했습니다.
- 결과적으로 `db.executeSql is not a function` 계열 `TypeError`가 발생해 정기 작업 전달이 차단됐습니다.

운영의 9개 schedule에서 `optionKeys`와 `dbValue: {}`를 payload 없이 확인해 원인을 확증했습니다.

## 변경 사항

- `schedule()`이 pg-boss에 넘기는 영속 options에서만 `db`를 제외합니다.
- `enqueue()`와 `cancel()`의 CLS 트랜잭션 결합은 그대로 유지합니다.
- 앱 재시작 시 동일 schedule key를 upsert하므로 기존 `db: {}` 데이터도 정상 options로 자동 교정됩니다.
- `ScheduleOptions`에 `db`가 포함되지 않는 회귀 테스트를 추가했습니다.

## 클라이언트 영향

- API 계약, DTO, 인증/세션, 모바일 코드 변경 없음
- 기존 사용자 로그아웃 없음
- DB schema migration 없음
- 재배포 중 작업은 PostgreSQL에 유지되며 worker graceful shutdown 90초 정책 유지

## 장점

- cron 작업이 pg-boss의 기본 DB 연결을 사용해 정상 전달됩니다.
- 비직렬화 런타임 객체가 영속 schedule 데이터에 섞이지 않습니다.
- enqueue의 transaction-aware atomicity는 유지됩니다.

## 단점 / 트레이드오프

- schedule 등록 자체는 호출자의 CLS 트랜잭션에 묶이지 않습니다. 다만 schedule은 애플리케이션 시작 시 idempotent upsert되는 운영 설정이며, 업무 트랜잭션과 원자적으로 생성되는 데이터가 아닙니다.
- 기존 schedule 정정은 배포 후 애플리케이션 bootstrap upsert에 의존합니다. 배포 검증에서 운영 schedule options를 다시 감사합니다.

## 검증

- TDD red: `options.db`가 존재해 신규 회귀 테스트 실패 확인
- TDD green: adapter spec 7/7 통과
- API unit: 292 suites, 2,310 passed, 4 skipped
- `pnpm typecheck` 통과
- `pnpm lint` 통과
- pre-commit `pnpm build` 통과

## 운영 검증 계획

1. develop CI 전체 통과
2. develop merge 후 develop → main release PR
3. 운영 배포 SHA/health/PostgreSQL backend 확인
4. schedule options에서 `db` key가 사라졌는지 확인
5. 5초/1분 cron tick 이후 pg-boss TypeError가 재발하지 않는지 확인
6. `main`과 `develop`을 동일 merge SHA로 동기화

Related to #678
