### PR TITLE
hotfix(api): Sentry 추적 헤더가 외부 API를 깨뜨리는 문제 수정 (날씨 전량 503)

### DIFF
--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -11,6 +11,8 @@ Sentry.init({
 	environment: options.environment,
 	// TODO: 서비스 스케일업 시 릴리스 버저닝 추가 (e.g., release: process.env.SENTRY_RELEASE)
 	tracesSampleRate: options.tracesSampleRate,
+	// 추적 헤더는 우리 서비스에만 전파한다 (외부 API가 baggage를 거부하는 사례 방지)
+	tracePropagationTargets: [...options.tracePropagationTargets],
 
 	beforeSend(event) {
 		// 요청 헤더에서 민감 정보 제거

--- a/apps/api/src/shared/infrastructure/config/utils/sentry-options.spec.ts
+++ b/apps/api/src/shared/infrastructure/config/utils/sentry-options.spec.ts
@@ -103,6 +103,42 @@ describe("resolveSentryOptions — Sentry 환경 게이트", () => {
 		expect(options.enabled).toBe(true);
 	});
 
+	describe("tracePropagationTargets — 외부 API 추적 헤더 차단", () => {
+		const matches = (url: string) =>
+			resolveSentryOptions({
+				APP_ENV: "production",
+			}).tracePropagationTargets.some((target) => target.test(url));
+
+		it("우리 API로 나가는 요청에는 추적 헤더를 전파한다", () => {
+			expect(matches("https://api.aido.kr/v1/todos")).toBe(true);
+		});
+
+		// 회귀 방지: Sentry가 붙이는 baggage 헤더를 data.go.kr 게이트웨이가
+		// "잘못된 요청 파라미터 에러(코드 10)"로 거부해 날씨 API가 전부 503이 됐다.
+		it.each([
+			[
+				"기상청 단기예보",
+				"https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst",
+			],
+			[
+				"한국천문연구원 일출",
+				"https://apis.data.go.kr/B090041/openapi/service/RiseSetInfoService/getAreaRiseSetInfo",
+			],
+			[
+				"에어코리아 대기질",
+				"https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getMsrstnAcctoRltmMesureDnsty",
+			],
+			[
+				"Google Generative AI",
+				"https://generativelanguage.googleapis.com/v1beta/models",
+			],
+			["Resend 메일", "https://api.resend.com/emails"],
+			["Expo 푸시", "https://exp.host/--/api/v2/push/send"],
+		])("%s 요청에는 추적 헤더를 전파하지 않는다", (_label, url) => {
+			expect(matches(url)).toBe(false);
+		});
+	});
+
 	describe("tracesSampleRate", () => {
 		it("명시된 SENTRY_TRACES_SAMPLE_RATE가 최우선이다", () => {
 			const options = resolveSentryOptions({

--- a/apps/api/src/shared/infrastructure/config/utils/sentry-options.ts
+++ b/apps/api/src/shared/infrastructure/config/utils/sentry-options.ts
@@ -14,10 +14,24 @@ const APP_ENVIRONMENTS = ["development", "staging", "production"] as const;
 
 export type AppEnvironment = (typeof APP_ENVIRONMENTS)[number];
 
+/**
+ * 분산 추적 헤더(sentry-trace·baggage)를 붙일 대상 — 우리 서비스로 한정한다.
+ *
+ * Sentry는 기본적으로 **모든** 아웃바운드 HTTP에 추적 헤더를 주입하는데,
+ * data.go.kr(기상청·천문연·에어코리아) 게이트웨이가 `baggage` 헤더를 요청 파라미터로
+ * 잘못 파싱해 `INVALID_REQUEST_PARAMETER_ERROR`(코드 10, HTTP 400)로 거부한다.
+ * 그 결과 날씨 조회가 전량 실패했다(WEATHER_1901 → 503).
+ *
+ * 외부 API는 우리 트레이스에 참여할 수 없어 헤더를 보낼 이유도 없다.
+ * (아웃바운드 span 자체는 계속 기록되므로 관측성 손실은 없다)
+ */
+const TRACE_PROPAGATION_TARGETS = [/^https:\/\/api\.aido\.kr/] as const;
+
 export interface SentryInstrumentOptions {
 	enabled: boolean;
 	environment: AppEnvironment;
 	tracesSampleRate: number;
+	tracePropagationTargets: readonly RegExp[];
 }
 
 /** process.env 호환 — 필요한 키(APP_ENV/NODE_ENV/SENTRY_*)만 읽는다 */
@@ -38,6 +52,7 @@ export function resolveSentryOptions(
 				: isProduction
 					? 0.2
 					: 1.0,
+		tracePropagationTargets: TRACE_PROPAGATION_TARGETS,
 	};
 }
 


### PR DESCRIPTION
## 🔥 장애 내용

**날씨 조회가 전량 실패**하고 있었습니다. 프로덕션 로그 기준 `GET /v1/weather/forecast` 요청이 **100% 503(`WEATHER_1901`)** 이며, `latest`(24h) 폴백 캐시까지 비어 있어 사용자에게 그대로 노출됐습니다.

## 🎯 근본 원인

Sentry가 **모든 아웃바운드 HTTP에 자동 주입하는 `baggage` 헤더**를 data.go.kr 게이트웨이가 요청 파라미터로 잘못 파싱해 `INVALID_REQUEST_PARAMETER_ERROR`(코드 10, HTTP 400)로 거부합니다.

동일 프로세스에서 **헤더만 바꿔** 격리 검증했습니다:

| 요청 | 결과 |
|---|---|
| 헤더 없음 | **200** ✅ |
| `sentry-trace`만 | **200** ✅ |
| **`baggage`만** | **400** ❌ |
| 둘 다 | **400** ❌ |

추가로 프로덕션 컨테이너 안에서 Sentry 로드 전/후를 대조해 재확인했습니다:
```
[Sentry 로드 전] HTTP 200
[Sentry 로드 후] HTTP 400  INVALID_REQUEST_PARAMETER_ERROR
```

> **이번 의존성 업데이트가 원인이 아닙니다.** 직전 버전 `@sentry/nestjs@10.66.0`에서도 동일하게 재현되어, 그 이전부터 존재하던 문제입니다. (폴백 캐시가 비어 있던 것도 "최소 24시간 이상 한 번도 성공하지 못했다"는 방증)

## 🔧 수정

`tracePropagationTargets`를 **우리 서비스로 한정**해, 외부 API에는 추적 헤더를 붙이지 않습니다.

```ts
const TRACE_PROPAGATION_TARGETS = [/^https:\/\/api\.aido\.kr/] as const;
```

- 외부 API는 애초에 우리 트레이스에 참여할 수 없어 헤더를 보낼 이유가 없습니다
- **아웃바운드 span은 계속 기록**되므로 관측성 손실 없음 (헤더 주입만 차단)
- 기존 `resolveSentryOptions`(순수 함수)에 넣어 테스트로 고정

## ♻️ 함께 복구되는 기능

같은 게이트웨이(data.go.kr)를 쓰는 기능이 모두 정상화됩니다:
- 날씨 예보 (기상청)
- 일출·일몰 (한국천문연구원)
- 대기질 (에어코리아)
- 생활기상지수

## 🧪 검증

- **회귀 테스트 추가**: 우리 API는 전파 ✅ / 외부 6곳(기상청·천문연·에어코리아·Google AI·Resend·Expo)은 미전파 ❌ 를 불변식으로 고정
- `sentry-options` **16/16** 통과
- API 유닛 **2579** 통과 · typecheck · lint · `lint:arch`(dependency-cruiser + no-cast) 통과
- 수정안 실효성: 프로덕션과 동일 조건(`enabled: true`, `tracesSampleRate: 0.2`)에서 **400 → 200** 확인

## 📋 배포 후 확인

- [ ] `GET /v1/weather/forecast` 200
- [ ] 헬스체크 정상 (database/queues up)