### PR TITLE
feat: 친구 캘린더에 일일 완료 마커(물고기·점) 표시

### DIFF
--- a/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.spec.ts
+++ b/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.spec.ts
@@ -7,11 +7,13 @@
 import { Logger } from "@nestjs/common";
 import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
+import { createDailyCompletionCacheMock } from "@test/mocks/ports";
 import {
 	TODO_EVENTS,
 	TodoCategoryChangedEvent,
 	TodoCreatedEvent,
 	TodoToggledEvent,
+	TodoVisibilityChangedEvent,
 } from "@/todo";
 import {
 	DAILY_COMPLETION_CACHE,
@@ -28,18 +30,14 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 			DailyCompletionCacheInvalidator,
 		)
 			.mock<DailyCompletionCachePort>(DAILY_COMPLETION_CACHE)
-			.impl(() => ({
-				getRange: jest.fn(),
-				setRange: jest.fn(),
-				invalidate: jest.fn().mockResolvedValue(undefined),
-			}))
+			.impl(() => createDailyCompletionCacheMock())
 			.compile();
 
 		invalidator = unit;
 		cache = unitRef.get<DailyCompletionCachePort>(DAILY_COMPLETION_CACHE);
 	});
 
-	it("6개 투두 쓰기 이벤트를 각각 개별 구독한다 (배열 인자는 결합된 단일 이벤트명이 되므로 회귀 방지)", () => {
+	it("7개 투두 쓰기 이벤트를 각각 개별 구독한다 (배열 인자는 결합된 단일 이벤트명이 되므로 회귀 방지)", () => {
 		// Given - @OnEvent가 남긴 메타데이터 (@nestjs/event-emitter 공개 상수)
 		const eventListenerMetadata: unknown = Reflect.getMetadata(
 			// EVENT_LISTENER_METADATA — 데코레이터가 handle 메서드에 기록하는 키
@@ -52,7 +50,7 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 			? eventListenerMetadata.map((m: { event: string }) => m.event)
 			: [];
 
-		// Then - 6개 이벤트가 문자열로 각각 구독되어야 한다
+		// Then - 7개 이벤트가 문자열로 각각 구독되어야 한다
 		expect(subscribed.sort()).toEqual(
 			[
 				TODO_EVENTS.CREATED,
@@ -61,6 +59,7 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 				TODO_EVENTS.RESCHEDULED,
 				TODO_EVENTS.UPDATED,
 				TODO_EVENTS.CATEGORY_CHANGED,
+				TODO_EVENTS.VISIBILITY_CHANGED,
 			].sort(),
 		);
 	});
@@ -96,6 +95,17 @@ describe("DailyCompletionCacheInvalidator — 투두 쓰기 이벤트 캐시 무
 
 		// Then
 		expect(cache.invalidate).toHaveBeenCalledWith("user-789");
+	});
+
+	it("공개 범위 변경 이벤트도 동일하게 무효화한다 (친구 캘린더 공개 범위 스테일 방지)", async () => {
+		// Given
+		const event = new TodoVisibilityChangedEvent(4, "user-visibility");
+
+		// When
+		await invalidator.handle(event);
+
+		// Then
+		expect(cache.invalidate).toHaveBeenCalledWith("user-visibility");
 	});
 
 	it("캐시 무효화 실패는 삼키고 로깅한다 (fire-and-forget)", async () => {

--- a/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.ts
+++ b/apps/api/src/daily-completion/application/events/daily-completion-cache.invalidator.ts
@@ -8,6 +8,7 @@ import {
 	type TodoRescheduledEvent,
 	type TodoToggledEvent,
 	type TodoUpdatedEvent,
+	type TodoVisibilityChangedEvent,
 } from "@/todo";
 import {
 	DAILY_COMPLETION_CACHE,
@@ -21,7 +22,8 @@ type TodoWriteEvent =
 	| TodoToggledEvent
 	| TodoRescheduledEvent
 	| TodoUpdatedEvent
-	| TodoCategoryChangedEvent;
+	| TodoCategoryChangedEvent
+	| TodoVisibilityChangedEvent;
 
 /**
  * 투두 쓰기 이벤트 구독 → 일별 완료 캐시 무효화 핸들러
@@ -46,6 +48,7 @@ export class DailyCompletionCacheInvalidator {
 	@OnEvent(TODO_EVENTS.RESCHEDULED)
 	@OnEvent(TODO_EVENTS.UPDATED)
 	@OnEvent(TODO_EVENTS.CATEGORY_CHANGED)
+	@OnEvent(TODO_EVENTS.VISIBILITY_CHANGED)
 	async handle(event: TodoWriteEvent): Promise<void> {
 		try {
 			await this.cache.invalidate(event.userId);

--- a/apps/api/src/daily-completion/application/facades/daily-completion.facade.ts
+++ b/apps/api/src/daily-completion/application/facades/daily-completion.facade.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import type { DailyCompletionsRange } from "../../domain/daily-completion";
 import { GetDailyCompletionsUseCase } from "../queries/get-daily-completions/get-daily-completions.use-case";
+import { GetFriendDailyCompletionsUseCase } from "../queries/get-friend-daily-completions/get-friend-daily-completions.use-case";
 
 /**
  * 일일 완료 애플리케이션 서비스(Facade) — 컨트롤러와 use-case 사이의 얇은 seam.
@@ -9,6 +10,7 @@ import { GetDailyCompletionsUseCase } from "../queries/get-daily-completions/get
 export class DailyCompletionFacade {
 	constructor(
 		private readonly getDailyCompletionsUseCase: GetDailyCompletionsUseCase,
+		private readonly getFriendDailyCompletionsUseCase: GetFriendDailyCompletionsUseCase,
 	) {}
 
 	getDailyCompletions(
@@ -18,6 +20,20 @@ export class DailyCompletionFacade {
 	): Promise<DailyCompletionsRange> {
 		return this.getDailyCompletionsUseCase.execute({
 			userId,
+			startDate,
+			endDate,
+		});
+	}
+
+	getFriendDailyCompletions(
+		userId: string,
+		friendUserId: string,
+		startDate: string,
+		endDate: string,
+	): Promise<DailyCompletionsRange> {
+		return this.getFriendDailyCompletionsUseCase.execute({
+			userId,
+			friendUserId,
 			startDate,
 			endDate,
 		});

--- a/apps/api/src/daily-completion/application/ports/daily-completion-cache.port.ts
+++ b/apps/api/src/daily-completion/application/ports/daily-completion-cache.port.ts
@@ -23,6 +23,20 @@ export interface DailyCompletionCachePort {
 		value: DailyCompletionsRange,
 	): Promise<void>;
 
-	/** 해당 사용자의 모든 범위 캐시를 무효화한다. */
+	/** 친구에게 보이는 공개(PUBLIC) 범위 캐시 — 키는 소유자 기준이라 뷰어 무관 공유. */
+	getPublicRange(
+		ownerUserId: string,
+		startDate: string,
+		endDate: string,
+	): Promise<DailyCompletionsRange | undefined>;
+
+	setPublicRange(
+		ownerUserId: string,
+		startDate: string,
+		endDate: string,
+		value: DailyCompletionsRange,
+	): Promise<void>;
+
+	/** 해당 사용자의 모든 범위 캐시(공개 범위 포함)를 무효화한다. */
 	invalidate(userId: string): Promise<void>;
 }

--- a/apps/api/src/daily-completion/application/ports/friend.port.ts
+++ b/apps/api/src/daily-completion/application/ports/friend.port.ts
@@ -1,0 +1,8 @@
+export const FRIEND_PORT = Symbol("FRIEND_PORT");
+
+/**
+ * 친구/맞팔 조회 포트 (follow 컨텍스트 경계)
+ */
+export interface FriendPort {
+	isMutualFriend(userId: string, targetUserId: string): Promise<boolean>;
+}

--- a/apps/api/src/daily-completion/application/ports/todo-completion.repository.port.ts
+++ b/apps/api/src/daily-completion/application/ports/todo-completion.repository.port.ts
@@ -20,4 +20,9 @@ export interface TodoCompletionRepositoryPort {
 	aggregateByDateRange(
 		params: AggregateByDateRangeParams,
 	): Promise<TodoAggregateByDate[]>;
+
+	/** 친구에게 보이는 PUBLIC 투두만 집계한다 (파라미터·반환 형태는 동일). */
+	aggregatePublicByDateRange(
+		params: AggregateByDateRangeParams,
+	): Promise<TodoAggregateByDate[]>;
 }

--- a/apps/api/src/daily-completion/application/queries/get-friend-daily-completions/get-friend-daily-completions.use-case.spec.ts
+++ b/apps/api/src/daily-completion/application/queries/get-friend-daily-completions/get-friend-daily-completions.use-case.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * GetFriendDailyCompletionsUseCase 단위 테스트
+ *
+ * Suites + 포트 mock + GWT 패턴 — 맞팔 검증, PUBLIC 집계, 소유자 기준 cache-aside 검증
+ */
+
+import { ErrorCode } from "@aido/errors";
+import type { Mocked } from "@suites/doubles.jest";
+import { TestBed } from "@suites/unit";
+import { ApplicationException } from "@/shared/domain";
+import type {
+	DailyCompletionsRange,
+	TodoAggregateByDate,
+} from "../../../domain/daily-completion";
+import {
+	DAILY_COMPLETION_CACHE,
+	type DailyCompletionCachePort,
+} from "../../ports/daily-completion-cache.port";
+import { FRIEND_PORT, type FriendPort } from "../../ports/friend.port";
+import {
+	TODO_COMPLETION_REPOSITORY,
+	type TodoCompletionRepositoryPort,
+} from "../../ports/todo-completion.repository.port";
+import { GetFriendDailyCompletionsUseCase } from "./get-friend-daily-completions.use-case";
+
+function buildAggregates(): TodoAggregateByDate[] {
+	return [
+		{
+			date: new Date("2026-01-15T00:00:00.000Z"),
+			total: 2,
+			completed: 2,
+			categoryColors: ["#FF6B43"],
+		},
+	];
+}
+
+describe("GetFriendDailyCompletionsUseCase — 친구 기간별 완료 현황 조회", () => {
+	let useCase: GetFriendDailyCompletionsUseCase;
+	let repository: Mocked<TodoCompletionRepositoryPort>;
+	let cache: Mocked<DailyCompletionCachePort>;
+	let friendPort: Mocked<FriendPort>;
+
+	const input = {
+		userId: "viewer-123",
+		friendUserId: "friend-456",
+		startDate: "2026-01-01",
+		endDate: "2026-01-31",
+	};
+
+	beforeEach(async () => {
+		const { unit, unitRef } = await TestBed.solitary(
+			GetFriendDailyCompletionsUseCase,
+		)
+			.mock<TodoCompletionRepositoryPort>(TODO_COMPLETION_REPOSITORY)
+			.impl(() => ({
+				aggregatePublicByDateRange: jest.fn().mockResolvedValue([]),
+			}))
+			.mock<DailyCompletionCachePort>(DAILY_COMPLETION_CACHE)
+			.impl(() => ({
+				getPublicRange: jest.fn().mockResolvedValue(undefined),
+				setPublicRange: jest.fn().mockResolvedValue(undefined),
+			}))
+			.mock<FriendPort>(FRIEND_PORT)
+			.impl(() => ({ isMutualFriend: jest.fn().mockResolvedValue(true) }))
+			.compile();
+
+		useCase = unit;
+		repository = unitRef.get<TodoCompletionRepositoryPort>(
+			TODO_COMPLETION_REPOSITORY,
+		);
+		cache = unitRef.get<DailyCompletionCachePort>(DAILY_COMPLETION_CACHE);
+		friendPort = unitRef.get<FriendPort>(FRIEND_PORT);
+	});
+
+	it("맞팔 관계가 아니면 FOLLOW_0906을 던진다", async () => {
+		// Given
+		friendPort.isMutualFriend.mockResolvedValue(false);
+
+		// When / Then
+		await expect(useCase.execute(input)).rejects.toMatchObject({
+			errorCode: ErrorCode.FOLLOW_0906,
+		});
+		await expect(useCase.execute(input)).rejects.toBeInstanceOf(
+			ApplicationException,
+		);
+		expect(repository.aggregatePublicByDateRange).not.toHaveBeenCalled();
+	});
+
+	it("친구의 PUBLIC 투두만 반열림 구간 [start, end+1일)로 집계한다", async () => {
+		// When
+		await useCase.execute(input);
+
+		// Then - 소유자(친구) 기준, 종료일 포함 위해 end에 +1일
+		expect(friendPort.isMutualFriend).toHaveBeenCalledWith(
+			"viewer-123",
+			"friend-456",
+		);
+		expect(repository.aggregatePublicByDateRange).toHaveBeenCalledWith({
+			userId: "friend-456",
+			startDate: new Date("2026-01-01T00:00:00.000Z"),
+			endDate: new Date("2026-02-01T00:00:00.000Z"),
+		});
+	});
+
+	it("집계를 일일 완료 요약으로 조립해 반환한다", async () => {
+		// Given
+		repository.aggregatePublicByDateRange.mockResolvedValue(buildAggregates());
+
+		// When
+		const result = await useCase.execute(input);
+
+		// Then
+		expect(result.completions).toHaveLength(1);
+		expect(result.totalCompleteDays).toBe(1);
+		expect(result.dateRange).toEqual({
+			startDate: "2026-01-01",
+			endDate: "2026-01-31",
+		});
+	});
+
+	it("캐시 히트 시에도 맞팔 검증은 수행하고 저장소는 호출하지 않는다", async () => {
+		// Given - 소유자 기준 공개 범위 캐시에 결과가 있음
+		const cachedResult: DailyCompletionsRange = {
+			completions: [
+				{
+					date: "2026-01-15",
+					totalTodos: 2,
+					completedTodos: 2,
+					isComplete: true,
+					completionRate: 100,
+					categoryColors: ["#FF6B43"],
+				},
+			],
+			totalCompleteDays: 1,
+			dateRange: { startDate: "2026-01-01", endDate: "2026-01-31" },
+		};
+		cache.getPublicRange.mockResolvedValue(cachedResult);
+
+		// When
+		const result = await useCase.execute(input);
+
+		// Then - 권한 확인은 캐시 히트와 무관하게 수행, 저장소 미호출
+		expect(result).toBe(cachedResult);
+		expect(friendPort.isMutualFriend).toHaveBeenCalled();
+		expect(cache.getPublicRange).toHaveBeenCalledWith(
+			"friend-456",
+			"2026-01-01",
+			"2026-01-31",
+		);
+		expect(repository.aggregatePublicByDateRange).not.toHaveBeenCalled();
+		expect(cache.setPublicRange).not.toHaveBeenCalled();
+	});
+
+	it("캐시 미스 시 계산 결과를 소유자 기준 키로 캐싱한다", async () => {
+		// Given - 캐시 미스 (기본 mock)
+		repository.aggregatePublicByDateRange.mockResolvedValue(buildAggregates());
+
+		// When
+		const result = await useCase.execute(input);
+
+		// Then - 뷰어가 아니라 소유자(친구) 키로 저장
+		expect(cache.setPublicRange).toHaveBeenCalledWith(
+			"friend-456",
+			"2026-01-01",
+			"2026-01-31",
+			result,
+		);
+	});
+});

--- a/apps/api/src/daily-completion/application/queries/get-friend-daily-completions/get-friend-daily-completions.use-case.ts
+++ b/apps/api/src/daily-completion/application/queries/get-friend-daily-completions/get-friend-daily-completions.use-case.ts
@@ -1,0 +1,94 @@
+import { ErrorCode } from "@aido/errors";
+import { Inject, Injectable } from "@nestjs/common";
+import { ApplicationException } from "@/shared/domain";
+import { addDays } from "@/shared/domain/date/utils/arithmetic";
+import { toDateString } from "@/shared/domain/date/utils/format";
+import { parseDateOnly } from "@/shared/domain/date/utils/parse";
+import {
+	buildDailyCompletionsRange,
+	type DailyCompletionsRange,
+} from "../../../domain/daily-completion";
+import {
+	DAILY_COMPLETION_CACHE,
+	type DailyCompletionCachePort,
+} from "../../ports/daily-completion-cache.port";
+import { FRIEND_PORT, type FriendPort } from "../../ports/friend.port";
+import {
+	TODO_COMPLETION_REPOSITORY,
+	type TodoCompletionRepositoryPort,
+} from "../../ports/todo-completion.repository.port";
+
+export interface GetFriendDailyCompletionsInput {
+	userId: string;
+	friendUserId: string;
+	startDate: string;
+	endDate: string;
+}
+
+/**
+ * 친구의 기간별 일일 완료 현황 조회 use-case (친구 캘린더용, 읽기 전용).
+ *
+ * 맞팔 관계를 확인한 뒤 친구의 PUBLIC 투두만 집계한다 — 친구 투두 목록과
+ * 같은 공개 기준이라 캘린더 마커와 날짜별 목록이 항상 일치한다.
+ * 캐시 키는 소유자(친구) 기준 공개 범위로 뷰어 무관 공유하며, 권한 확인은
+ * 캐시 히트와 무관하게 매 요청 수행한다.
+ */
+@Injectable()
+export class GetFriendDailyCompletionsUseCase {
+	constructor(
+		@Inject(TODO_COMPLETION_REPOSITORY)
+		private readonly repository: TodoCompletionRepositoryPort,
+		@Inject(DAILY_COMPLETION_CACHE)
+		private readonly cache: DailyCompletionCachePort,
+		@Inject(FRIEND_PORT)
+		private readonly friendPort: FriendPort,
+	) {}
+
+	async execute(
+		input: GetFriendDailyCompletionsInput,
+	): Promise<DailyCompletionsRange> {
+		const { userId, friendUserId } = input;
+
+		const isMutualFriend = await this.friendPort.isMutualFriend(
+			userId,
+			friendUserId,
+		);
+		if (!isMutualFriend) {
+			throw new ApplicationException(ErrorCode.FOLLOW_0906, {
+				targetUserId: friendUserId,
+			});
+		}
+
+		const start = parseDateOnly(input.startDate);
+		const endInclusive = parseDateOnly(input.endDate);
+
+		// 캐시 키 세그먼트는 파싱된 날짜를 YYYY-MM-DD로 정규화해 사용
+		const startKey = toDateString(start);
+		const endKey = toDateString(endInclusive);
+
+		const cached = await this.cache.getPublicRange(
+			friendUserId,
+			startKey,
+			endKey,
+		);
+		if (cached !== undefined) {
+			return cached;
+		}
+
+		// 조회 범위를 반열림 구간 [start, end)로 변환 (종료일 포함 위해 +1일)
+		const aggregates = await this.repository.aggregatePublicByDateRange({
+			userId: friendUserId,
+			startDate: start,
+			endDate: addDays(1, endInclusive),
+		});
+
+		const result = buildDailyCompletionsRange(aggregates, {
+			startDate: input.startDate,
+			endDate: input.endDate,
+		});
+
+		await this.cache.setPublicRange(friendUserId, startKey, endKey, result);
+
+		return result;
+	}
+}

--- a/apps/api/src/daily-completion/application/queries/index.ts
+++ b/apps/api/src/daily-completion/application/queries/index.ts
@@ -1,4 +1,8 @@
 import { GetDailyCompletionsUseCase } from "./get-daily-completions/get-daily-completions.use-case";
+import { GetFriendDailyCompletionsUseCase } from "./get-friend-daily-completions/get-friend-daily-completions.use-case";
 
 /** 모듈 등록용 쿼리 use-case 목록 */
-export const DailyCompletionQueryUseCases = [GetDailyCompletionsUseCase];
+export const DailyCompletionQueryUseCases = [
+	GetDailyCompletionsUseCase,
+	GetFriendDailyCompletionsUseCase,
+];

--- a/apps/api/src/daily-completion/daily-completion.module.ts
+++ b/apps/api/src/daily-completion/daily-completion.module.ts
@@ -1,10 +1,13 @@
 import { Module } from "@nestjs/common";
+import { FollowModule } from "@/follow";
 import { DailyCompletionCacheInvalidator } from "./application/events/daily-completion-cache.invalidator";
 import { DailyCompletionFacade } from "./application/facades/daily-completion.facade";
 import { DAILY_COMPLETION_CACHE } from "./application/ports/daily-completion-cache.port";
+import { FRIEND_PORT } from "./application/ports/friend.port";
 import { TODO_COMPLETION_REPOSITORY } from "./application/ports/todo-completion.repository.port";
 import { DailyCompletionQueryUseCases } from "./application/queries";
 import { DailyCompletionCacheAdapter } from "./infrastructure/adapters/daily-completion-cache.adapter";
+import { FriendAdapter } from "./infrastructure/adapters/friend.adapter";
 import { PrismaTodoCompletionRepository } from "./infrastructure/adapters/prisma-todo-completion.repository";
 import { DailyCompletionController } from "./presentation/daily-completion.controller";
 
@@ -16,6 +19,7 @@ import { DailyCompletionController } from "./presentation/daily-completion.contr
  * 캐싱되고, 투두 쓰기 도메인 이벤트(@OnEvent) 구독으로 무효화된다.
  */
 @Module({
+	imports: [FollowModule],
 	controllers: [DailyCompletionController],
 	providers: [
 		DailyCompletionFacade,
@@ -27,6 +31,7 @@ import { DailyCompletionController } from "./presentation/daily-completion.contr
 			provide: DAILY_COMPLETION_CACHE,
 			useClass: DailyCompletionCacheAdapter,
 		},
+		{ provide: FRIEND_PORT, useClass: FriendAdapter },
 		DailyCompletionCacheInvalidator,
 		...DailyCompletionQueryUseCases,
 	],

--- a/apps/api/src/daily-completion/infrastructure/adapters/daily-completion-cache.adapter.ts
+++ b/apps/api/src/daily-completion/infrastructure/adapters/daily-completion-cache.adapter.ts
@@ -35,6 +35,29 @@ export class DailyCompletionCacheAdapter implements DailyCompletionCachePort {
 		);
 	}
 
+	getPublicRange(
+		ownerUserId: string,
+		startDate: string,
+		endDate: string,
+	): Promise<DailyCompletionsRange | undefined> {
+		return this.cacheService.get<DailyCompletionsRange>(
+			CacheKeys.dailyCompletionPublicRange(ownerUserId, startDate, endDate),
+		);
+	}
+
+	setPublicRange(
+		ownerUserId: string,
+		startDate: string,
+		endDate: string,
+		value: DailyCompletionsRange,
+	): Promise<void> {
+		return this.cacheService.set(
+			CacheKeys.dailyCompletionPublicRange(ownerUserId, startDate, endDate),
+			value,
+			CacheKeys.TTL.DAILY_COMPLETIONS,
+		);
+	}
+
 	async invalidate(userId: string): Promise<void> {
 		await this.cacheService.delByPattern(
 			CacheKeys.dailyCompletionPattern(userId),

--- a/apps/api/src/daily-completion/infrastructure/adapters/friend.adapter.ts
+++ b/apps/api/src/daily-completion/infrastructure/adapters/friend.adapter.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@nestjs/common";
+import { FollowFacade } from "@/follow";
+import type { FriendPort } from "../../application/ports/friend.port";
+
+/**
+ * 친구/맞팔 포트 어댑터 — FollowFacade에 위임
+ */
+@Injectable()
+export class FriendAdapter implements FriendPort {
+	constructor(private readonly followFacade: FollowFacade) {}
+
+	isMutualFriend(userId: string, targetUserId: string): Promise<boolean> {
+		return this.followFacade.isMutualFriend(userId, targetUserId);
+	}
+}

--- a/apps/api/src/daily-completion/infrastructure/adapters/prisma-todo-completion.repository.ts
+++ b/apps/api/src/daily-completion/infrastructure/adapters/prisma-todo-completion.repository.ts
@@ -33,11 +33,30 @@ export class PrismaTodoCompletionRepository
 		params: AggregateByDateRangeParams,
 	): Promise<TodoAggregateByDate[]> {
 		const { userId, startDate, endDate } = params;
-		const whereClause = {
+
+		return this.#aggregate({
 			userId,
 			startDate: { gte: startDate, lt: endDate },
-		};
+		});
+	}
 
+	async aggregatePublicByDateRange(
+		params: AggregateByDateRangeParams,
+	): Promise<TodoAggregateByDate[]> {
+		const { userId, startDate, endDate } = params;
+
+		return this.#aggregate({
+			userId,
+			visibility: "PUBLIC",
+			startDate: { gte: startDate, lt: endDate },
+		});
+	}
+
+	async #aggregate(whereClause: {
+		userId: string;
+		visibility?: "PUBLIC";
+		startDate: { gte: Date; lt: Date };
+	}): Promise<TodoAggregateByDate[]> {
 		// 전체·완료·카테고리 색상 집계를 병렬 실행 (waterfall 제거)
 		const [aggregations, completedAggregations, categoryColorResults] =
 			await Promise.all([

--- a/apps/api/src/daily-completion/presentation/daily-completion.controller.ts
+++ b/apps/api/src/daily-completion/presentation/daily-completion.controller.ts
@@ -1,9 +1,11 @@
 import { ErrorCode } from "@aido/errors";
-import { Controller, Get, Logger, Query } from "@nestjs/common";
+import { Controller, Get, Logger, Param, Query } from "@nestjs/common";
 import { ApiBearerAuth, ApiQuery, ApiTags } from "@nestjs/swagger";
 
+import { UserIdParamDto } from "@/shared/presentation/dtos";
 import {
 	ApiDoc,
+	ApiForbiddenError,
 	ApiSuccessResponse,
 	ApiUnauthorizedError,
 	SWAGGER_TAGS,
@@ -133,6 +135,73 @@ GET /daily-completions?startDate=2026-01-01&endDate=2026-01-31
 
 		this.#logger.debug(
 			`일일 완료 현황 조회 완료: user=${user.userId}, days=${result.completions.length}, completeDays=${result.totalCompleteDays}`,
+		);
+
+		return this.#mapToResponse(result);
+	}
+
+	@Get("friends/:userId")
+	@ApiQuery({
+		name: "startDate",
+		required: true,
+		description: "조회 시작 날짜 (YYYY-MM-DD)",
+		example: "2026-01-01",
+	})
+	@ApiQuery({
+		name: "endDate",
+		required: true,
+		description: "조회 종료 날짜 (YYYY-MM-DD)",
+		example: "2026-01-31",
+	})
+	@ApiDoc({
+		summary: "친구의 날짜 범위 내 일일 완료 현황 조회",
+		operationId: "getFriendDailyCompletions",
+		description: `
+## 친구 일일 완료 현황 조회
+
+친구의 지정된 날짜 범위 내 일일 완료 현황을 조회합니다.
+친구 캘린더에서 물고기 아이콘·카테고리 점을 표시하는 데 사용됩니다.
+
+맞팔 관계여야만 조회 가능하며, 공개(PUBLIC) 할 일만 집계합니다 —
+\`GET /todos/friends/{userId}\` 목록과 같은 공개 기준이라 캘린더 마커와
+날짜별 목록이 항상 일치합니다.
+
+### 인증 필요
+\`Authorization: Bearer {accessToken}\`
+
+### 요청 예시
+\`\`\`
+GET /daily-completions/friends/{userId}?startDate=2026-01-01&endDate=2026-01-31
+\`\`\`
+
+응답 구조는 \`GET /daily-completions\`와 동일합니다 (PUBLIC 할 일 기준 집계).
+
+#### 에러 케이스
+
+| 케이스 | 응답 |
+|--------|------|
+| 맞팔 관계가 아닌 경우 | \`403 Forbidden\` (FOLLOW_0906) |
+| startDate가 endDate보다 이후 | \`400 Bad Request\` (SYS_0002) |
+| 잘못된 날짜 형식 | \`400 Bad Request\` (SYS_0002) |
+		`,
+	})
+	@ApiSuccessResponse({ type: DailyCompletionsRangeResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiForbiddenError(ErrorCode.FOLLOW_0906)
+	async getFriendDailyCompletions(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: UserIdParamDto,
+		@Query() query: GetDailyCompletionsRangeDto,
+	): Promise<DailyCompletionsRangeResponseDto> {
+		this.#logger.debug(
+			`친구 일일 완료 현황 조회: friendUserId=${params.userId}, user=${user.userId}, range=${query.startDate}~${query.endDate}`,
+		);
+
+		const result = await this.dailyCompletionFacade.getFriendDailyCompletions(
+			user.userId,
+			params.userId,
+			query.startDate,
+			query.endDate,
 		);
 
 		return this.#mapToResponse(result);

--- a/apps/api/src/shared/infrastructure/cache/constants/cache-keys.ts
+++ b/apps/api/src/shared/infrastructure/cache/constants/cache-keys.ts
@@ -190,6 +190,25 @@ export const CacheKeys = {
 	dailyCompletionRange: (userId: string, startDate: string, endDate: string) =>
 		cacheKey("daily-completion", "range-v1", userId, startDate, endDate),
 
+	/**
+	 * 친구에게 보이는 공개(PUBLIC) 일별 완료 현황 캐시 키 — 소유자 기준.
+	 * userId 뒤 세그먼트라 dailyCompletionPattern(소유자) 무효화에 함께 걸린다.
+	 * @example daily-completion:range:v1:user_1:public:2026-07-01:2026-07-31
+	 */
+	dailyCompletionPublicRange: (
+		ownerUserId: string,
+		startDate: string,
+		endDate: string,
+	) =>
+		cacheKey(
+			"daily-completion",
+			"range-v1",
+			ownerUserId,
+			"public",
+			startDate,
+			endDate,
+		),
+
 	// === 패턴 빌더 (와일드카드) ===
 
 	/**

--- a/apps/api/src/todo/application/ports/todo-cache.port.ts
+++ b/apps/api/src/todo/application/ports/todo-cache.port.ts
@@ -8,7 +8,7 @@ export const TODO_CACHE = Symbol("TODO_CACHE");
  *
  * 친구 공개 투두 캐시: 값은 소유자의 PUBLIC 첫 페이지이며 뷰어와 무관하게 공유됩니다
  * (권한 확인은 매 요청 수행). 날짜 세그먼트는 YYYY-MM-DD 또는 "-"(미지정)입니다.
- * reorder/visibility/title/item 쓰기는 도메인 이벤트를 발생시키지 않으므로
+ * reorder/title/item 쓰기는 도메인 이벤트를 발생시키지 않으므로
  * 이벤트 기반이 아닌 명시적 무효화(invalidateFriendTodos)가 필요합니다 —
  * 모든 쓰기 use-case가 TX 커밋 후 직접 호출합니다.
  */

--- a/apps/api/src/todo/application/use-cases/update-todo-visibility/update-todo-visibility.use-case.spec.ts
+++ b/apps/api/src/todo/application/use-cases/update-todo-visibility/update-todo-visibility.use-case.spec.ts
@@ -10,12 +10,18 @@ import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
 import { TodoBuilder } from "@test/builders";
 import {
+	createTodoCacheMock,
 	createTodoReadRepositoryMock,
 	createTodoRepositoryMock,
 	createUnitOfWorkMock,
 } from "@test/mocks/ports";
-import { UNIT_OF_WORK } from "@/shared/application/ports";
+import {
+	DOMAIN_EVENT_PUBLISHER,
+	type DomainEventPublisherPort,
+	UNIT_OF_WORK,
+} from "@/shared/application/ports";
 import { Todo } from "../../../domain/entities/todo.entity";
+import { TodoVisibilityChangedEvent } from "../../../domain/events/todo-visibility-changed.event";
 import { TodoId } from "../../../domain/value-objects/todo-id.vo";
 import { TodoSchedule } from "../../../domain/value-objects/todo-schedule.vo";
 import { TodoMapper } from "../../../infrastructure/persistence/todo-response.mapper";
@@ -23,6 +29,7 @@ import {
 	TODO_REPOSITORY,
 	type TodoRepositoryPort,
 } from "../../ports/todo.repository.port";
+import { TODO_CACHE, type TodoCachePort } from "../../ports/todo-cache.port";
 import {
 	TODO_READ_REPOSITORY,
 	type TodoReadRepositoryPort,
@@ -62,6 +69,8 @@ describe("UpdateTodoVisibilityUseCase — 할 일 공개 범위 변경 핸들러
 	let useCase: UpdateTodoVisibilityUseCase;
 	let todoRepository: Mocked<TodoRepositoryPort>;
 	let todoReadRepository: Mocked<TodoReadRepositoryPort>;
+	let todoCache: Mocked<TodoCachePort>;
+	let eventPublisher: Mocked<DomainEventPublisherPort>;
 
 	beforeEach(async () => {
 		const { unit, unitRef } = await TestBed.solitary(
@@ -73,15 +82,23 @@ describe("UpdateTodoVisibilityUseCase — 할 일 공개 범위 변경 핸들러
 			.impl(() => createTodoReadRepositoryMock())
 			.mock(UNIT_OF_WORK)
 			.impl(() => createUnitOfWorkMock())
+			.mock<TodoCachePort>(TODO_CACHE)
+			.impl(() => createTodoCacheMock())
+			.mock<DomainEventPublisherPort>(DOMAIN_EVENT_PUBLISHER)
+			.impl(() => ({ publishAll: jest.fn().mockResolvedValue(undefined) }))
 			.compile();
 
 		useCase = unit;
 		todoRepository = unitRef.get<TodoRepositoryPort>(TODO_REPOSITORY);
 		todoReadRepository =
 			unitRef.get<TodoReadRepositoryPort>(TODO_READ_REPOSITORY);
+		todoCache = unitRef.get<TodoCachePort>(TODO_CACHE);
+		eventPublisher = unitRef.get<DomainEventPublisherPort>(
+			DOMAIN_EVENT_PUBLISHER,
+		);
 	});
 
-	it("공개 범위를 영속화하고 응답을 재조회한다", async () => {
+	it("공개 범위를 영속화하고 이벤트를 발행한 뒤 공개 캐시를 무효화한다", async () => {
 		// Given
 		todoRepository.findByIdAndUserId.mockResolvedValue(buildEntity());
 		todoReadRepository.findByIdAndUserId.mockResolvedValue(buildResponse());
@@ -95,6 +112,10 @@ describe("UpdateTodoVisibilityUseCase — 할 일 공개 범위 변경 핸들러
 
 		// Then
 		expect(todoRepository.updateVisibility).toHaveBeenCalledWith(1, "PRIVATE");
+		expect(eventPublisher.publishAll).toHaveBeenCalledWith([
+			new TodoVisibilityChangedEvent(1, "user-123"),
+		]);
+		expect(todoCache.invalidateFriendTodos).toHaveBeenCalledWith("user-123");
 		expect(result.id).toBe(1);
 	});
 
@@ -107,6 +128,7 @@ describe("UpdateTodoVisibilityUseCase — 할 일 공개 범위 변경 핸들러
 			useCase.execute({ id: 999, userId: "user-123", visibility: "PUBLIC" }),
 		).rejects.toMatchObject({ errorCode: ErrorCode.TODO_0801 });
 		expect(todoRepository.updateVisibility).not.toHaveBeenCalled();
+		expect(eventPublisher.publishAll).not.toHaveBeenCalled();
 	});
 
 	it("재조회 응답이 없으면 ApplicationException(TODO_0801)을 던진다", async () => {

--- a/apps/api/src/todo/application/use-cases/update-todo-visibility/update-todo-visibility.use-case.ts
+++ b/apps/api/src/todo/application/use-cases/update-todo-visibility/update-todo-visibility.use-case.ts
@@ -1,7 +1,12 @@
 import { ErrorCode } from "@aido/errors";
 import type { Todo as TodoResponse } from "@aido/validators";
 import { Inject, Injectable, Logger } from "@nestjs/common";
-import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import {
+	DOMAIN_EVENT_PUBLISHER,
+	type DomainEventPublisherPort,
+	UNIT_OF_WORK,
+	type UnitOfWorkPort,
+} from "@/shared/application/ports";
 import { ApplicationException } from "@/shared/domain";
 import type { TodoVisibility } from "../../../domain/entities/todo.entity";
 import {
@@ -25,7 +30,7 @@ export interface UpdateTodoVisibilityInput {
  * Todo 공개 범위 변경 use-case
  *
  * 소유권 확인 → 애그리게잇 전이 → 애그리게잇 상태로 영속화 → 읽기 포트로 응답 재조회.
- * 부수효과 없음(레거시 동작 보존).
+ * 커밋 후 이벤트를 발행해 공개 범위에 의존하는 크로스모듈 캐시를 무효화합니다.
  */
 @Injectable()
 export class UpdateTodoVisibilityUseCase {
@@ -40,13 +45,15 @@ export class UpdateTodoVisibilityUseCase {
 		private readonly uow: UnitOfWorkPort,
 		@Inject(TODO_CACHE)
 		private readonly todoCache: TodoCachePort,
+		@Inject(DOMAIN_EVENT_PUBLISHER)
+		private readonly eventPublisher: DomainEventPublisherPort,
 	) {}
 
 	async execute(input: UpdateTodoVisibilityInput): Promise<TodoResponse> {
 		const { id, userId, visibility } = input;
 
 		// TX 안에서 로드 → 애그리게잇 전이 → 애그리게잇 상태로 영속화
-		await this.uow.run(async () => {
+		const events = await this.uow.run(async () => {
 			const todo = await this.todoRepository.findByIdAndUserId(id, userId);
 			if (!todo) {
 				throw new ApplicationException(ErrorCode.TODO_0801, { todoId: id });
@@ -57,13 +64,17 @@ export class UpdateTodoVisibilityUseCase {
 				id,
 				todo.toPersistence().visibility,
 			);
+			return todo.pullDomainEvents();
 		});
 
 		this.#logger.log(
 			`Todo visibility updated: ${id} -> ${visibility} for user: ${userId}`,
 		);
 
-		// 친구 공개 투두 캐시 무효화 (TX 커밋 후 — visibility 변경은 도메인 이벤트가 없어 명시적 무효화)
+		// 저장(TX 커밋) 완료 후 이벤트 발행 (daily-completion 공개 캐시 무효화 트리거)
+		await this.eventPublisher.publishAll(events);
+
+		// 친구 공개 투두 캐시 무효화 (TX 커밋 후)
 		await this.todoCache.invalidateFriendTodos(userId);
 
 		// 응답 재조회

--- a/apps/api/src/todo/domain/entities/todo.entity.spec.ts
+++ b/apps/api/src/todo/domain/entities/todo.entity.spec.ts
@@ -12,6 +12,7 @@ import { TodoCreatedEvent } from "../events/todo-created.event";
 import { TodoRescheduledEvent } from "../events/todo-rescheduled.event";
 import { TodoToggledEvent } from "../events/todo-toggled.event";
 import { TodoUpdatedEvent } from "../events/todo-updated.event";
+import { TodoVisibilityChangedEvent } from "../events/todo-visibility-changed.event";
 import { TodoId } from "../value-objects/todo-id.vo";
 import {
 	TodoSchedule,
@@ -434,16 +435,27 @@ describe("Todo — 할 일 애그리게잇", () => {
 	});
 
 	describe("changeVisibility / changeCategory", () => {
-		it("공개 범위를 변경하고 이벤트는 적립하지 않는다", () => {
+		it("공개 범위를 변경하고 TodoVisibilityChangedEvent를 적립한다", () => {
 			// Given
-			const todo = Todo.reconstitute(buildProps({ visibility: "PUBLIC" }));
+			const todo = Todo.reconstitute(
+				buildProps({
+					id: TodoId.create(3),
+					userId: "user-1",
+					visibility: "PUBLIC",
+				}),
+			);
 
 			// When
 			todo.changeVisibility("PRIVATE");
 
 			// Then
 			expect(todo.toPersistence().visibility).toBe("PRIVATE");
-			expect(todo.pullDomainEvents()).toHaveLength(0);
+			const event = todo.pullDomainEvents()[0];
+			expect(event).toBeInstanceOf(TodoVisibilityChangedEvent);
+			if (event instanceof TodoVisibilityChangedEvent) {
+				expect(event.todoId).toBe(3);
+				expect(event.userId).toBe("user-1");
+			}
 		});
 
 		it("카테고리를 변경하고 TodoCategoryChangedEvent를 적립한다 (일별 완료 색상 집계 캐시 무효화)", () => {

--- a/apps/api/src/todo/domain/entities/todo.entity.ts
+++ b/apps/api/src/todo/domain/entities/todo.entity.ts
@@ -8,6 +8,7 @@ import { TodoDeletedEvent } from "../events/todo-deleted.event";
 import { TodoRescheduledEvent } from "../events/todo-rescheduled.event";
 import { TodoToggledEvent } from "../events/todo-toggled.event";
 import { TodoUpdatedEvent } from "../events/todo-updated.event";
+import { TodoVisibilityChangedEvent } from "../events/todo-visibility-changed.event";
 import { TodoId } from "../value-objects/todo-id.vo";
 import {
 	TodoSchedule,
@@ -308,10 +309,17 @@ export class Todo extends AggregateRoot<TodoProps> {
 	/**
 	 * 공개 범위를 변경합니다 (PATCH /todos/:id/visibility).
 	 *
-	 * 부수효과가 없는 단순 상태 전이라 이벤트를 적립하지 않습니다.
+	 * 친구 공개 투두와 일별 완료 현황의 공개 범위가 달라지므로,
+	 * TodoVisibilityChangedEvent를 적립해 공개 캐시 무효화를 트리거합니다.
 	 */
 	changeVisibility(visibility: TodoVisibility): void {
 		this.props.visibility = visibility;
+		this.raise(
+			new TodoVisibilityChangedEvent(
+				this.props.id.getValue(),
+				this.props.userId,
+			),
+		);
 	}
 
 	/**

--- a/apps/api/src/todo/domain/events/todo-event-names.ts
+++ b/apps/api/src/todo/domain/events/todo-event-names.ts
@@ -11,4 +11,5 @@ export const TODO_EVENTS = {
 	TOGGLED: "todo.toggled",
 	RESCHEDULED: "todo.rescheduled",
 	CATEGORY_CHANGED: "todo.category-changed",
+	VISIBILITY_CHANGED: "todo.visibility-changed",
 } as const;

--- a/apps/api/src/todo/domain/events/todo-visibility-changed.event.ts
+++ b/apps/api/src/todo/domain/events/todo-visibility-changed.event.ts
@@ -1,0 +1,16 @@
+/**
+ * Todo 공개 범위 변경 도메인 이벤트 (PATCH /todos/:id/visibility)
+ *
+ * 친구에게 보이는 투두와 일별 완료 현황은 PUBLIC 투두만 집계하므로,
+ * 공개 범위가 바뀌면 소유자 기준 공개 캐시를 무효화해야 합니다.
+ */
+import { TODO_EVENTS } from "./todo-event-names";
+
+export class TodoVisibilityChangedEvent {
+	readonly eventName = TODO_EVENTS.VISIBILITY_CHANGED;
+
+	constructor(
+		public readonly todoId: number,
+		public readonly userId: string,
+	) {}
+}

--- a/apps/api/src/todo/index.ts
+++ b/apps/api/src/todo/index.ts
@@ -15,5 +15,6 @@ export * from "./domain/events/todo-event-names";
 export * from "./domain/events/todo-rescheduled.event";
 export * from "./domain/events/todo-toggled.event";
 export * from "./domain/events/todo-updated.event";
+export * from "./domain/events/todo-visibility-changed.event";
 export * from "./presentation/dtos";
 export * from "./todo.module";

--- a/apps/api/test/e2e/__snapshots__/openapi-contract.e2e-spec.ts.snap
+++ b/apps/api/test/e2e/__snapshots__/openapi-contract.e2e-spec.ts.snap
@@ -20482,6 +20482,227 @@ GET /daily-completions?startDate=2026-01-01&endDate=2026-01-31
       ],
     },
   },
+  "/v1/daily-completions/friends/{userId}": {
+    "get": {
+      "description": "
+## 친구 일일 완료 현황 조회
+
+친구의 지정된 날짜 범위 내 일일 완료 현황을 조회합니다.
+친구 캘린더에서 물고기 아이콘·카테고리 점을 표시하는 데 사용됩니다.
+
+맞팔 관계여야만 조회 가능하며, 공개(PUBLIC) 할 일만 집계합니다 —
+\`GET /todos/friends/{userId}\` 목록과 같은 공개 기준이라 캘린더 마커와
+날짜별 목록이 항상 일치합니다.
+
+### 인증 필요
+\`Authorization: Bearer {accessToken}\`
+
+### 요청 예시
+\`\`\`
+GET /daily-completions/friends/{userId}?startDate=2026-01-01&endDate=2026-01-31
+\`\`\`
+
+응답 구조는 \`GET /daily-completions\`와 동일합니다 (PUBLIC 할 일 기준 집계).
+
+#### 에러 케이스
+
+| 케이스 | 응답 |
+|--------|------|
+| 맞팔 관계가 아닌 경우 | \`403 Forbidden\` (FOLLOW_0906) |
+| startDate가 endDate보다 이후 | \`400 Bad Request\` (SYS_0002) |
+| 잘못된 날짜 형식 | \`400 Bad Request\` (SYS_0002) |
+		",
+      "operationId": "getFriendDailyCompletions",
+      "parameters": [
+        {
+          "description": "사용자 ID (CUID 25자, 예: clz7x5p8k0001qz0z8z8z8z8z)",
+          "in": "path",
+          "name": "userId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+        {
+          "description": "조회 시작 날짜 (YYYY-MM-DD)",
+          "in": "query",
+          "name": "startDate",
+          "required": true,
+          "schema": {
+            "example": "2026-01-01",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "type": "string",
+          },
+        },
+        {
+          "description": "조회 종료 날짜 (YYYY-MM-DD)",
+          "in": "query",
+          "name": "endDate",
+          "required": true,
+          "schema": {
+            "example": "2026-01-31",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "type": "string",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/DailyCompletionsRangeResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "403": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "FOLLOW_0906",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "친구가 아닌 사용자의 투두를 볼 수 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "친구가 아닌 사용자의 투두를 볼 수 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "친구의 날짜 범위 내 일일 완료 현황 조회",
+      "tags": [
+        "Daily Completions",
+      ],
+    },
+  },
   "/v1/follows/friends": {
     "get": {
       "description": "나와 맞팔 관계인 친구 목록을 조회합니다.

--- a/apps/api/test/e2e/daily-completion.e2e-spec.ts
+++ b/apps/api/test/e2e/daily-completion.e2e-spec.ts
@@ -575,6 +575,98 @@ describe("일일 달성 E2E", () => {
 				expect(ownerView.body.data.completions[0].totalTodos).toBe(2);
 				expect(ownerView.body.data.completions[0].isComplete).toBe(false);
 			});
+
+			it("친구용 캐시 생성 후 PUBLIC을 PRIVATE으로 바꾸면 같은 범위에서 즉시 사라진다", async () => {
+				// Given - 맞팔 친구의 완료된 PUBLIC 할 일과 캐시된 친구 완료 현황
+				const viewer = await ctx.helpers.createVerifiedUser(
+					"dc-visibility-private-viewer@test.com",
+					password,
+				);
+				const friend = await ctx.helpers.createVerifiedUser(
+					"dc-visibility-private-owner@test.com",
+					password,
+				);
+				await ctx.helpers.createFriendship(viewer, friend);
+				const todo = await createTodo(friend.accessToken, {
+					title: "공개 완료",
+					startDate: "2026-08-01",
+					completed: true,
+					visibility: "PUBLIC",
+				});
+				const query = { startDate: "2026-08-01", endDate: "2026-08-01" };
+
+				const cached = await request(ctx.app.getHttpServer())
+					.get(`/v1/daily-completions/friends/${friend.userId}`)
+					.set("Authorization", `Bearer ${viewer.accessToken}`)
+					.query(query)
+					.expect(200);
+				expect(cached.body.data.completions).toHaveLength(1);
+
+				// When - 소유자가 공개 할 일을 비공개로 변경한 뒤 같은 조건으로 재조회
+				await request(ctx.app.getHttpServer())
+					.patch(`/v1/todos/${todo.id}/visibility`)
+					.set("Authorization", `Bearer ${friend.accessToken}`)
+					.send({ visibility: "PRIVATE" })
+					.expect(200);
+				const refreshed = await request(ctx.app.getHttpServer())
+					.get(`/v1/daily-completions/friends/${friend.userId}`)
+					.set("Authorization", `Bearer ${viewer.accessToken}`)
+					.query(query)
+					.expect(200);
+
+				// Then - 기존 공개 집계가 캐시 TTL 동안 노출되지 않음
+				expect(refreshed.body.data.completions).toEqual([]);
+				expect(refreshed.body.data.totalCompleteDays).toBe(0);
+			});
+
+			it("친구용 빈 캐시 생성 후 PRIVATE을 PUBLIC으로 바꾸면 같은 범위에 즉시 나타난다", async () => {
+				// Given - 맞팔 친구의 완료된 PRIVATE 할 일과 캐시된 빈 친구 완료 현황
+				const viewer = await ctx.helpers.createVerifiedUser(
+					"dc-visibility-public-viewer@test.com",
+					password,
+				);
+				const friend = await ctx.helpers.createVerifiedUser(
+					"dc-visibility-public-owner@test.com",
+					password,
+				);
+				await ctx.helpers.createFriendship(viewer, friend);
+				const todo = await createTodo(friend.accessToken, {
+					title: "비공개 완료",
+					startDate: "2026-08-02",
+					completed: true,
+					visibility: "PRIVATE",
+				});
+				const query = { startDate: "2026-08-02", endDate: "2026-08-02" };
+
+				const cached = await request(ctx.app.getHttpServer())
+					.get(`/v1/daily-completions/friends/${friend.userId}`)
+					.set("Authorization", `Bearer ${viewer.accessToken}`)
+					.query(query)
+					.expect(200);
+				expect(cached.body.data.completions).toEqual([]);
+
+				// When - 소유자가 비공개 할 일을 공개로 변경한 뒤 같은 조건으로 재조회
+				await request(ctx.app.getHttpServer())
+					.patch(`/v1/todos/${todo.id}/visibility`)
+					.set("Authorization", `Bearer ${friend.accessToken}`)
+					.send({ visibility: "PUBLIC" })
+					.expect(200);
+				const refreshed = await request(ctx.app.getHttpServer())
+					.get(`/v1/daily-completions/friends/${friend.userId}`)
+					.set("Authorization", `Bearer ${viewer.accessToken}`)
+					.query(query)
+					.expect(200);
+
+				// Then - 빈 캐시가 제거되어 현재 공개 집계를 반환함
+				expect(refreshed.body.data.completions).toHaveLength(1);
+				expect(refreshed.body.data.completions[0]).toMatchObject({
+					date: "2026-08-02",
+					totalTodos: 1,
+					completedTodos: 1,
+					isComplete: true,
+				});
+				expect(refreshed.body.data.totalCompleteDays).toBe(1);
+			});
 		});
 
 		describe("월간 캘린더 시나리오", () => {

--- a/apps/api/test/e2e/daily-completion.e2e-spec.ts
+++ b/apps/api/test/e2e/daily-completion.e2e-spec.ts
@@ -17,7 +17,12 @@ describe("일일 달성 E2E", () => {
 	 */
 	async function createTodo(
 		accessToken: string,
-		data: { title: string; startDate: string; completed?: boolean },
+		data: {
+			title: string;
+			startDate: string;
+			completed?: boolean;
+			visibility?: "PUBLIC" | "PRIVATE";
+		},
 	): Promise<{ id: number }> {
 		const categoryId = await ctx.helpers.getDefaultCategoryId(accessToken);
 		const response = await request(ctx.app.getHttpServer())
@@ -27,6 +32,7 @@ describe("일일 달성 E2E", () => {
 				title: data.title,
 				startDate: data.startDate,
 				categoryId,
+				visibility: data.visibility,
 			})
 			.expect(201);
 
@@ -411,6 +417,163 @@ describe("일일 달성 E2E", () => {
 				expect(response.status).toBe(200);
 				expect(response.body.data.completions[0].completedTodos).toBe(1);
 				expect(response.body.data.completions[0].completionRate).toBe(50);
+			});
+		});
+
+		describe("GET /daily-completions/friends/:userId - 친구 일일 완료 현황 조회", () => {
+			it("인증 없이 접근 시 401 반환", async () => {
+				// Given - 인증되지 않은 상태
+
+				// When - 인증 토큰 없이 API 호출
+				const response = await request(ctx.app.getHttpServer())
+					.get("/v1/daily-completions/friends/clz7x5p8k0001qz0z8z8z8z8z8")
+					.query({ startDate: "2026-01-01", endDate: "2026-01-31" });
+
+				// Then - 401 Unauthorized 반환
+				expect(response.status).toBe(401);
+			});
+
+			it("맞팔 관계가 아니면 403 반환", async () => {
+				// Given - 팔로우 관계가 없는 두 사용자 준비
+				const viewer = await ctx.helpers.createVerifiedUser(
+					"dc-friend-viewer1@test.com",
+					password,
+				);
+				const stranger = await ctx.helpers.createVerifiedUser(
+					"dc-friend-stranger@test.com",
+					password,
+				);
+
+				// When - 맞팔이 아닌 사용자의 완료 현황 조회
+				const response = await request(ctx.app.getHttpServer())
+					.get(`/v1/daily-completions/friends/${stranger.userId}`)
+					.set("Authorization", `Bearer ${viewer.accessToken}`)
+					.query({ startDate: "2026-01-01", endDate: "2026-01-31" });
+
+				// Then - 403 Forbidden (FOLLOW_0906) 반환
+				expect(response.status).toBe(403);
+				expect(response.body.success).toBe(false);
+				expect(response.body.error.code).toBe("FOLLOW_0906");
+			});
+
+			it("맞팔이면 친구의 PUBLIC 할 일만 집계해 반환한다", async () => {
+				// Given - 맞팔 관계인 두 사용자와 친구의 PUBLIC/PRIVATE 할 일 준비
+				const viewer = await ctx.helpers.createVerifiedUser(
+					"dc-friend-viewer2@test.com",
+					password,
+				);
+				const friend = await ctx.helpers.createVerifiedUser(
+					"dc-friend-owner@test.com",
+					password,
+				);
+				await ctx.helpers.createFriendship(viewer, friend);
+
+				// 6/1: PUBLIC 2개(1개 완료) + PRIVATE 1개(완료) → PUBLIC 기준 2개 중 1개
+				await createTodo(friend.accessToken, {
+					title: "공개 완료",
+					startDate: "2026-06-01",
+					completed: true,
+					visibility: "PUBLIC",
+				});
+				await createTodo(friend.accessToken, {
+					title: "공개 미완료",
+					startDate: "2026-06-01",
+					visibility: "PUBLIC",
+				});
+				await createTodo(friend.accessToken, {
+					title: "비공개 완료",
+					startDate: "2026-06-01",
+					completed: true,
+					visibility: "PRIVATE",
+				});
+
+				// 6/2: PUBLIC 1개(완료) + PRIVATE 1개(미완료) → PUBLIC 기준 100% 완료(물고기)
+				await createTodo(friend.accessToken, {
+					title: "공개 완료",
+					startDate: "2026-06-02",
+					completed: true,
+					visibility: "PUBLIC",
+				});
+				await createTodo(friend.accessToken, {
+					title: "비공개 미완료",
+					startDate: "2026-06-02",
+					visibility: "PRIVATE",
+				});
+
+				// 6/3: PRIVATE만 1개 → PUBLIC 기준 할 일 없는 날 (응답 미포함)
+				await createTodo(friend.accessToken, {
+					title: "비공개만",
+					startDate: "2026-06-03",
+					visibility: "PRIVATE",
+				});
+
+				// When - 친구의 6월 완료 현황 조회
+				const response = await request(ctx.app.getHttpServer())
+					.get(`/v1/daily-completions/friends/${friend.userId}`)
+					.set("Authorization", `Bearer ${viewer.accessToken}`)
+					.query({ startDate: "2026-06-01", endDate: "2026-06-30" });
+
+				// Then - PUBLIC 기준으로만 집계되어 PRIVATE 존재가 드러나지 않음
+				expect(response.status).toBe(200);
+				const { completions, totalCompleteDays } = response.body.data;
+
+				expect(completions.length).toBe(2);
+
+				const day1 = completions.find(
+					(c: { date: string }) => c.date === "2026-06-01",
+				);
+				expect(day1.totalTodos).toBe(2);
+				expect(day1.completedTodos).toBe(1);
+				expect(day1.isComplete).toBe(false);
+
+				const day2 = completions.find(
+					(c: { date: string }) => c.date === "2026-06-02",
+				);
+				expect(day2.totalTodos).toBe(1);
+				expect(day2.completedTodos).toBe(1);
+				expect(day2.isComplete).toBe(true);
+
+				expect(totalCompleteDays).toBe(1);
+			});
+
+			it("내 완료 현황 조회는 PRIVATE을 포함해 친구용 조회와 독립적이다", async () => {
+				// Given - 맞팔 친구가 PUBLIC 1개(완료) + PRIVATE 1개(미완료) 보유
+				const viewer = await ctx.helpers.createVerifiedUser(
+					"dc-friend-viewer3@test.com",
+					password,
+				);
+				const friend = await ctx.helpers.createVerifiedUser(
+					"dc-friend-owner2@test.com",
+					password,
+				);
+				await ctx.helpers.createFriendship(viewer, friend);
+
+				await createTodo(friend.accessToken, {
+					title: "공개 완료",
+					startDate: "2026-07-01",
+					completed: true,
+					visibility: "PUBLIC",
+				});
+				await createTodo(friend.accessToken, {
+					title: "비공개 미완료",
+					startDate: "2026-07-01",
+					visibility: "PRIVATE",
+				});
+
+				// When - 뷰어가 친구용으로, 친구 본인이 내 것으로 각각 조회
+				const friendView = await request(ctx.app.getHttpServer())
+					.get(`/v1/daily-completions/friends/${friend.userId}`)
+					.set("Authorization", `Bearer ${viewer.accessToken}`)
+					.query({ startDate: "2026-07-01", endDate: "2026-07-01" });
+				const ownerView = await request(ctx.app.getHttpServer())
+					.get("/v1/daily-completions")
+					.set("Authorization", `Bearer ${friend.accessToken}`)
+					.query({ startDate: "2026-07-01", endDate: "2026-07-01" });
+
+				// Then - 친구용은 PUBLIC 기준 완료(물고기), 본인은 전체 기준 미완료
+				expect(friendView.body.data.completions[0].isComplete).toBe(true);
+				expect(ownerView.body.data.completions[0].totalTodos).toBe(2);
+				expect(ownerView.body.data.completions[0].isComplete).toBe(false);
 			});
 		});
 

--- a/apps/api/test/integration/daily-completion.integration-spec.ts
+++ b/apps/api/test/integration/daily-completion.integration-spec.ts
@@ -22,10 +22,15 @@
 
 import { Test, type TestingModule } from "@nestjs/testing";
 import { TransactionHost } from "@nestjs-cls/transactional";
+import {
+	createDailyCompletionCacheMock,
+	createDailyCompletionFriendMock,
+} from "@test/mocks/ports";
 import { suppressLogger } from "@test/setup/suppress-logger";
 import dayjs from "dayjs";
 import { DailyCompletionFacade } from "@/daily-completion/application/facades/daily-completion.facade";
 import { DAILY_COMPLETION_CACHE } from "@/daily-completion/application/ports/daily-completion-cache.port";
+import { FRIEND_PORT } from "@/daily-completion/application/ports/friend.port";
 import { TODO_COMPLETION_REPOSITORY } from "@/daily-completion/application/ports/todo-completion.repository.port";
 import { DailyCompletionQueryUseCases } from "@/daily-completion/application/queries";
 import { PrismaTodoCompletionRepository } from "@/daily-completion/infrastructure/adapters/prisma-todo-completion.repository";
@@ -39,6 +44,8 @@ describe("DailyCompletion 통합 테스트 (실제 DB)", () => {
 	let repository: PrismaTodoCompletionRepository;
 	let testDb: TestDatabase;
 	let databaseService: DatabaseService;
+	const cache = createDailyCompletionCacheMock();
+	const friend = createDailyCompletionFriendMock();
 
 	// 테스트 스위트 시작 시 한 번만 실행
 	beforeAll(async () => {
@@ -63,14 +70,11 @@ describe("DailyCompletion 통합 테스트 (실제 DB)", () => {
 					useValue: { tx: databaseService },
 				},
 				{
-					// 통합 테스트는 DB 경로를 검증하므로 캐시는 항상 미스인 no-op 스텁
 					provide: DAILY_COMPLETION_CACHE,
-					useValue: {
-						getRange: async () => undefined,
-						setRange: async () => undefined,
-						invalidate: async () => undefined,
-					},
+					// 통합 테스트는 DB 경로를 검증하므로 기본 undefined를 반환하는 mock 사용
+					useValue: cache,
 				},
+				{ provide: FRIEND_PORT, useValue: friend },
 			],
 		}).compile();
 

--- a/apps/api/test/mocks/ports/daily-completion.mock.ts
+++ b/apps/api/test/mocks/ports/daily-completion.mock.ts
@@ -1,0 +1,24 @@
+import type { DailyCompletionCachePort } from "@/daily-completion/application/ports/daily-completion-cache.port";
+import type { FriendPort } from "@/daily-completion/application/ports/friend.port";
+
+/**
+ * DailyCompletion 애플리케이션 포트 mock 팩토리 모음.
+ *
+ * 반환 타입을 포트 인터페이스로 강제해 포트 확장 시 누락을 타입 에러로 잡습니다.
+ * 개별 메서드 mock API는 `jest.mocked(mock.method)`로 접근합니다.
+ */
+export function createDailyCompletionCacheMock(): DailyCompletionCachePort {
+	return {
+		getRange: jest.fn(),
+		setRange: jest.fn(),
+		getPublicRange: jest.fn(),
+		setPublicRange: jest.fn(),
+		invalidate: jest.fn(),
+	};
+}
+
+export function createDailyCompletionFriendMock(): FriendPort {
+	return {
+		isMutualFriend: jest.fn(),
+	};
+}

--- a/apps/api/test/mocks/ports/index.ts
+++ b/apps/api/test/mocks/ports/index.ts
@@ -8,6 +8,7 @@
  */
 export * from "./cheer.mock";
 export * from "./cross-module.mock";
+export * from "./daily-completion.mock";
 export * from "./follow.mock";
 export * from "./memo.mock";
 export * from "./notification.mock";

--- a/apps/mobile/app/(app)/(tabs)/feed/(feed)/_layout.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/(feed)/_layout.tsx
@@ -1,4 +1,5 @@
 import { useGetFriendsQueryOptions } from '@src/features/friend/presentations/queries/use-get-friends-query-options';
+import { CalendarProvider } from '@src/features/todo/presentations/components/Calendar/calendar-view-mode-context';
 import { FeedDateProvider } from '@src/features/todo/presentations/providers/feed-date-provider';
 import { useGetMeQueryOptions } from '@src/features/user/presentations/queries/use-get-me-query-options';
 import { getProfileIconSource } from '@src/features/user/presentations/utils/profile-icon.util';
@@ -21,16 +22,18 @@ import { ScrollView, View } from 'react-native';
 export default function FeedGroupLayout() {
   return (
     <FeedDateProvider>
-      <StyledSafeAreaView className="flex-1 bg-white" edges={['bottom']}>
-        <VStack>
-          <QueryErrorBoundary>
-            <Suspense fallback={<AvatarList.Loading />}>
-              <AvatarList />
-            </Suspense>
-          </QueryErrorBoundary>
-        </VStack>
-        <Slot />
-      </StyledSafeAreaView>
+      <CalendarProvider>
+        <StyledSafeAreaView className="flex-1 bg-white" edges={['bottom']}>
+          <VStack>
+            <QueryErrorBoundary>
+              <Suspense fallback={<AvatarList.Loading />}>
+                <AvatarList />
+              </Suspense>
+            </QueryErrorBoundary>
+          </VStack>
+          <Slot />
+        </StyledSafeAreaView>
+      </CalendarProvider>
     </FeedDateProvider>
   );
 }

--- a/apps/mobile/app/(app)/(tabs)/feed/(feed)/friend/[friendId].tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/(feed)/friend/[friendId].tsx
@@ -1,5 +1,5 @@
 import { useFriendById } from '@src/features/friend/presentations/hooks/use-friend-by-id';
-import { Calendar } from '@src/features/todo/presentations/components/Calendar/Calendar';
+import { FriendCalendar } from '@src/features/todo/presentations/components/Calendar/FriendCalendar';
 import { FriendTodoList } from '@src/features/todo/presentations/components/FriendTodoList';
 import { PokeBanner } from '@src/features/todo/presentations/components/PokeBanner';
 import { TODO_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-query-keys.constant';
@@ -33,7 +33,7 @@ export default function FriendFeedScreen() {
       contentContainerStyle={{ flexGrow: 1, paddingBottom: tabBarHeight }}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     >
-      <Calendar showCompletions={false} />
+      <FriendCalendar friendUserId={friend.id} />
 
       <Spacing size={8} />
 

--- a/apps/mobile/app/(app)/(tabs)/feed/(feed)/index.tsx
+++ b/apps/mobile/app/(app)/(tabs)/feed/(feed)/index.tsx
@@ -5,7 +5,7 @@ import { useGetSuggestionsQueryOptions } from '@src/features/ai/presentations/qu
 import { FeatureDiscoveryReentryCard } from '@src/features/feature-discovery/presentations/components/FeatureDiscoveryReentryCard';
 import { useFeatureDiscoveryFeed } from '@src/features/feature-discovery/presentations/hooks/use-feature-discovery-feed';
 import { MarketingPushOptInBanner } from '@src/features/notification/presentations/components/MarketingPushOptInBanner';
-import { Calendar } from '@src/features/todo/presentations/components/Calendar/Calendar';
+import { MyCalendar } from '@src/features/todo/presentations/components/Calendar/MyCalendar';
 import { TodoList } from '@src/features/todo/presentations/components/TodoList/TodoList';
 import { TODO_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-query-keys.constant';
 import { useFeedDateKey } from '@src/features/todo/presentations/hooks/use-feed-date';
@@ -44,7 +44,7 @@ export default function MyFeedScreen() {
       contentContainerStyle={{ flexGrow: 1, paddingBottom: tabBarHeight }}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     >
-      <Calendar />
+      <MyCalendar />
 
       <Spacing size={10} />
 

--- a/apps/mobile/src/features/todo/presentations/components/Calendar/Calendar.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/Calendar/Calendar.tsx
@@ -7,23 +7,20 @@ import {
   diffMonths,
   diffWeeks,
   formatDate,
-  getCalendarRange,
   getMonthHeaderText,
   getMonthStart,
   getMonthWeeks,
   getNextDay,
   getWeekDates,
   getWeekHeaderText,
-  getWeekRange,
   getWeekStart,
   isSameMonth,
   withDayOfMonth,
   withDayOfWeek,
 } from '@src/shared/utils/date';
-import { useQuery } from '@tanstack/react-query';
 import { range } from 'es-toolkit/compat';
 import { PressableFeedback, Skeleton } from 'heroui-native';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   FlatList,
   type NativeScrollEvent,
@@ -34,16 +31,11 @@ import {
 import { match } from 'ts-pattern';
 import type { DailyCompletionSummary } from '../../../models/todo.model';
 import type { CompletionsByDate } from '../../queries/use-get-daily-completions-query-options';
-import { useGetDailyCompletionsQueryOptions } from '../../queries/use-get-daily-completions-query-options';
 import { CalendarDateCell } from './CalendarDateCell';
 import { CalendarNavigation } from './CalendarNavigation';
 import { CalendarViewModeToggle } from './CalendarViewModeToggle';
 import { CalendarWeekdayHeader } from './CalendarWeekdayHeader';
-import { CalendarProvider, useCalendarContext } from './calendar-view-mode-context';
-
-interface CalendarProps {
-  showCompletions?: boolean;
-}
+import { useCalendarContext } from './calendar-view-mode-context';
 
 const EMPTY_COMPLETIONS: CompletionsByDate = {};
 const WEEKDAY_INDICES = [0, 1, 2, 3, 4, 5, 6] as const;
@@ -53,34 +45,14 @@ const TOTAL_PAGES = 521;
 const CENTER_PAGE = 260;
 const PAGES = range(TOTAL_PAGES);
 
-export function Calendar({ showCompletions = true }: CalendarProps) {
-  return (
-    <CalendarProvider>
-      <CalendarInner showCompletions={showCompletions} />
-    </CalendarProvider>
-  );
+interface CalendarProps {
+  completions?: CompletionsByDate;
 }
 
-function CalendarInner({ showCompletions = true }: CalendarProps) {
+export function Calendar({ completions = EMPTY_COMPLETIONS }: CalendarProps) {
   const { t } = useTranslation('common');
   const [selectedDate, setSelectedDate] = useFeedDate();
   const { viewMode } = useCalendarContext();
-
-  const { rangeStart, rangeEnd } = useMemo(
-    () =>
-      match(viewMode)
-        .with('week', () => getWeekRange(selectedDate))
-        .with('month', () => getCalendarRange(selectedDate))
-        .exhaustive(),
-    [viewMode, selectedDate],
-  );
-
-  const { data } = useQuery({
-    ...useGetDailyCompletionsQueryOptions(rangeStart, rangeEnd),
-    enabled: showCompletions,
-  });
-
-  const completions = (showCompletions && data) || EMPTY_COMPLETIONS;
 
   const pagerHeight = match(viewMode)
     .with('week', () => DATE_CELL_HEIGHT)

--- a/apps/mobile/src/features/todo/presentations/components/Calendar/FriendCalendar.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/Calendar/FriendCalendar.tsx
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useGetFriendDailyCompletionsQueryOptions } from '../../queries/use-get-friend-daily-completions-query-options';
+import { Calendar } from './Calendar';
+import { useCalendarRange } from './use-calendar-range';
+
+interface FriendCalendarProps {
+  friendUserId: string;
+}
+
+/** 친구의 공개(PUBLIC) 완료 현황을 표시하는 캘린더 — 틀은 내 캘린더와 동일 */
+export function FriendCalendar({ friendUserId }: FriendCalendarProps) {
+  const { rangeStart, rangeEnd } = useCalendarRange();
+  const { data } = useQuery(
+    useGetFriendDailyCompletionsQueryOptions(friendUserId, rangeStart, rangeEnd),
+  );
+
+  return <Calendar completions={data} />;
+}

--- a/apps/mobile/src/features/todo/presentations/components/Calendar/MyCalendar.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/Calendar/MyCalendar.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useGetDailyCompletionsQueryOptions } from '../../queries/use-get-daily-completions-query-options';
+import { Calendar } from './Calendar';
+import { useCalendarRange } from './use-calendar-range';
+
+/** 나의 일일 완료 현황을 표시하는 캘린더 */
+export function MyCalendar() {
+  const { rangeStart, rangeEnd } = useCalendarRange();
+  const { data } = useQuery(useGetDailyCompletionsQueryOptions(rangeStart, rangeEnd));
+
+  return <Calendar completions={data} />;
+}

--- a/apps/mobile/src/features/todo/presentations/components/Calendar/use-calendar-range.ts
+++ b/apps/mobile/src/features/todo/presentations/components/Calendar/use-calendar-range.ts
@@ -1,0 +1,21 @@
+import { useFeedDate } from '@src/features/todo/presentations/hooks/use-feed-date';
+import { getCalendarRange, getWeekRange } from '@src/shared/utils/date';
+import { useMemo } from 'react';
+import { match } from 'ts-pattern';
+
+import { useCalendarContext } from './calendar-view-mode-context';
+
+/** 현재 뷰 모드(주/월)에 해당하는 캘린더 조회 범위 */
+export function useCalendarRange() {
+  const [selectedDate] = useFeedDate();
+  const { viewMode } = useCalendarContext();
+
+  return useMemo(
+    () =>
+      match(viewMode)
+        .with('week', () => getWeekRange(selectedDate))
+        .with('month', () => getCalendarRange(selectedDate))
+        .exhaustive(),
+    [viewMode, selectedDate],
+  );
+}

--- a/apps/mobile/src/features/todo/presentations/constants/todo-query-keys.constant.ts
+++ b/apps/mobile/src/features/todo/presentations/constants/todo-query-keys.constant.ts
@@ -26,6 +26,10 @@ export const TODO_QUERY_KEYS = {
   friendListByDate: (userId: string, date: string) =>
     [...TODO_QUERY_KEYS.friendLists(), userId, date] as const,
 
+  // 친구 일일 완료 현황 (친구 캘린더 달성 표시 — PUBLIC 기준)
+  friendCompletionsByRange: (userId: string, start: string, end: string) =>
+    [...TODO_QUERY_KEYS.friendLists(), userId, 'completion', start, end] as const,
+
   // 콕 찌르기 (Nudge)
   nudges: () => [...TODO_QUERY_KEYS.all, 'nudge'] as const,
   nudgeLimit: () => [...TODO_QUERY_KEYS.nudges(), 'limit'] as const,

--- a/apps/mobile/src/features/todo/presentations/queries/use-get-friend-daily-completions-query-options.ts
+++ b/apps/mobile/src/features/todo/presentations/queries/use-get-friend-daily-completions-query-options.ts
@@ -1,0 +1,23 @@
+import { useTodoService } from '@src/bootstrap/providers/di-context';
+import { unwrap } from '@src/shared/errors/result';
+import { queryOptions } from '@tanstack/react-query';
+
+import { TODO_QUERY_KEYS } from '../constants/todo-query-keys.constant';
+import { toCompletionsViewModel } from './use-get-daily-completions-query-options';
+
+export const useGetFriendDailyCompletionsQueryOptions = (
+  friendUserId: string,
+  startDate: string,
+  endDate: string,
+) => {
+  const service = useTodoService();
+
+  return queryOptions({
+    queryKey: TODO_QUERY_KEYS.friendCompletionsByRange(friendUserId, startDate, endDate),
+    queryFn: async () => {
+      const result = await service.getFriendDailyCompletions(friendUserId, startDate, endDate);
+      return unwrap(result);
+    },
+    select: toCompletionsViewModel,
+  });
+};

--- a/apps/mobile/src/features/todo/services/todo.service.ts
+++ b/apps/mobile/src/features/todo/services/todo.service.ts
@@ -264,6 +264,33 @@ export class TodoService {
     return ok(toDailyCompletionsResult(parsed.data));
   };
 
+  /** 친구의 일일 완료 현황 — 공개(PUBLIC) 할 일 기준 집계 (친구 캘린더 마커용) */
+  getFriendDailyCompletions = async (
+    friendUserId: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<Result<DailyCompletionsResult, ApiError>> => {
+    const result = await this.#httpClient.get<unknown>(
+      `v1/daily-completions/friends/${friendUserId}`,
+      {
+        params: { startDate, endDate },
+      },
+    );
+
+    if (!result.ok) {
+      return result;
+    }
+
+    const parsed = dailyCompletionsRangeResponseSchema.safeParse(result.value);
+    if (!parsed.success) {
+      throw new ParseError(
+        `[TodoService] Invalid getFriendDailyCompletions response: ${parsed.error.message}`,
+      );
+    }
+
+    return ok(toDailyCompletionsResult(parsed.data));
+  };
+
   /** 오늘의 할 일 요약 (홈 위젯 스냅샷) — 진행률·스트릭·상위 할 일을 한 번에 */
   getTodoSummary = async (): Promise<Result<TodoSummary, ApiError>> => {
     const result = await this.#httpClient.get<unknown>('v1/todos/summary');


### PR DESCRIPTION
## 📋 개요

친구 캘린더에서 달력만 보이고 완료 마커(물고기·카테고리 점)가 표시되지 않던 문제를 해결합니다. 친구용 일일 완료 현황 API를 신설하고(PUBLIC 할 일 기준, 맞팔 검증), 모바일 캘린더를 연결했습니다.

<img width="" height="500" alt="시뮬" src="https://github.com/user-attachments/assets/cd3cb284-9f41-4767-95c5-9b24394016a6" />



## 🏷️ 변경 유형

- [x] ✨ `feat` - 새로운 기능 추가

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [x] `apps/mobile` - Expo 모바일 앱
- [x] multiple - 여러 영역 동시 변경

## 📝 변경 내용

**API — `GET /daily-completions/friends/:userId` 신설**

- `GetFriendDailyCompletionsUseCase`: 맞팔 검증(403 FOLLOW_0906, 캐시 히트와 무관하게 매 요청) → 캐시 → PUBLIC 집계 → 도메인 조립
- **PUBLIC 할 일만 집계** — 친구 할 일 목록(`GET /todos/friends/:userId`)과 같은 공개 기준이라 마커와 날짜별 목록이 항상 일치하고, 비공개 할 일의 존재(개수·카테고리 색)가 유출되지 않음
- `FriendPort`/`FriendAdapter` 신설 (todo 모듈과 동일 패턴, FollowFacade 위임)
- 집계 리포지토리에 `aggregatePublicByDateRange` 추가 (내부 집계 로직 공유, visibility 필터만 추가)
- 캐시 키를 소유자 네임스페이스 하위 `public` 세그먼트로 설계(`daily-completion:range-v1:{owner}:public:…`) — 기존 투두 쓰기 이벤트 무효화 패턴이 그대로 커버 (무효화 코드 추가 0줄)

**Mobile — 친구 캘린더 마커 연결**

- `Calendar`를 `completions` prop을 받는 표현 컴포넌트로 정리하고, 데이터 소스별로 `FriendCalendar`(친구 공개 완료 현황 fetch) 분리 — 틀(주/월 전환·페이저)은 공유
- `CalendarProvider`(viewMode)를 feed 레이아웃으로 호이스팅 — `FeedDateProvider`와 같은 결, 래퍼/Inner 배선 제거
- `getFriendDailyCompletions` 서비스 + `friendCompletionsByRange` 쿼리 키(친구 목록 네임스페이스 하위 — 당겨서 새로고침 시 마커도 갱신) + 쿼리 옵션 추가
- 친구 화면의 `showCompletions={false}` 제거 → `<FriendCalendar friendUserId={friend.id} />`

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck && pnpm lint
pnpm --filter @aido/api test          # 단위 (use-case spec 5개 신규)
pnpm --filter @aido/api test:e2e      # e2e 438개 (친구 완료 현황 4개 신규 + openapi 계약)
npx jest src/features/todo            # mobile todo feature 215개
```

### 테스트 결과

- [x] 단위 테스트 통과
- [x] 통합 테스트 통과
- [x] 수동 테스트 완료 (시뮬레이터에서 친구 캘린더 마커 표시 확인)

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check` (Biome) 검사를 통과했습니다
- [x] 변경사항에 대한 테스트를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다 (`pnpm test`)
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

## 🔗 관련 이슈

Closes #714

## 💬 추가 정보

- OpenAPI 계약 스냅샷: 기존 계약 제거 0줄 / 신규 라우트 추가만 확인 후 갱신 (계약 게이트 정책의 '새 route 추가만 허용' 준수)
- 친구 시점의 '물고기(전부 완료)' 의미는 '공개 할 일 전부 완료'로 정의됨 — 비공개 할 일이 남아 있어도 물고기가 표시되는 트레이드오프는 이슈(#714)에서 논의된 대로 프라이버시 우선으로 결정

🤖 Generated with [Claude Code](https://claude.com/claude-code)