### PR TITLE
fix(release): pg-boss 정기 작업 전달 정상화

### DIFF
--- a/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.spec.ts
+++ b/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.spec.ts
@@ -211,6 +211,7 @@ describe("PgBossJobRuntimeAdapter — PostgreSQL durable runtime", () => {
 				tz: "Asia/Seoul",
 			},
 		});
+		expect(boss.scheduleCalls[0]?.options).not.toHaveProperty("db");
 	});
 
 	it("worker batch를 vendor-neutral envelope로 변환한다", async () => {

--- a/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.ts
+++ b/apps/api/src/shared/infrastructure/jobs/pg-boss-job-runtime.adapter.ts
@@ -249,8 +249,12 @@ export class PgBossJobRuntimeAdapter implements JobRuntimePort {
 			await this.ensureQueue(options.deadLetter);
 		}
 		await this.ensureQueue(queue);
+		const { db: _transactionDb, ...persistedOptions } = this.toPgBossOptions(
+			options,
+			this.transactionDatabase(),
+		);
 		await this.boss.schedule(queue, cron, data, {
-			...this.toPgBossOptions(options, this.transactionDatabase()),
+			...persistedOptions,
 			key: scheduleKey,
 			tz: options.timezone,
 		});


### PR DESCRIPTION
## Release 목적

운영 PostgreSQL job runtime에서 발견된 pg-boss 정기 작업 전달 `TypeError`를 수정합니다. API/클라이언트 계약 변경 없이 schedule options의 직렬화 경계를 바로잡는 단일 hotfix입니다.

## 운영 진단 근거

- 외부 health: HTTP 200, queue backend `postgres`, `degraded=false`
- 일반 업무 큐: 최근 30분 retry/failed 0건
- 운영 schedule 9개 전부에서 영속 options의 `dbValue: {}` 확인
- pg-boss cron tick이 `{}`를 DB 핸들로 사용하며 정기 작업 전달을 차단하는 원인 확증

## 변경

- CLS transaction DB 핸들을 `schedule()`의 영속 options에서 제외
- `enqueue()`/`cancel()`의 transaction-aware 동작 유지
- 앱 bootstrap의 동일-key upsert로 기존 잘못된 schedule options 자동 정정
- `db` 비영속 회귀 테스트 추가

## 사용자/클라이언트 영향

- API schema/DTO 변경 없음
- 모바일 변경 없음
- 인증 토큰/세션 저장 방식 변경 없음, 기존 사용자 로그아웃 없음
- DB migration 없음
- PostgreSQL durable queue와 graceful shutdown 정책 유지

## Pros

- 5초/1분/일간/주간/monthly cron 전달 정상화
- 직렬화할 수 없는 런타임 객체의 schedule 영속화 방지
- transaction-aware 일반 enqueue의 안전성 유지

## Cons / 트레이드오프

- schedule upsert 자체는 CLS 업무 트랜잭션과 분리됩니다. 이 경로는 애플리케이션 bootstrap의 idempotent 운영 설정이므로 업무 데이터 원자성 요구 대상이 아닙니다.
- 배포 직후 schedule upsert 및 최소 1분 이상의 cron 관찰 검증이 필요합니다.

## 검증 완료

- TDD red/green 확인
- adapter spec: 7/7
- API unit: 292 suites, 2,310 passed, 4 skipped
- local typecheck/lint/build 통과
- PR #681 CI: build, lint/typecheck, unit, integration, E2E 전부 통과

## 배포 후 확인

1. 운영 SHA 확인
2. `/health` HTTP 200, backend postgres, degraded=false
3. schedule options에서 `db` key 제거 확인
4. 5초/1분 cron tick 후 TypeError 미재발 확인
5. ElastiCache가 삭제된 상태에서도 정상 동작 확인
6. main → develop 동기화로 동일 SHA 유지

Includes #681
Related to #678
