### PR TITLE
fix(api): 카테고리 변경 시 daily-completion 캐시 무효화 [Phase 1/7]

### DIFF
--- a/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.spec.ts
+++ b/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.spec.ts
@@ -7,7 +7,12 @@
 import { Logger } from "@nestjs/common";
 import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
-import { TODO_EVENTS, TodoCreatedEvent, TodoToggledEvent } from "@/todo";
+import {
+	TODO_EVENTS,
+	TodoCategoryChangedEvent,
+	TodoCreatedEvent,
+	TodoToggledEvent,
+} from "@/todo";
 import {
 	DAILY_COMPLETION_CACHE,
 	type DailyCompletionCachePort,
@@ -34,7 +39,7 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 		cache = unitRef.get<DailyCompletionCachePort>(DAILY_COMPLETION_CACHE);
 	});
 
-	it("5개 투두 쓰기 이벤트를 각각 개별 구독한다 (배열 인자는 결합된 단일 이벤트명이 되므로 회귀 방지)", () => {
+	it("6개 투두 쓰기 이벤트를 각각 개별 구독한다 (배열 인자는 결합된 단일 이벤트명이 되므로 회귀 방지)", () => {
 		// Given - @OnEvent가 남긴 메타데이터 (@nestjs/event-emitter 공개 상수)
 		const eventListenerMetadata: unknown = Reflect.getMetadata(
 			// EVENT_LISTENER_METADATA — 데코레이터가 handle 메서드에 기록하는 키
@@ -47,7 +52,7 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 			? eventListenerMetadata.map((m: { event: string }) => m.event)
 			: [];
 
-		// Then - 5개 이벤트가 문자열로 각각 구독되어야 한다
+		// Then - 6개 이벤트가 문자열로 각각 구독되어야 한다
 		expect(subscribed.sort()).toEqual(
 			[
 				TODO_EVENTS.CREATED,
@@ -55,6 +60,7 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 				TODO_EVENTS.TOGGLED,
 				TODO_EVENTS.RESCHEDULED,
 				TODO_EVENTS.UPDATED,
+				TODO_EVENTS.CATEGORY_CHANGED,
 			].sort(),
 		);
 	});
@@ -79,6 +85,17 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 
 		// Then
 		expect(cache.invalidate).toHaveBeenCalledWith("user-456");
+	});
+
+	it("카테고리 변경 이벤트도 동일하게 무효화한다 (캘린더 색상 스테일 방지)", async () => {
+		// Given
+		const event = new TodoCategoryChangedEvent(3, "user-789", 2);
+
+		// When
+		await invalidator.handle(event);
+
+		// Then
+		expect(cache.invalidate).toHaveBeenCalledWith("user-789");
 	});
 
 	it("캐시 무효화 실패는 삼키고 로깅한다 (fire-and-forget)", async () => {

--- a/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.ts
+++ b/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Logger } from "@nestjs/common";
 import { OnEvent } from "@nestjs/event-emitter";
 import {
 	TODO_EVENTS,
+	type TodoCategoryChangedEvent,
 	type TodoCreatedEvent,
 	type TodoDeletedEvent,
 	type TodoRescheduledEvent,
@@ -19,7 +20,8 @@ type TodoWriteEvent =
 	| TodoDeletedEvent
 	| TodoToggledEvent
 	| TodoRescheduledEvent
-	| TodoUpdatedEvent;
+	| TodoUpdatedEvent
+	| TodoCategoryChangedEvent;
 
 /**
  * 투두 쓰기 이벤트 구독 → 일별 완료 캐시 무효화 핸들러
@@ -43,6 +45,7 @@ export class DailyCompletionCacheInvalidator {
 	@OnEvent(TODO_EVENTS.TOGGLED)
 	@OnEvent(TODO_EVENTS.RESCHEDULED)
 	@OnEvent(TODO_EVENTS.UPDATED)
+	@OnEvent(TODO_EVENTS.CATEGORY_CHANGED)
 	async handle(event: TodoWriteEvent): Promise<void> {
 		try {
 			await this.cache.invalidate(event.userId);

--- a/apps/api/src/todo/application/use-cases/change-todo-category/change-todo-category.use-case.spec.ts
+++ b/apps/api/src/todo/application/use-cases/change-todo-category/change-todo-category.use-case.spec.ts
@@ -18,8 +18,13 @@ import {
 	createTodoRepositoryMock,
 	createUnitOfWorkMock,
 } from "@test/mocks/ports";
-import { UNIT_OF_WORK } from "@/shared/application/ports";
+import {
+	DOMAIN_EVENT_PUBLISHER,
+	type DomainEventPublisherPort,
+	UNIT_OF_WORK,
+} from "@/shared/application/ports";
 import { Todo } from "../../../domain/entities/todo.entity";
+import { TodoCategoryChangedEvent } from "../../../domain/events/todo-category-changed.event";
 import { TodoId } from "../../../domain/value-objects/todo-id.vo";
 import { TodoSchedule } from "../../../domain/value-objects/todo-schedule.vo";
 import { TodoMapper } from "../../../infrastructure/persistence/todo-response.mapper";
@@ -73,6 +78,7 @@ describe("ChangeTodoCategoryUseCase — 할 일 카테고리 변경 핸들러", 
 	let todoReadRepository: Mocked<TodoReadRepositoryPort>;
 	let categoryOwnership: Mocked<CategoryOwnershipPort>;
 	let todoCache: Mocked<TodoCachePort>;
+	let eventPublisher: Mocked<DomainEventPublisherPort>;
 
 	beforeEach(async () => {
 		const { unit, unitRef } = await TestBed.solitary(ChangeTodoCategoryUseCase)
@@ -86,6 +92,8 @@ describe("ChangeTodoCategoryUseCase — 할 일 카테고리 변경 핸들러", 
 			.impl(() => createCategoryOwnershipMock())
 			.mock<TodoCachePort>(TODO_CACHE)
 			.impl(() => createTodoCacheMock())
+			.mock<DomainEventPublisherPort>(DOMAIN_EVENT_PUBLISHER)
+			.impl(() => ({ publishAll: jest.fn() }))
 			.compile();
 
 		useCase = unit;
@@ -94,6 +102,9 @@ describe("ChangeTodoCategoryUseCase — 할 일 카테고리 변경 핸들러", 
 			unitRef.get<TodoReadRepositoryPort>(TODO_READ_REPOSITORY);
 		categoryOwnership = unitRef.get<CategoryOwnershipPort>(CATEGORY_OWNERSHIP);
 		todoCache = unitRef.get<TodoCachePort>(TODO_CACHE);
+		eventPublisher = unitRef.get<DomainEventPublisherPort>(
+			DOMAIN_EVENT_PUBLISHER,
+		);
 	});
 
 	it("활성(미완료) 할 일은 TX 안에서 한도 체크 후 이동하고 캐시를 무효화한다", async () => {
@@ -121,6 +132,21 @@ describe("ChangeTodoCategoryUseCase — 할 일 카테고리 변경 핸들러", 
 		expect(todoRepository.updateCategory).toHaveBeenCalledWith(1, 2);
 		expect(todoCache.invalidateTodoCategories).toHaveBeenCalledWith("user-123");
 		expect(result.id).toBe(1);
+	});
+
+	it("카테고리 변경 후 TodoCategoryChangedEvent를 발행한다 (daily-completion 캐시 무효화 트리거)", async () => {
+		// Given
+		todoRepository.findByIdAndUserId.mockResolvedValue(buildEntity());
+		todoRepository.countActiveByCategory.mockResolvedValue(0);
+		todoReadRepository.findByIdAndUserId.mockResolvedValue(buildResponse());
+
+		// When
+		await useCase.execute({ id: 1, userId: "user-123", categoryId: 2 });
+
+		// Then - 커밋 후 카테고리 변경 이벤트 발행 (색상 집계 캐시 스테일 방지)
+		expect(eventPublisher.publishAll).toHaveBeenCalledWith([
+			new TodoCategoryChangedEvent(1, "user-123", 2),
+		]);
 	});
 
 	it("대상 카테고리가 가득 차면 ApplicationException(TODO_0811)을 던진다", async () => {

--- a/apps/api/src/todo/application/use-cases/change-todo-category/change-todo-category.use-case.ts
+++ b/apps/api/src/todo/application/use-cases/change-todo-category/change-todo-category.use-case.ts
@@ -2,7 +2,12 @@ import { ErrorCode } from "@aido/errors";
 import type { Todo as TodoResponse } from "@aido/validators";
 import { TODO_LIMITS } from "@aido/validators";
 import { Inject, Injectable, Logger } from "@nestjs/common";
-import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import {
+	DOMAIN_EVENT_PUBLISHER,
+	type DomainEventPublisherPort,
+	UNIT_OF_WORK,
+	type UnitOfWorkPort,
+} from "@/shared/application/ports";
 import { ApplicationException } from "@/shared/domain";
 import {
 	CATEGORY_OWNERSHIP,
@@ -47,6 +52,8 @@ export class ChangeTodoCategoryUseCase {
 		private readonly categoryOwnership: CategoryOwnershipPort,
 		@Inject(TODO_CACHE)
 		private readonly todoCache: TodoCachePort,
+		@Inject(DOMAIN_EVENT_PUBLISHER)
+		private readonly eventPublisher: DomainEventPublisherPort,
 	) {}
 
 	async execute(input: ChangeTodoCategoryInput): Promise<TodoResponse> {
@@ -56,7 +63,7 @@ export class ChangeTodoCategoryUseCase {
 		await this.categoryOwnership.validateOwnership(categoryId, userId);
 
 		// 2. TX 안에서 로드 → 애그리게잇 전이 → 활성 할 일만 한도 체크 후 영속화 (race 방지)
-		await this.uow.run(async () => {
+		const events = await this.uow.run(async () => {
 			const todo = await this.todoRepository.findByIdAndUserId(id, userId);
 			if (!todo) {
 				throw new ApplicationException(ErrorCode.TODO_0801, { todoId: id });
@@ -78,9 +85,13 @@ export class ChangeTodoCategoryUseCase {
 				}
 			}
 			await this.todoRepository.updateCategory(id, targetCategoryId);
+			return todo.pullDomainEvents();
 		});
 
-		// 3. 캐시 무효화 (todoCount 변경)
+		// 3. 저장(TX 커밋) 완료 후 이벤트 발행 (daily-completion 캐시 무효화 트리거)
+		this.eventPublisher.publishAll(events);
+
+		// 4. 캐시 무효화 (todoCount 변경)
 		await this.todoCache.invalidateTodoCategories(userId);
 		await this.todoCache.invalidateFriendTodos(userId);
 
@@ -88,7 +99,7 @@ export class ChangeTodoCategoryUseCase {
 			`Todo category updated: ${id} -> ${categoryId} for user: ${userId}`,
 		);
 
-		// 4. 응답 재조회
+		// 5. 응답 재조회
 		const response = await this.todoReadRepository.findByIdAndUserId(
 			id,
 			userId,

--- a/apps/api/src/todo/domain/entities/todo.entity.spec.ts
+++ b/apps/api/src/todo/domain/entities/todo.entity.spec.ts
@@ -7,6 +7,7 @@
 import { ErrorCode } from "@aido/errors";
 import { TODO_ITEM_LIMITS } from "@aido/validators";
 import { DomainException } from "@/shared/domain";
+import { TodoCategoryChangedEvent } from "../events/todo-category-changed.event";
 import { TodoCreatedEvent } from "../events/todo-created.event";
 import { TodoRescheduledEvent } from "../events/todo-rescheduled.event";
 import { TodoToggledEvent } from "../events/todo-toggled.event";
@@ -445,16 +446,24 @@ describe("Todo — 할 일 애그리게잇", () => {
 			expect(todo.pullDomainEvents()).toHaveLength(0);
 		});
 
-		it("카테고리를 변경하고 이벤트는 적립하지 않는다", () => {
+		it("카테고리를 변경하고 TodoCategoryChangedEvent를 적립한다 (일별 완료 색상 집계 캐시 무효화)", () => {
 			// Given
-			const todo = Todo.reconstitute(buildProps({ categoryId: 1 }));
+			const todo = Todo.reconstitute(
+				buildProps({ id: TodoId.create(3), userId: "user-1", categoryId: 1 }),
+			);
 
 			// When
 			todo.changeCategory(7);
 
 			// Then
 			expect(todo.toPersistence().categoryId).toBe(7);
-			expect(todo.pullDomainEvents()).toHaveLength(0);
+			const event = todo.pullDomainEvents()[0];
+			expect(event).toBeInstanceOf(TodoCategoryChangedEvent);
+			if (event instanceof TodoCategoryChangedEvent) {
+				expect(event.todoId).toBe(3);
+				expect(event.userId).toBe("user-1");
+				expect(event.categoryId).toBe(7);
+			}
 		});
 	});
 

--- a/apps/api/src/todo/domain/entities/todo.entity.ts
+++ b/apps/api/src/todo/domain/entities/todo.entity.ts
@@ -2,6 +2,7 @@ import { ErrorCode } from "@aido/errors";
 import { TODO_ITEM_LIMITS } from "@aido/validators";
 import { AggregateRoot, DomainException } from "@/shared/domain";
 import { now } from "@/shared/domain/date/utils/core";
+import { TodoCategoryChangedEvent } from "../events/todo-category-changed.event";
 import { TodoCreatedEvent } from "../events/todo-created.event";
 import { TodoDeletedEvent } from "../events/todo-deleted.event";
 import { TodoRescheduledEvent } from "../events/todo-rescheduled.event";
@@ -316,11 +317,20 @@ export class Todo extends AggregateRoot<TodoProps> {
 	/**
 	 * 카테고리를 변경합니다 (PATCH /todos/:id/category).
 	 *
-	 * 소유권·활성 여부 검증은 애플리케이션 계층(포트) 책임이며,
-	 * 부수효과가 없는 단순 상태 전이라 이벤트를 적립하지 않습니다.
+	 * 소유권·활성 여부 검증은 애플리케이션 계층(포트) 책임입니다.
+	 * 일별 완료 통계가 할 일의 카테고리 색상을 집계하므로, 카테고리 변경은
+	 * TodoCategoryChangedEvent를 적립해 daily-completion 캐시 무효화를 트리거합니다
+	 * (부수효과는 커밋 후 크로스모듈 @OnEvent 구독자가 처리).
 	 */
 	changeCategory(categoryId: number): void {
 		this.props.categoryId = categoryId;
+		this.raise(
+			new TodoCategoryChangedEvent(
+				this.props.id.getValue(),
+				this.props.userId,
+				categoryId,
+			),
+		);
 	}
 
 	// ── 하위 항목 (자식 엔티티) ───────────────────────────────────────────

--- a/apps/api/src/todo/domain/events/todo-category-changed.event.ts
+++ b/apps/api/src/todo/domain/events/todo-category-changed.event.ts
@@ -1,0 +1,18 @@
+/**
+ * Todo 카테고리 변경 도메인 이벤트 (PATCH /todos/:id/category)
+ *
+ * 일별 완료 통계는 각 할 일의 카테고리 색상을 일자별로 집계하므로,
+ * 카테고리가 바뀌면 daily-completion 캐시(캘린더 dot 색상)가 스테일해집니다.
+ * 무효화 부수효과는 크로스모듈 @OnEvent 구독자가 커밋 후 처리합니다.
+ */
+import { TODO_EVENTS } from "./todo-event-names";
+
+export class TodoCategoryChangedEvent {
+	readonly eventName = TODO_EVENTS.CATEGORY_CHANGED;
+
+	constructor(
+		public readonly todoId: number,
+		public readonly userId: string,
+		public readonly categoryId: number,
+	) {}
+}

--- a/apps/api/src/todo/domain/events/todo-event-names.ts
+++ b/apps/api/src/todo/domain/events/todo-event-names.ts
@@ -10,4 +10,5 @@ export const TODO_EVENTS = {
 	DELETED: "todo.deleted",
 	TOGGLED: "todo.toggled",
 	RESCHEDULED: "todo.rescheduled",
+	CATEGORY_CHANGED: "todo.category-changed",
 } as const;

--- a/apps/api/src/todo/index.ts
+++ b/apps/api/src/todo/index.ts
@@ -8,6 +8,7 @@
  */
 export { TodoFacade } from "./application/facades/todo.facade";
 export type { CreateRecurringTodosResult } from "./application/use-cases/create-recurring-todos/create-recurring-todos.use-case";
+export * from "./domain/events/todo-category-changed.event";
 export * from "./domain/events/todo-created.event";
 export * from "./domain/events/todo-deleted.event";
 export * from "./domain/events/todo-event-names";

--- a/apps/api/src/user-settings/application/use-cases/upsert-push-timezone/upsert-push-timezone.use-case.spec.ts
+++ b/apps/api/src/user-settings/application/use-cases/upsert-push-timezone/upsert-push-timezone.use-case.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * UpsertPushTimezoneUseCase 단위 테스트
+ *
+ * 푸시 토큰 등록 시 타임존 upsert 후 activeTimezones 캐시 무효화 검증
+ * (새 타임존이 스케줄러 활성 목록에서 누락되지 않도록 — update-preference와 대칭)
+ */
+import type { Mocked } from "@suites/doubles.jest";
+import { TestBed } from "@suites/unit";
+import { CacheService } from "@/shared/infrastructure/cache/cache.service";
+
+import {
+	USER_PREFERENCE_REPOSITORY,
+	type UserPreferenceRepositoryPort,
+} from "../../ports/user-preference.repository.port";
+import { UpsertPushTimezoneUseCase } from "./upsert-push-timezone.use-case";
+
+describe("UpsertPushTimezoneUseCase — 푸시 토큰 등록 시 타임존 upsert", () => {
+	let useCase: UpsertPushTimezoneUseCase;
+	let repo: Mocked<UserPreferenceRepositoryPort>;
+	let cache: Mocked<CacheService>;
+
+	beforeEach(async () => {
+		const { unit, unitRef } = await TestBed.solitary(
+			UpsertPushTimezoneUseCase,
+		).compile();
+		useCase = unit;
+		repo = unitRef.get(USER_PREFERENCE_REPOSITORY);
+		cache = unitRef.get(CacheService);
+	});
+
+	it("타임존을 upsert하고 activeTimezones 캐시를 무효화한다", async () => {
+		// Given
+		repo.upsertTimezone.mockResolvedValue(undefined);
+
+		// When
+		await useCase.execute("user-1", "Asia/Seoul");
+
+		// Then - upsert 후 활성 타임존 목록 캐시 무효화 (스테일 방지)
+		expect(repo.upsertTimezone).toHaveBeenCalledWith("user-1", "Asia/Seoul");
+		expect(cache.invalidateActiveTimezones).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/user-settings/application/use-cases/upsert-push-timezone/upsert-push-timezone.use-case.ts
+++ b/apps/api/src/user-settings/application/use-cases/upsert-push-timezone/upsert-push-timezone.use-case.ts
@@ -1,19 +1,27 @@
 import { Inject, Injectable } from "@nestjs/common";
+import { CacheService } from "@/shared/infrastructure/cache/cache.service";
 
 import {
 	USER_PREFERENCE_REPOSITORY,
 	type UserPreferenceRepositoryPort,
 } from "../../ports/user-preference.repository.port";
 
-/** 푸시 토큰 등록 시 타임존 upsert (notification). */
+/**
+ * 푸시 토큰 등록 시 타임존 upsert (notification).
+ *
+ * 새 타임존이 등록되면 스케줄러의 활성 타임존 목록이 스테일해지므로,
+ * upsert 후 activeTimezones 캐시를 무효화한다(update-preference와 대칭).
+ */
 @Injectable()
 export class UpsertPushTimezoneUseCase {
 	constructor(
 		@Inject(USER_PREFERENCE_REPOSITORY)
 		private readonly preferenceRepository: UserPreferenceRepositoryPort,
+		private readonly cacheService: CacheService,
 	) {}
 
-	execute(userId: string, timezone: string): Promise<void> {
-		return this.preferenceRepository.upsertTimezone(userId, timezone);
+	async execute(userId: string, timezone: string): Promise<void> {
+		await this.preferenceRepository.upsertTimezone(userId, timezone);
+		await this.cacheService.invalidateActiveTimezones();
 	}
 }


### PR DESCRIPTION
> **스택 PR 1/7** — DDD 클린아키텍처 일관성 개선 시리즈. base: `develop`

## 배경
전 모듈 클린아키 감사에서 발견된 **정합성 버그**를 수정한다. `change-todo-category`가 도메인 이벤트를 적립하지 않고 daily-completion 캐시도 무효화하지 않아, 카테고리 색상을 일자별로 집계하는 캘린더 dot 색상이 최대 10분(`CacheKeys.TTL.DAILY_COMPLETIONS`) 스테일해졌다.

## 변경
- **`TODO_EVENTS.CATEGORY_CHANGED` 신설** — `UPDATED` 재사용을 의도적으로 피함(리마인더 취소 등 기존 `UPDATED` 구독자와의 부수효과 커플링 방지). `Todo.changeCategory()`가 이벤트를 적립하고, use-case가 TX 커밋 후 `DOMAIN_EVENT_PUBLISHER.publishAll`로 발행.
- **`DailyCompletionCacheInvalidator`**가 `CATEGORY_CHANGED`를 추가 구독해 무효화 (크로스모듈 결합은 도메인 이벤트로만 — 기존 패턴 유지).
- **`activeTimezones` 스테일 수정** — `register-push-token` 경로가 타고 들어오는 `UpsertPushTimezoneUseCase`가 upsert 후 `invalidateActiveTimezones` 호출 (`update-preference`와 대칭).

## 검증
- ✅ `pnpm typecheck` / `pnpm lint` / `pnpm lint:arch` (boundaries + no-cast)
- ✅ 단위 293 스위트 / 2313 통과 (신규 이벤트·무효화 단위 커버리지 포함)
- ✅ **openapi-contract 스냅샷 diff 0 — 클라이언트 계약 무변경**

세 계층 단위 체인으로 수정 검증: 엔티티가 이벤트 적립 → use-case가 커밋 후 발행 → invalidator가 `CATEGORY_CHANGED` 구독·무효화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)