### PR TITLE
test(api): send-nudge 시간 의존 테스트 안정화 (dependabot PR 차단 해소)

### DIFF
--- a/apps/api/src/nudge/application/use-cases/send-nudge/send-nudge.use-case.spec.ts
+++ b/apps/api/src/nudge/application/use-cases/send-nudge/send-nudge.use-case.spec.ts
@@ -187,7 +187,9 @@ describe("SendNudgeUseCase", () => {
 		});
 		repo.findTargetTodo.mockImplementation(async () => {
 			events.push("target-read");
-			return targetTodo;
+			// 고정 시각(2026-07-26 KST)과 같은 날의 할 일이어야 isActiveOn을 통과한다.
+			// 모듈 상단 targetTodo는 실행 시점의 실제 오늘이라 고정 시각과 어긋난다.
+			return { ...targetTodo, startDate: new Date("2026-07-26T00:00:00.000Z") };
 		});
 		limitReader.getDailyLimitInTx.mockImplementation(async () => {
 			events.push("limit");


### PR DESCRIPTION
## 📋 개요

열린 dependabot PR 4건(#701·#704·#705·#706)이 **전부 CI 실패** 상태였고, 원인은 의존성이 아니라 **develop에 이미 있던 시간 의존 테스트 버그**입니다. `actions/checkout` 버전 한 줄만 바꾼 #701조차 같은 이유로 막혀 있었습니다.

## 🔍 근본 원인

`send-nudge.use-case.spec.ts`의 "같은 시각 기준의 일일·Todo 쿨다운 키…" 테스트가

- 시각은 `jest.setSystemTime(new Date("2026-07-26T14:59:59.900Z"))`로 **고정**하는데
- 비교 대상 할 일은 모듈 상단 `const today = todayInTimezone("UTC")`로 만든 **실행 시점의 실제 오늘**을 사용

`isActiveOn`은 `endDate: null`일 때 `isSameDay(startDate, today)`이므로, 실제 날짜가 2026-07-26을 지나는 순간부터 판정이 어긋나 `NUDGE_1106(오늘의 할 일에만 콕 찌를 수 있습니다)`으로 **결정적 실패**합니다(flaky 아님).

- develop CI 마지막 성공: 2026-07-26 17:15 UTC
- 이후 모든 PR 런 실패: 2026-07-27 00:08 UTC ~
- 로컬 재현: 1 failed / 9 passed → 수정 후 10/10 통과

## 📝 변경 내용

해당 테스트에서만 고정 시각과 같은 날의 `startDate`를 반환하도록 수정했습니다. 나머지 9개 테스트는 실시간 기준으로 정합하므로 무변경입니다.

**런타임 코드 변경 없음 — 테스트 파일 1개만 수정**이라 서비스/기존 유저 영향 0입니다.

## 🧪 테스트

```bash
pnpm --filter @aido/api test
```

- [x] API 유닛 **353 suites / 2569 tests 전부 통과**
- [x] 대상 스펙 10/10 통과

## 🔗 후속

머지 후 #701·#704·#705·#706을 rebase하면 CI가 초록으로 돌아옵니다.

선례: `faca32de test(api): 마케팅 푸시 시간 의존 테스트 안정화` (동일 유형)