### PR TITLE
refactor(api): 구독 웹훅 오케스트레이션을 application 레이어로 이관 [Phase 3/7]

### DIFF
--- a/apps/api/src/subscription/application/facades/subscription.facade.ts
+++ b/apps/api/src/subscription/application/facades/subscription.facade.ts
@@ -1,4 +1,3 @@
-import type { RevenueCatWebhookPayload } from "@aido/validators";
 import { Injectable } from "@nestjs/common";
 
 import { HandleWebhookEventUseCase } from "../use-cases/handle-webhook-event/handle-webhook-event.use-case";
@@ -7,6 +6,7 @@ import { HandleWebhookEventUseCase } from "../use-cases/handle-webhook-event/han
  * 구독 Facade.
  *
  * 컨트롤러의 유일한 주입 대상. RevenueCat 웹훅 이벤트 처리 use-case로 위임한다.
+ * 검증·오케스트레이션은 use-case가 소유하므로 원시 본문(unknown)을 그대로 전달한다.
  */
 @Injectable()
 export class SubscriptionFacade {
@@ -14,7 +14,7 @@ export class SubscriptionFacade {
 		private readonly handleWebhookEventUseCase: HandleWebhookEventUseCase,
 	) {}
 
-	handleWebhookEvent(payload: RevenueCatWebhookPayload): Promise<void> {
-		return this.handleWebhookEventUseCase.execute(payload);
+	handleWebhookEvent(body: unknown): Promise<{ received: true }> {
+		return this.handleWebhookEventUseCase.execute(body);
 	}
 }

--- a/apps/api/src/subscription/application/ports/subscription-event-notifier.port.ts
+++ b/apps/api/src/subscription/application/ports/subscription-event-notifier.port.ts
@@ -1,3 +1,5 @@
+import type { RevenueCatWebhookPayload } from "@aido/validators";
+
 import type { SubscriptionEventPayload } from "../../domain/events/subscription-event.payload";
 
 export const SUBSCRIPTION_EVENT_NOTIFIER = Symbol(
@@ -9,8 +11,16 @@ export const SUBSCRIPTION_EVENT_NOTIFIER = Symbol(
  *
  * DB 반영 후(커밋 후) 관리자 알림(Discord) 및 결제 이슈 푸시 알림 잡을 fire-and-forget으로
  * 등록한다. 어댑터가 admin-notification·notification 큐 서비스로 위임한다.
+ * 웹훅 처리 실패 보고(에러 관측 + 관리자 알림)도 벤더(Sentry·Discord) 추상화로 노출한다.
  */
 export interface SubscriptionEventNotifierPort {
 	notifySubscriptionEvent(payload: SubscriptionEventPayload): void;
 	notifyBillingIssue(userId: string): void;
+
+	/**
+	 * 웹훅 처리 실패를 보고한다 (fire-and-forget).
+	 * 에러 관측(Sentry 태깅 캡처)과 관리자 알림(Discord)을 어댑터가 수행한다.
+	 * RevenueCat 무한 재시도 방지를 위해 호출자는 이후 200으로 응답한다.
+	 */
+	reportWebhookFailure(error: unknown, payload: RevenueCatWebhookPayload): void;
 }

--- a/apps/api/src/subscription/application/use-cases/handle-webhook-event/handle-webhook-event.use-case.spec.ts
+++ b/apps/api/src/subscription/application/use-cases/handle-webhook-event/handle-webhook-event.use-case.spec.ts
@@ -12,7 +12,6 @@ import { TestBed } from "@suites/unit";
 import { SubscriptionEventBuilder } from "@test/builders";
 import { createUnitOfWorkMock } from "@test/mocks/ports";
 import { UNIT_OF_WORK } from "@/shared/application/ports";
-import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 import { LOCK_PROVIDER } from "@/shared/infrastructure/lock";
 
 import { Subscription } from "../../../domain/entities/subscription.entity";
@@ -91,8 +90,54 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 		mockRepository.findByRevenueCatId.mockResolvedValue(null);
 	});
 
+	/**
+	 * 비-1605 처리 실패는 execute가 삼켜 200({ received: true })을 반환하고 notifier로
+	 * 보고한다(Sentry·Discord 오케스트레이션은 어댑터 소유). Lock 경합(1605)만 rethrow한다.
+	 */
+	const expectSwallowedFailure = async (
+		payload: unknown,
+		errorCode: string,
+	): Promise<void> => {
+		const result = await useCase.execute(payload);
+		expect(result).toEqual({ received: true });
+		expect(mockNotifier.reportWebhookFailure).toHaveBeenCalledWith(
+			expect.objectContaining({ errorCode }),
+			payload,
+		);
+	};
+
+	describe("오케스트레이션 (execute)", () => {
+		it("Zod 검증 실패(잘못된 본문) → 처리·보고 없이 200 반환", async () => {
+			const result = await useCase.execute({ invalid: "data" });
+
+			expect(result).toEqual({ received: true });
+			expect(mockRepository.findUserByAppUserId).not.toHaveBeenCalled();
+			expect(mockNotifier.reportWebhookFailure).not.toHaveBeenCalled();
+		});
+
+		it("빈 객체 본문 → 처리·보고 없이 200 반환", async () => {
+			const result = await useCase.execute({});
+
+			expect(result).toEqual({ received: true });
+			expect(mockRepository.findUserByAppUserId).not.toHaveBeenCalled();
+		});
+
+		it("정상 처리 → 200 반환, 실패 보고 없음", async () => {
+			const payload = SubscriptionEventBuilder.initialPurchase()
+				.withAppUserId(APP_USER_ID)
+				.withOriginalTransactionId(TXN_ID)
+				.withExpirationAtMs(FUTURE_MS)
+				.build();
+
+			const result = await useCase.execute(payload);
+
+			expect(result).toEqual({ received: true });
+			expect(mockNotifier.reportWebhookFailure).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("Lock / 사용자 조회", () => {
-		it("Lock 획득 실패 → SUBSCRIPTION_1605, DB 조회 없음", async () => {
+		it("Lock 획득 실패 → SUBSCRIPTION_1605는 rethrow(429 유도), DB 조회 없음", async () => {
 			acquireMock.mockResolvedValue(null);
 			const payload = SubscriptionEventBuilder.initialPurchase()
 				.withAppUserId(APP_USER_ID)
@@ -104,15 +149,13 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 			expect(mockRepository.findUserByAppUserId).not.toHaveBeenCalled();
 		});
 
-		it("사용자 없음 → SUBSCRIPTION_1602, release 호출", async () => {
+		it("사용자 없음 → SUBSCRIPTION_1602 보고 + 200, release 호출", async () => {
 			mockRepository.findUserByAppUserId.mockResolvedValue(null);
 			const payload = SubscriptionEventBuilder.initialPurchase()
 				.withAppUserId("rc-unknown")
 				.build();
 
-			await expect(useCase.execute(payload)).rejects.toMatchObject({
-				errorCode: "SUBSCRIPTION_1602",
-			});
+			await expectSwallowedFailure(payload, "SUBSCRIPTION_1602");
 			expect(releaseMock).toHaveBeenCalledTimes(1);
 		});
 	});
@@ -221,9 +264,7 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 				.withoutPurchasedAt()
 				.build();
 
-			await expect(useCase.execute(payload)).rejects.toMatchObject({
-				errorCode: "SUBSCRIPTION_1604",
-			});
+			await expectSwallowedFailure(payload, "SUBSCRIPTION_1604");
 		});
 
 		it("expiration_at_ms 누락 → SUBSCRIPTION_1604", async () => {
@@ -233,9 +274,7 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 				.withoutExpiration()
 				.build();
 
-			await expect(useCase.execute(payload)).rejects.toMatchObject({
-				errorCode: "SUBSCRIPTION_1604",
-			});
+			await expectSwallowedFailure(payload, "SUBSCRIPTION_1604");
 		});
 
 		it("NON_RENEWING_PURCHASE → 최초 구매 경로로 처리", async () => {
@@ -259,9 +298,7 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 				.withoutTransactionIds()
 				.build();
 
-			await expect(useCase.execute(payload)).rejects.toMatchObject({
-				errorCode: "SUBSCRIPTION_1604",
-			});
+			await expectSwallowedFailure(payload, "SUBSCRIPTION_1604");
 		});
 	});
 
@@ -296,9 +333,7 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 				.withExpirationAtMs(FUTURE_MS)
 				.build();
 
-			await expect(useCase.execute(payload)).rejects.toMatchObject({
-				errorCode: "SUBSCRIPTION_1604",
-			});
+			await expectSwallowedFailure(payload, "SUBSCRIPTION_1604");
 		});
 
 		it("동일 expiresAt으로 이미 갱신됨 → 스킵 (이벤트 미발행)", async () => {
@@ -324,9 +359,7 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 				.withoutExpiration()
 				.build();
 
-			await expect(useCase.execute(payload)).rejects.toMatchObject({
-				errorCode: "SUBSCRIPTION_1604",
-			});
+			await expectSwallowedFailure(payload, "SUBSCRIPTION_1604");
 		});
 	});
 
@@ -513,7 +546,7 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 		expect(releaseMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("핸들러 예외 시에도 release 호출 (finally)", async () => {
+	it("핸들러 예외 시에도 release 호출 (finally) + 실패 보고 후 200", async () => {
 		mockRepository.findByRevenueCatId.mockResolvedValue(null);
 		const payload = SubscriptionEventBuilder.renewal()
 			.withAppUserId(APP_USER_ID)
@@ -521,9 +554,10 @@ describe("HandleWebhookEventUseCase — RevenueCat 웹훅 처리", () => {
 			.withExpirationAtMs(FUTURE_MS)
 			.build();
 
-		await expect(useCase.execute(payload)).rejects.toBeInstanceOf(
-			ApplicationException,
-		);
+		// #process가 던져도 finally에서 release, execute는 삼켜 200 + 보고
+		const result = await useCase.execute(payload);
+		expect(result).toEqual({ received: true });
+		expect(mockNotifier.reportWebhookFailure).toHaveBeenCalledTimes(1);
 		expect(releaseMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/api/src/subscription/application/use-cases/handle-webhook-event/handle-webhook-event.use-case.ts
+++ b/apps/api/src/subscription/application/use-cases/handle-webhook-event/handle-webhook-event.use-case.ts
@@ -1,7 +1,8 @@
 import { ErrorCode } from "@aido/errors";
-import type {
-	RevenueCatEventType,
-	RevenueCatWebhookPayload,
+import {
+	type RevenueCatEventType,
+	type RevenueCatWebhookPayload,
+	revenueCatWebhookPayloadSchema,
 } from "@aido/validators";
 import { Inject, Injectable, Logger } from "@nestjs/common";
 
@@ -47,8 +48,13 @@ type RevenueCatEvent = RevenueCatWebhookPayload["event"];
 /**
  * RevenueCat 웹훅 이벤트 처리 use-case.
  *
- * 플로우: Lock 획득 → 사용자 조회 → event.id 중복 체크 → 이벤트 타입별 트랜잭션 처리 →
- * (DB 변경 시) 캐시 무효화 + 큐 잡 등록 → Lock 해제. 멱등성은 byte-identical하게 유지된다.
+ * `execute(body)`가 오케스트레이션(Zod 검증 → 처리 → 실패 보고)을 소유해 컨트롤러는
+ * thin하게 유지된다. 항상 `{ received: true }`를 반환하되, Lock 경합(SUBSCRIPTION_1605)만
+ * rethrow해 필터가 429로 변환한다(RevenueCat 재시도 유도). 그 외 에러는 notifier 포트로
+ * 보고(Sentry·Discord)한 뒤 200으로 삼켜 무한 재시도를 막는다.
+ *
+ * 처리 플로우(`#process`): Lock 획득 → 사용자 조회 → event.id 중복 체크 → 이벤트 타입별
+ * 트랜잭션 처리 → (DB 변경 시) 캐시 무효화 + 큐 잡 등록 → Lock 해제. 멱등성은 byte-identical.
  */
 @Injectable()
 export class HandleWebhookEventUseCase {
@@ -98,7 +104,48 @@ export class HandleWebhookEventUseCase {
 		@Inject(LOCK_PROVIDER) private readonly lockProvider: ILockProvider,
 	) {}
 
-	async execute(payload: RevenueCatWebhookPayload): Promise<void> {
+	/**
+	 * 웹훅 요청 본문을 검증·처리하고 항상 `{ received: true }`를 반환한다.
+	 *
+	 * - Zod 검증 실패 → 경고 로그 후 200 (RevenueCat 재시도 방지)
+	 * - Lock 경합(SUBSCRIPTION_1605) → rethrow (필터가 429로 변환, 재시도 유도)
+	 * - 그 외 에러 → notifier로 실패 보고(Sentry·Discord) 후 200
+	 */
+	async execute(body: unknown): Promise<{ received: true }> {
+		const parseResult = revenueCatWebhookPayloadSchema.safeParse(body);
+		if (!parseResult.success) {
+			this.#logger.warn(
+				`Invalid webhook payload: ${JSON.stringify(parseResult.error.issues)}`,
+			);
+			return { received: true };
+		}
+
+		const payload = parseResult.data;
+		try {
+			await this.#process(payload);
+		} catch (error) {
+			// Lock 경합 → 429 반환 (RevenueCat 재시도 유도)
+			// SUBSCRIPTION_1605는 httpStatus=429이므로 GlobalExceptionFilter가 그대로 처리
+			if (
+				error instanceof ApplicationException &&
+				error.errorCode === ErrorCode.SUBSCRIPTION_1605
+			) {
+				this.#logger.warn(`Lock contention, returning 429: ${error.message}`);
+				throw error;
+			}
+
+			// 그 외 에러 → Sentry + Discord 알림 (200 반환, 무한 재시도 방지)
+			this.notifier.reportWebhookFailure(error, payload);
+			this.#logger.error(
+				`Failed to process webhook event: ${error}`,
+				error instanceof Error ? error.stack : undefined,
+			);
+		}
+
+		return { received: true };
+	}
+
+	async #process(payload: RevenueCatWebhookPayload): Promise<void> {
 		const { event } = payload;
 		const appUserId = event.app_user_id;
 		const eventType = event.type;

--- a/apps/api/src/subscription/infrastructure/adapters/subscription-event-notifier.adapter.spec.ts
+++ b/apps/api/src/subscription/infrastructure/adapters/subscription-event-notifier.adapter.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * SubscriptionEventNotifierAdapter 단위 테스트
+ *
+ * 웹훅 실패 보고(reportWebhookFailure)의 Sentry 태깅·Discord 메시지 형식을 검증한다.
+ * Sentry SDK는 벤더 경계라 jest.mock으로 격리한다(프로젝트 규칙 — vendor/native만 허용).
+ * withScope는 팩토리에서 즉시 콜백을 호출해 mockScope로 태깅을 관측한다.
+ */
+const mockScope = { setTag: jest.fn(), setExtra: jest.fn() };
+jest.mock("@sentry/nestjs", () => ({
+	captureException: jest.fn(),
+	withScope: jest.fn((cb: (scope: typeof mockScope) => void) => cb(mockScope)),
+}));
+
+import * as Sentry from "@sentry/nestjs";
+import { TestBed } from "@suites/unit";
+import { SubscriptionEventBuilder } from "@test/builders";
+
+import { PAYMENT_NOTIFIER } from "@/admin-notification";
+import { SubscriptionEventNotifierAdapter } from "./subscription-event-notifier.adapter";
+
+const captureException = jest.mocked(Sentry.captureException);
+
+describe("SubscriptionEventNotifierAdapter — 웹훅 실패 보고", () => {
+	let adapter: SubscriptionEventNotifierAdapter;
+	let mockNotifier: { name: string; send: jest.Mock; isConfigured: jest.Mock };
+
+	beforeEach(async () => {
+		mockNotifier = {
+			name: "fake",
+			send: jest.fn().mockResolvedValue({ success: true }),
+			isConfigured: jest.fn().mockReturnValue(true),
+		};
+
+		const { unit } = await TestBed.solitary(SubscriptionEventNotifierAdapter)
+			.mock(PAYMENT_NOTIFIER)
+			.impl(() => mockNotifier)
+			.compile();
+
+		adapter = unit;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const payload = SubscriptionEventBuilder.initialPurchase()
+		.withAppUserId("user-123")
+		.withProductId("premium_monthly")
+		.build();
+
+	it("Sentry에 결제 도메인 컨텍스트를 태깅해 캡처한다", () => {
+		// Given
+		const error = new Error("Processing failed");
+
+		// When
+		adapter.reportWebhookFailure(error, payload);
+
+		// Then — 컨트롤러에서 옮겨온 태그/extra 그대로 유지
+		expect(mockScope.setTag).toHaveBeenCalledWith("domain", "payment");
+		expect(mockScope.setTag).toHaveBeenCalledWith(
+			"webhook.event_type",
+			"INITIAL_PURCHASE",
+		);
+		expect(mockScope.setTag).toHaveBeenCalledWith("webhook.store", "APP_STORE");
+		expect(mockScope.setExtra).toHaveBeenCalledWith(
+			"webhook.app_user_id",
+			"user-123",
+		);
+		expect(mockScope.setExtra).toHaveBeenCalledWith(
+			"webhook.product_id",
+			"premium_monthly",
+		);
+		expect(captureException).toHaveBeenCalledWith(error);
+	});
+
+	it("Discord로 에러 메시지를 전송한다 (제목·색·필드 byte-identical)", async () => {
+		// Given
+		const error = new Error("Processing failed");
+
+		// When
+		adapter.reportWebhookFailure(error, payload);
+		await new Promise((resolve) => setTimeout(resolve, 0)); // fire-and-forget 대기
+
+		// Then
+		expect(mockNotifier.send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "Webhook 처리 에러",
+				body: "RevenueCat 웹훅 처리 중 에러가 발생했습니다.",
+				color: 0xff0000,
+				fields: expect.arrayContaining([
+					expect.objectContaining({ name: "에러", value: "Processing failed" }),
+					expect.objectContaining({
+						name: "이벤트 타입",
+						value: "INITIAL_PURCHASE",
+					}),
+					expect.objectContaining({ name: "사용자 ID", value: "user-123" }),
+					expect.objectContaining({ name: "상품", value: "premium_monthly" }),
+				]),
+			}),
+		);
+	});
+
+	it("Discord 전송 실패는 삼킨다 (호출자에 전파 없음)", async () => {
+		// Given
+		mockNotifier.send.mockRejectedValue(new Error("Discord down"));
+
+		// When & Then — 동기 호출은 throw하지 않는다
+		expect(() =>
+			adapter.reportWebhookFailure(new Error("x"), payload),
+		).not.toThrow();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+});

--- a/apps/api/src/subscription/infrastructure/adapters/subscription-event-notifier.adapter.ts
+++ b/apps/api/src/subscription/infrastructure/adapters/subscription-event-notifier.adapter.ts
@@ -1,6 +1,11 @@
-import { Injectable } from "@nestjs/common";
-
-import { AdminNotificationFacade } from "@/admin-notification";
+import type { RevenueCatWebhookPayload } from "@aido/validators";
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import * as Sentry from "@sentry/nestjs";
+import {
+	AdminNotificationFacade,
+	type AdminNotifier,
+	PAYMENT_NOTIFIER,
+} from "@/admin-notification";
 import { NotificationQueueService } from "@/notification";
 import type { SubscriptionEventNotifierPort } from "../../application/ports/subscription-event-notifier.port";
 import type { SubscriptionEventPayload } from "../../domain/events/subscription-event.payload";
@@ -10,14 +15,20 @@ import type { SubscriptionEventPayload } from "../../domain/events/subscription-
  *
  * 관리자 알림(Discord)은 admin-notification 큐로, 결제 이슈 푸시는 notification 큐로
  * fire-and-forget 위임한다. 트랜잭션 커밋 후 use-case가 호출한다.
+ * 웹훅 처리 실패는 Sentry(에러 관측)·Discord(관리자 알림)로 보고한다 — 벤더 SDK는
+ * infrastructure에 격리한다.
  */
 @Injectable()
 export class SubscriptionEventNotifierAdapter
 	implements SubscriptionEventNotifierPort
 {
+	readonly #logger = new Logger(SubscriptionEventNotifierAdapter.name);
+
 	constructor(
 		private readonly adminNotificationFacade: AdminNotificationFacade,
 		private readonly notificationQueueService: NotificationQueueService,
+		@Inject(PAYMENT_NOTIFIER)
+		private readonly paymentNotifier: AdminNotifier,
 	) {}
 
 	notifySubscriptionEvent(payload: SubscriptionEventPayload): void {
@@ -26,5 +37,61 @@ export class SubscriptionEventNotifierAdapter
 
 	notifyBillingIssue(userId: string): void {
 		this.notificationQueueService.enqueueBillingIssue({ userId });
+	}
+
+	reportWebhookFailure(
+		error: unknown,
+		payload: RevenueCatWebhookPayload,
+	): void {
+		// 1. Sentry 태깅 캡처 (결제 도메인 컨텍스트)
+		Sentry.withScope((scope) => {
+			scope.setTag("domain", "payment");
+			scope.setTag("webhook.event_type", payload.event.type);
+			scope.setTag("webhook.store", payload.event.store ?? "unknown");
+			scope.setExtra("webhook.app_user_id", payload.event.app_user_id);
+			scope.setExtra("webhook.product_id", payload.event.product_id);
+			scope.setExtra("webhook.event_id", payload.event.id);
+			Sentry.captureException(error);
+		});
+
+		// 2. Discord 관리자 알림 (fire-and-forget)
+		this.#notifyWebhookError(error, payload).catch((e) =>
+			this.#logger.warn(`Failed to send webhook error notification: ${e}`),
+		);
+	}
+
+	async #notifyWebhookError(
+		error: unknown,
+		payload: RevenueCatWebhookPayload,
+	): Promise<void> {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+
+		await this.paymentNotifier.send({
+			title: "Webhook 처리 에러",
+			body: "RevenueCat 웹훅 처리 중 에러가 발생했습니다.",
+			color: 0xff0000,
+			fields: [
+				{
+					name: "에러",
+					value: errorMessage.slice(0, 1024),
+					inline: false,
+				},
+				{
+					name: "이벤트 타입",
+					value: payload.event.type,
+					inline: true,
+				},
+				{
+					name: "사용자 ID",
+					value: payload.event.app_user_id,
+					inline: true,
+				},
+				{
+					name: "상품",
+					value: payload.event.product_id,
+					inline: true,
+				},
+			],
+		});
 	}
 }

--- a/apps/api/src/subscription/presentation/subscription.controller.spec.ts
+++ b/apps/api/src/subscription/presentation/subscription.controller.spec.ts
@@ -1,53 +1,34 @@
 /**
  * SubscriptionController 컨트롤러 단위 테스트
  *
- * @description
- * SubscriptionController의 엔드포인트 핸들러를 격리 테스트합니다.
+ * 컨트롤러는 thin delegation만 담당한다 — 원시 본문(request.body)을 Facade로 넘기고
+ * 결과를 반환하며, 예외(Lock 경합 1605 등)는 GlobalExceptionFilter로 전파한다.
+ * 검증·Sentry·Discord 오케스트레이션은 use-case/adapter가 소유한다(각 spec에서 검증).
  *
  * 실행 명령:
  * ```bash
  * pnpm --filter @aido/api test subscription.controller
  * ```
  */
-jest.mock("@sentry/nestjs", () => ({
-	captureException: jest.fn(),
-	withScope: jest.fn((callback) =>
-		callback({
-			setTag: jest.fn(),
-			setExtra: jest.fn(),
-		}),
-	),
-}));
-
 import { ErrorCode } from "@aido/errors";
-import * as Sentry from "@sentry/nestjs";
 import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
 import { SubscriptionEventBuilder } from "@test/builders";
 import type { Request } from "express";
 
-import { PAYMENT_NOTIFIER } from "@/admin-notification";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 
 import { SubscriptionFacade } from "../application/facades/subscription.facade";
 import { SubscriptionController } from "./subscription.controller";
 
-describe("SubscriptionController — 구독 컨트롤러", () => {
+describe("SubscriptionController — 구독 컨트롤러 (thin delegation)", () => {
 	let controller: SubscriptionController;
 	let mockFacade: Mocked<SubscriptionFacade>;
-	let mockNotifier: { send: jest.Mock; name: string; isConfigured: jest.Mock };
 
 	beforeEach(async () => {
-		mockNotifier = {
-			name: "fake",
-			send: jest.fn().mockResolvedValue({ success: true }),
-			isConfigured: jest.fn().mockReturnValue(true),
-		};
-
-		const { unit, unitRef } = await TestBed.solitary(SubscriptionController)
-			.mock(PAYMENT_NOTIFIER)
-			.impl(() => mockNotifier)
-			.compile();
+		const { unit, unitRef } = await TestBed.solitary(
+			SubscriptionController,
+		).compile();
 
 		controller = unit;
 		mockFacade = unitRef.get(SubscriptionFacade);
@@ -60,33 +41,20 @@ describe("SubscriptionController — 구독 컨트롤러", () => {
 			.withPrice(4900, "KRW")
 			.build();
 
-		it("유효한 payload → 서비스 호출 + { received: true } 반환", async () => {
+		it("원시 request.body를 Facade로 위임하고 결과를 반환한다", async () => {
 			// Given
 			const request = { body: validPayload } as unknown as Request;
-			mockFacade.handleWebhookEvent.mockResolvedValue(undefined);
+			mockFacade.handleWebhookEvent.mockResolvedValue({ received: true });
 
 			// When
 			const result = await controller.handleRevenueCatWebhook(request);
 
-			// Then
-			expect(mockFacade.handleWebhookEvent).toHaveBeenCalledTimes(1);
+			// Then — 파싱 없이 원시 본문을 그대로 전달 (검증은 use-case 소유)
+			expect(mockFacade.handleWebhookEvent).toHaveBeenCalledWith(validPayload);
 			expect(result).toEqual({ received: true });
 		});
 
-		it("Zod 검증 실패 (invalid payload) → 서비스 미호출 + { received: true }", async () => {
-			// Given
-			const invalidBody = { invalid: "data" };
-			const request = { body: invalidBody } as unknown as Request;
-
-			// When
-			const result = await controller.handleRevenueCatWebhook(request);
-
-			// Then
-			expect(mockFacade.handleWebhookEvent).not.toHaveBeenCalled();
-			expect(result).toEqual({ received: true });
-		});
-
-		it("Lock 경합 (SUBSCRIPTION_1605) → 재던짐 (429 유도), Sentry 미캡처", async () => {
+		it("Lock 경합(SUBSCRIPTION_1605)은 잡지 않고 그대로 전파한다 (필터가 429 처리)", async () => {
 			// Given
 			const request = { body: validPayload } as unknown as Request;
 			const lockError = new ApplicationException(ErrorCode.SUBSCRIPTION_1605, {
@@ -94,154 +62,10 @@ describe("SubscriptionController — 구독 컨트롤러", () => {
 			});
 			mockFacade.handleWebhookEvent.mockRejectedValue(lockError);
 
-			// When & Then — 그대로 재던져 GlobalExceptionFilter가 429 처리
+			// When & Then — try/catch 없이 GlobalExceptionFilter로 전파
 			await expect(controller.handleRevenueCatWebhook(request)).rejects.toBe(
 				lockError,
 			);
-			expect(Sentry.captureException).not.toHaveBeenCalled();
-			expect(mockNotifier.send).not.toHaveBeenCalled();
-		});
-
-		it("서비스 에러 → Sentry 캡처 (결제 context 포함) + Discord 알림 + { received: true }", async () => {
-			// Given
-			const request = { body: validPayload } as unknown as Request;
-			const error = new Error("Processing failed");
-			mockFacade.handleWebhookEvent.mockRejectedValue(error);
-			const mockScope = { setTag: jest.fn(), setExtra: jest.fn() };
-			(Sentry.withScope as jest.Mock).mockImplementation((cb) => cb(mockScope));
-
-			// When
-			const result = await controller.handleRevenueCatWebhook(request);
-			// fire-and-forget 완료 대기
-			await new Promise((resolve) => setTimeout(resolve, 0));
-
-			// Then — Sentry context 검증
-			expect(Sentry.withScope).toHaveBeenCalledTimes(1);
-			expect(mockScope.setTag).toHaveBeenCalledWith("domain", "payment");
-			expect(mockScope.setTag).toHaveBeenCalledWith(
-				"webhook.event_type",
-				"INITIAL_PURCHASE",
-			);
-			expect(mockScope.setExtra).toHaveBeenCalledWith(
-				"webhook.app_user_id",
-				"user-123",
-			);
-			expect(Sentry.captureException).toHaveBeenCalledWith(error);
-
-			// Then — Discord 알림 검증
-			expect(mockNotifier.send).toHaveBeenCalledWith(
-				expect.objectContaining({
-					title: "Webhook 처리 에러",
-					color: 0xff0000,
-					fields: expect.arrayContaining([
-						expect.objectContaining({
-							name: "에러",
-							value: "Processing failed",
-						}),
-						expect.objectContaining({
-							name: "이벤트 타입",
-							value: "INITIAL_PURCHASE",
-						}),
-					]),
-				}),
-			);
-			expect(result).toEqual({ received: true });
-		});
-
-		it("서비스 정상 처리 후 { received: true } 반환 확인", async () => {
-			// Given
-			const request = { body: validPayload } as unknown as Request;
-			mockFacade.handleWebhookEvent.mockResolvedValue(undefined);
-
-			// When
-			const result = await controller.handleRevenueCatWebhook(request);
-
-			// Then
-			expect(mockFacade.handleWebhookEvent).toHaveBeenCalledTimes(1);
-			expect(result).toEqual({ received: true });
-			expect(Sentry.captureException).not.toHaveBeenCalled();
-		});
-
-		it("request.body가 빈 객체 → 서비스 미호출", async () => {
-			// Given
-			const request = { body: {} } as unknown as Request;
-
-			// When
-			const result = await controller.handleRevenueCatWebhook(request);
-
-			// Then
-			expect(mockFacade.handleWebhookEvent).not.toHaveBeenCalled();
-			expect(result).toEqual({ received: true });
-		});
-
-		it("알 수 없는 이벤트 타입도 Zod 검증을 통과하고 서비스가 호출된다", async () => {
-			// Given — RevenueCat이 새로 추가한 이벤트 타입 시뮬레이션
-			const unknownEventPayload = SubscriptionEventBuilder.customType(
-				"FUTURE_NEW_EVENT",
-			)
-				.withAppUserId("user-123")
-				.build();
-			const request = { body: unknownEventPayload } as unknown as Request;
-			mockFacade.handleWebhookEvent.mockResolvedValue(undefined);
-
-			// When
-			const result = await controller.handleRevenueCatWebhook(request);
-
-			// Then
-			expect(mockFacade.handleWebhookEvent).toHaveBeenCalledTimes(1);
-			expect(result).toEqual({ received: true });
-		});
-
-		it("알 수 없는 스토어 값도 Zod 검증을 통과한다", async () => {
-			// Given — RevenueCat이 새로 추가한 스토어 시뮬레이션
-			const payload = SubscriptionEventBuilder.initialPurchase()
-				.withAppUserId("user-123")
-				.withStore("ROKU")
-				.build();
-			const request = { body: payload } as unknown as Request;
-			mockFacade.handleWebhookEvent.mockResolvedValue(undefined);
-
-			// When
-			const result = await controller.handleRevenueCatWebhook(request);
-
-			// Then
-			expect(mockFacade.handleWebhookEvent).toHaveBeenCalledTimes(1);
-			expect(result).toEqual({ received: true });
-		});
-
-		it("서비스 호출 시 Zod 파싱된 데이터가 전달된다", async () => {
-			// Given
-			const request = { body: validPayload } as unknown as Request;
-			mockFacade.handleWebhookEvent.mockResolvedValue(undefined);
-
-			// When
-			await controller.handleRevenueCatWebhook(request);
-
-			// Then
-			expect(mockFacade.handleWebhookEvent).toHaveBeenCalledWith(
-				expect.objectContaining({
-					event: expect.objectContaining({
-						type: "INITIAL_PURCHASE",
-						app_user_id: "user-123",
-						product_id: "premium_monthly",
-					}),
-				}),
-			);
-		});
-
-		it("Discord 알림 실패해도 webhook 응답에 영향 없다", async () => {
-			// Given
-			const request = { body: validPayload } as unknown as Request;
-			mockFacade.handleWebhookEvent.mockRejectedValue(
-				new Error("Processing failed"),
-			);
-			mockNotifier.send.mockRejectedValue(new Error("Discord down"));
-
-			// When
-			const result = await controller.handleRevenueCatWebhook(request);
-
-			// Then
-			expect(result).toEqual({ received: true });
 		});
 	});
 });

--- a/apps/api/src/subscription/presentation/subscription.controller.ts
+++ b/apps/api/src/subscription/presentation/subscription.controller.ts
@@ -1,25 +1,15 @@
-import { ErrorCode } from "@aido/errors";
-import {
-	type RevenueCatWebhookPayload,
-	revenueCatWebhookPayloadSchema,
-} from "@aido/validators";
 import {
 	Controller,
 	HttpCode,
 	HttpStatus,
-	Inject,
-	Logger,
 	Post,
 	Req,
 	UseGuards,
 } from "@nestjs/common";
 import { ApiExcludeEndpoint } from "@nestjs/swagger";
 import { SkipThrottle } from "@nestjs/throttler";
-import * as Sentry from "@sentry/nestjs";
 import type { Request } from "express";
-import { type AdminNotifier, PAYMENT_NOTIFIER } from "@/admin-notification";
 import { Public } from "@/auth/presentation/decorators";
-import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 
 import { SubscriptionFacade } from "../application/facades/subscription.facade";
 import { WebhookSignatureGuard } from "../infrastructure/guards/webhook-signature.guard";
@@ -32,112 +22,23 @@ import { WebhookSignatureGuard } from "../infrastructure/guards/webhook-signatur
  * - JWT 인증 건너뜀 (@Public)
  * - Rate limiting 건너뜀 (@SkipThrottle)
  * - Authorization 헤더로 서명 검증 (WebhookSignatureGuard)
- * - 항상 200 OK 반환 (RevenueCat는 non-2xx 시 재시도하므로)
+ * - 항상 200 OK 반환 (RevenueCat는 non-2xx 시 재시도하므로) — Lock 경합(429)만 예외
+ *
+ * 검증·처리·실패 보고 오케스트레이션은 Facade → use-case가 소유한다.
  */
 @Controller("webhooks")
 @SkipThrottle()
 export class SubscriptionController {
-	readonly #logger = new Logger(SubscriptionController.name);
-
-	constructor(
-		private readonly subscriptionFacade: SubscriptionFacade,
-		@Inject(PAYMENT_NOTIFIER)
-		private readonly paymentNotifier: AdminNotifier,
-	) {}
+	constructor(private readonly subscriptionFacade: SubscriptionFacade) {}
 
 	@Post("revenuecat")
 	@Public()
 	@ApiExcludeEndpoint()
 	@UseGuards(WebhookSignatureGuard)
 	@HttpCode(HttpStatus.OK)
-	async handleRevenueCatWebhook(
+	handleRevenueCatWebhook(
 		@Req() request: Request,
 	): Promise<{ received: true }> {
-		// 1. Zod 검증
-		const parseResult = revenueCatWebhookPayloadSchema.safeParse(request.body);
-
-		if (!parseResult.success) {
-			this.#logger.warn(
-				`Invalid webhook payload: ${JSON.stringify(parseResult.error.issues)}`,
-			);
-			return { received: true };
-		}
-
-		// 2. 서비스 호출 (에러가 발생해도 항상 200 OK 반환)
-		try {
-			await this.subscriptionFacade.handleWebhookEvent(parseResult.data);
-		} catch (error) {
-			// Lock 경합 → 429 반환 (RevenueCat 재시도 유도)
-			// SUBSCRIPTION_1605는 httpStatus=429이므로 GlobalExceptionFilter가 그대로 처리
-			if (
-				error instanceof ApplicationException &&
-				error.errorCode === ErrorCode.SUBSCRIPTION_1605
-			) {
-				this.#logger.warn(`Lock contention, returning 429: ${error.message}`);
-				throw error;
-			}
-			// 그 외 에러 → Sentry + Discord 알림 + 200 반환 (무한 재시도 방지)
-			Sentry.withScope((scope) => {
-				scope.setTag("domain", "payment");
-				scope.setTag("webhook.event_type", parseResult.data.event.type);
-				scope.setTag(
-					"webhook.store",
-					parseResult.data.event.store ?? "unknown",
-				);
-				scope.setExtra(
-					"webhook.app_user_id",
-					parseResult.data.event.app_user_id,
-				);
-				scope.setExtra("webhook.product_id", parseResult.data.event.product_id);
-				scope.setExtra("webhook.event_id", parseResult.data.event.id);
-				Sentry.captureException(error);
-			});
-
-			this.#logger.error(
-				`Failed to process webhook event: ${error}`,
-				error instanceof Error ? error.stack : undefined,
-			);
-
-			this.#notifyWebhookError(error, parseResult.data).catch((e) =>
-				this.#logger.warn(`Failed to send webhook error notification: ${e}`),
-			);
-		}
-
-		return { received: true };
-	}
-
-	async #notifyWebhookError(
-		error: unknown,
-		payload: RevenueCatWebhookPayload,
-	): Promise<void> {
-		const errorMessage = error instanceof Error ? error.message : String(error);
-
-		await this.paymentNotifier.send({
-			title: "Webhook 처리 에러",
-			body: "RevenueCat 웹훅 처리 중 에러가 발생했습니다.",
-			color: 0xff0000,
-			fields: [
-				{
-					name: "에러",
-					value: errorMessage.slice(0, 1024),
-					inline: false,
-				},
-				{
-					name: "이벤트 타입",
-					value: payload.event.type,
-					inline: true,
-				},
-				{
-					name: "사용자 ID",
-					value: payload.event.app_user_id,
-					inline: true,
-				},
-				{
-					name: "상품",
-					value: payload.event.product_id,
-					inline: true,
-				},
-			],
-		});
+		return this.subscriptionFacade.handleWebhookEvent(request.body);
 	}
 }

--- a/apps/api/test/integration/subscription.integration-spec.ts
+++ b/apps/api/test/integration/subscription.integration-spec.ts
@@ -26,7 +26,10 @@ import { SubscriptionEventBuilder } from "@test/builders";
 import { createMockDatabaseService } from "@test/mocks/mock-database.factory";
 import { createUnitOfWorkMock } from "@test/mocks/ports";
 import { suppressLogger } from "@test/setup/suppress-logger";
-import { AdminNotificationFacade } from "@/admin-notification";
+import {
+	AdminNotificationFacade,
+	PAYMENT_NOTIFIER,
+} from "@/admin-notification";
 import { NotificationQueueService } from "@/notification";
 import { UNIT_OF_WORK } from "@/shared/application/ports";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
@@ -76,6 +79,13 @@ describe("HandleWebhookEventUseCase 통합 테스트 (Mock DB)", () => {
 	// Mock NotificationQueueService
 	const mockNotificationQueueService = {
 		enqueueBillingIssue: jest.fn(),
+	};
+
+	// Mock PAYMENT_NOTIFIER (웹훅 실패 보고의 Discord 전송 — reportWebhookFailure 경로)
+	const mockPaymentNotifier = {
+		name: "fake",
+		send: jest.fn().mockResolvedValue({ success: true }),
+		isConfigured: jest.fn().mockReturnValue(true),
 	};
 
 	// Mock LockProvider
@@ -132,6 +142,10 @@ describe("HandleWebhookEventUseCase 통합 테스트 (Mock DB)", () => {
 				{
 					provide: NotificationQueueService,
 					useValue: mockNotificationQueueService,
+				},
+				{
+					provide: PAYMENT_NOTIFIER,
+					useValue: mockPaymentNotifier,
 				},
 				{
 					provide: LOCK_PROVIDER,
@@ -424,10 +438,10 @@ describe("HandleWebhookEventUseCase 통합 테스트 (Mock DB)", () => {
 			.withAppUserId("rc-unknown-user")
 			.build();
 
-		// When & Then - ApplicationException 발생
-		await expect(useCase.execute(payload)).rejects.toThrow(
-			ApplicationException,
-		);
+		// When & Then - 비-1605 실패는 삼켜 200 반환 + notifier로 보고 (Discord 전송)
+		const result = await useCase.execute(payload);
+		expect(result).toEqual({ received: true });
+		expect(mockPaymentNotifier.send).toHaveBeenCalledTimes(1);
 
 		// 사용자 조회는 시도했으나 이후 처리는 하지 않음
 		expect(mockUserDb.findFirst).toHaveBeenCalled();


### PR DESCRIPTION
> **스택 PR 3/7** — DDD 클린아키텍처 일관성 개선 시리즈. base: `refactor/module-cache-ports` (#684)

## 배경
`subscription.controller`가 `PAYMENT_NOTIFIER`(AdminNotifier)를 Facade와 함께 직접 주입하고, 웹훅 오케스트레이션 로직(Zod 검증·try/catch·Sentry 태깅·Discord 알림·`SUBSCRIPTION_1605` 조건부 rethrow)을 보유하고 있었다 — 전 코드베이스에서 컨트롤러가 비-Facade 프로바이더를 주입하고 로직을 갖는 **유일한** 위반.

## 변경
- **`HandleWebhookEventUseCase.execute(body: unknown)`** 이 오케스트레이션을 소유: 기존 처리 로직은 `#process`로 분리. Zod 실패 → 200, Lock 경합(1605)만 rethrow(429 유도), 그 외 에러 → `notifier.reportWebhookFailure` 후 200. **응답 시맨틱 완전 불변.**
- **`SubscriptionEventNotifierPort.reportWebhookFailure(error, payload)`** 추가 — 어댑터가 Sentry `withScope` 태깅(domain·event_type·store·app_user_id·product_id·event_id)과 Discord 메시지(제목·색·필드·`slice(0,1024)`)를 **byte-identical** 이식. Sentry SDK는 infrastructure에 격리.
- **컨트롤러는 thin delegation** — `SubscriptionFacade`만 주입, `request.body`를 그대로 위임. 데코레이터(`@Public`/`@ApiExcludeEndpoint`/`@HttpCode(200)`/서명 가드) 불변.

## 보존 시맨틱 (테스트로 고정)
| 시나리오 | 응답 |
|----------|------|
| 잘못된 payload (Zod 실패) | 200 `{received:true}`, 처리 없음 |
| 정상 처리 | 200 `{received:true}` |
| Lock 경합 (1605) | rethrow → 429 (동일 바디) |
| 그 외 에러 | Sentry 태깅 캡처 + Discord 알림 + 200 |

## 검증
- ✅ `pnpm typecheck` / `pnpm lint` / `pnpm lint:arch`
- ✅ 단위 294 스위트 (컨트롤러 thin spec + use-case 오케스트레이션 4케이스 + 신규 어댑터 spec) · 통합 8 통과
- ✅ **openapi-contract 스냅샷 diff 0 — 클라이언트 계약 무변경**

🤖 Generated with [Claude Code](https://claude.com/claude-code)