### PR TITLE
refactor(api): Notification endpoint 경계를 정리

### DIFF
--- a/apps/api/src/notification/application/use-cases/mark-as-read/mark-as-read.use-case.ts
+++ b/apps/api/src/notification/application/use-cases/mark-as-read/mark-as-read.use-case.ts
@@ -1,7 +1,7 @@
 import { ErrorCode } from "@aido/errors";
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
-import { Notification } from "../../../domain/entities/notification.entity";
+import { Notification } from "../../../domain/entities/notification.aggregate";
 import {
 	NOTIFICATION_REPOSITORY,
 	type NotificationRepositoryPort,

--- a/apps/api/src/notification/domain/entities/notification.aggregate.ts
+++ b/apps/api/src/notification/domain/entities/notification.aggregate.ts
@@ -1,4 +1,5 @@
 import { ErrorCode } from "@aido/errors";
+import { AggregateRoot } from "@/shared/domain";
 import { DomainException } from "@/shared/domain/exceptions/domain.exception";
 import type { NotificationRecord } from "../records/notification.record";
 
@@ -8,21 +9,21 @@ import type { NotificationRecord } from "../records/notification.record";
  * 읽음 처리 시 소유권 불변식(타 사용자 알림 접근 금지 → NOTIFICATION_1005)과
  * 멱등성(이미 읽은 알림은 무동작)을 소유한다.
  */
-export class Notification {
-	private constructor(
-		private readonly _id: number,
-		private readonly _userId: string,
-		private readonly _isRead: boolean,
-	) {}
+interface NotificationProps {
+	id: number;
+	userId: string;
+	isRead: boolean;
+}
 
+export class Notification extends AggregateRoot<NotificationProps> {
 	static reconstitute(
 		record: Pick<NotificationRecord, "id" | "userId" | "isRead">,
 	): Notification {
-		return new Notification(record.id, record.userId, record.isRead);
+		return new Notification({ ...record });
 	}
 
 	get id(): number {
-		return this._id;
+		return this.props.id;
 	}
 
 	/**
@@ -32,11 +33,13 @@ export class Notification {
 	 * @throws {DomainException} NOTIFICATION_1005 — 다른 사용자의 알림
 	 */
 	planMarkRead(requesterId: string): boolean {
-		if (this._userId !== requesterId) {
+		if (this.props.userId !== requesterId) {
 			throw new DomainException(ErrorCode.NOTIFICATION_1005, {
-				notificationId: this._id,
+				notificationId: this.props.id,
 			});
 		}
-		return !this._isRead;
+		if (this.props.isRead) return false;
+		this.props.isRead = true;
+		return true;
 	}
 }

--- a/apps/api/src/notification/index.ts
+++ b/apps/api/src/notification/index.ts
@@ -46,8 +46,8 @@ export {
 // --- Templates (메시지 빌더 + 로케일 해석) ---
 export * from "./domain/services/templates/notification-templates";
 export type { NotificationType } from "./domain/types/notification-type";
-// --- Repository (미이관 소비자 전이용 concrete + 포트 토큰) ---
-export { NotificationRepository } from "./infrastructure/persistence/notification.repository";
+// Prisma repository is internal to NotificationModule.
+// Cross-module consumers use the public capability boundary above.
 // --- Queue constants + job data ---
 export * from "./infrastructure/queue/notification-queue.constants";
 export { NotificationQueueModule } from "./infrastructure/queue/notification-queue.module";

--- a/apps/api/src/notification/notification.module.ts
+++ b/apps/api/src/notification/notification.module.ts
@@ -47,8 +47,8 @@ import { NotificationController } from "./presentation/notification.controller";
 /**
  * Notification 모듈 (클린아키텍처 4계층 + 포트/어댑터)
  *
- * - presentation: NotificationController → NotificationFacade(유스케이스 조합)
- * - application: 조회·읽음·토큰·발송 유스케이스 + NotificationFacade
+ * - presentation: NotificationController → endpoint UseCase
+ * - application: 조회·읽음·토큰·발송 UseCase
  * - infrastructure: Prisma 저장소·Expo 푸시 프로바이더·PushDispatcher·rate limiter·BullMQ 프로세서
  *
  * Provider 추상화(PUSH_PROVIDER 포트)로 Expo → FCM/APNs 교체를 어댑터 추가만으로 대비.
@@ -60,7 +60,7 @@ import { NotificationController } from "./presentation/notification.controller";
 	imports: [NotificationQueueModule, UserSettingsModule],
 	controllers: [NotificationController],
 	providers: [
-		// Facade + Use-cases (presentation 진입점)
+		// 크로스 모듈 호환 경계 + endpoint UseCase
 		NotificationFacade,
 		GetNotificationsUseCase,
 		GetUnreadCountUseCase,
@@ -126,7 +126,6 @@ import { NotificationController } from "./presentation/notification.controller";
 	],
 	exports: [
 		NotificationFacade,
-		NotificationRepository,
 		NotificationQueueModule,
 		PUSH_PROVIDER,
 		PUSH_RATE_LIMITER,

--- a/apps/api/src/notification/presentation/notification.controller.spec.ts
+++ b/apps/api/src/notification/presentation/notification.controller.spec.ts
@@ -3,7 +3,7 @@
  *
  * @description
  * NotificationController의 엔드포인트 핸들러를 격리 테스트합니다.
- * 컨트롤러는 NotificationFacade만 주입받는다.
+ * 컨트롤러는 endpoint UseCase를 직접 주입받는다.
  *
  * 실행 명령:
  * ```bash
@@ -15,13 +15,19 @@ import { TestBed } from "@suites/unit";
 
 import type { CurrentUserPayload } from "@/auth/presentation/decorators";
 
-import { NotificationFacade } from "../application/facades/notification.facade";
+import { GetUnreadCountUseCase } from "../application/use-cases/get-unread-count/get-unread-count.use-case";
+import { MarkAllAsReadUseCase } from "../application/use-cases/mark-all-as-read/mark-all-as-read.use-case";
+import { MarkAsReadUseCase } from "../application/use-cases/mark-as-read/mark-as-read.use-case";
+import { RegisterPushTokenUseCase } from "../application/use-cases/register-push-token/register-push-token.use-case";
 import type { RegisterPushTokenDto } from "./dtos";
 import { NotificationController } from "./notification.controller";
 
 describe("NotificationController — 알림 컨트롤러", () => {
 	let controller: NotificationController;
-	let mockFacade: Mocked<NotificationFacade>;
+	let getUnreadCountUseCase: Mocked<GetUnreadCountUseCase>;
+	let markAllAsReadUseCase: Mocked<MarkAllAsReadUseCase>;
+	let markAsReadUseCase: Mocked<MarkAsReadUseCase>;
+	let registerPushTokenUseCase: Mocked<RegisterPushTokenUseCase>;
 
 	const mockUser: CurrentUserPayload = {
 		userId: "user-123",
@@ -36,25 +42,30 @@ describe("NotificationController — 알림 컨트롤러", () => {
 		).compile();
 
 		controller = unit;
-		mockFacade = unitRef.get(NotificationFacade);
+		getUnreadCountUseCase = unitRef.get(GetUnreadCountUseCase);
+		markAllAsReadUseCase = unitRef.get(MarkAllAsReadUseCase);
+		markAsReadUseCase = unitRef.get(MarkAsReadUseCase);
+		registerPushTokenUseCase = unitRef.get(RegisterPushTokenUseCase);
 	});
 
 	describe("getUnreadCount", () => {
 		it("읽지 않은 알림 수를 반환해야 한다", async () => {
 			// Given -읽지 않은 알림이 5개 있을 때
-			mockFacade.getUnreadCount.mockResolvedValue(5);
+			getUnreadCountUseCase.execute.mockResolvedValue(5);
 
 			// When -getUnreadCount를 호출하면
 			const result = await controller.getUnreadCount(mockUser);
 
-			// Then -파사드에 userId를 전달하고 unreadCount를 반환해야 한다
-			expect(mockFacade.getUnreadCount).toHaveBeenCalledWith(mockUser.userId);
+			// Then -use-case에 userId를 전달하고 unreadCount를 반환해야 한다
+			expect(getUnreadCountUseCase.execute).toHaveBeenCalledWith(
+				mockUser.userId,
+			);
 			expect(result).toEqual({ unreadCount: 5 });
 		});
 
 		it("읽지 않은 알림이 없으면 0을 반환해야 한다", async () => {
 			// Given -읽지 않은 알림이 없을 때
-			mockFacade.getUnreadCount.mockResolvedValue(0);
+			getUnreadCountUseCase.execute.mockResolvedValue(0);
 
 			// When -getUnreadCount를 호출하면
 			const result = await controller.getUnreadCount(mockUser);
@@ -74,13 +85,13 @@ describe("NotificationController — 알림 컨트롤러", () => {
 			};
 			const tz = "Asia/Seoul";
 			const locale = "ko";
-			mockFacade.registerPushToken.mockResolvedValue(undefined);
+			registerPushTokenUseCase.execute.mockResolvedValue(undefined);
 
 			// When -registerToken을 호출하면
 			const result = await controller.registerToken(mockUser, dto, tz, locale);
 
-			// Then -파사드에 올바른 파라미터를 전달하고 성공 응답을 반환해야 한다
-			expect(mockFacade.registerPushToken).toHaveBeenCalledWith({
+			// Then -use-case에 올바른 파라미터를 전달하고 성공 응답을 반환해야 한다
+			expect(registerPushTokenUseCase.execute).toHaveBeenCalledWith({
 				userId: mockUser.userId,
 				token: dto.token,
 				deviceId: dto.deviceId,
@@ -103,7 +114,7 @@ describe("NotificationController — 알림 컨트롤러", () => {
 
 			await controller.registerToken(mockUser, dto, undefined, undefined);
 
-			expect(mockFacade.registerPushToken).toHaveBeenCalledWith({
+			expect(registerPushTokenUseCase.execute).toHaveBeenCalledWith({
 				userId: mockUser.userId,
 				token: dto.token,
 				deviceId: undefined,
@@ -119,15 +130,15 @@ describe("NotificationController — 알림 컨트롤러", () => {
 		it("단일 알림을 읽음 처리하고 결과를 반환해야 한다", async () => {
 			// Given -읽음 처리할 알림 ID가 있을 때
 			const notificationId = 42;
-			mockFacade.markAsRead.mockResolvedValue(undefined);
+			markAsReadUseCase.execute.mockResolvedValue(undefined);
 
 			// When -markAsRead를 호출하면
 			const result = await controller.markAsRead(mockUser, {
 				id: notificationId,
 			});
 
-			// Then -파사드에 userId와 id를 전달하고 성공 응답을 반환해야 한다
-			expect(mockFacade.markAsRead).toHaveBeenCalledWith(
+			// Then -use-case에 userId와 id를 전달하고 성공 응답을 반환해야 한다
+			expect(markAsReadUseCase.execute).toHaveBeenCalledWith(
 				mockUser.userId,
 				notificationId,
 			);
@@ -141,13 +152,15 @@ describe("NotificationController — 알림 컨트롤러", () => {
 	describe("markAllAsRead", () => {
 		it("모든 알림을 읽음 처리하고 결과를 반환해야 한다", async () => {
 			// Given -읽지 않은 알림이 3개 있을 때
-			mockFacade.markAllAsRead.mockResolvedValue({ count: 3 });
+			markAllAsReadUseCase.execute.mockResolvedValue({ count: 3 });
 
 			// When -markAllAsRead를 호출하면
 			const result = await controller.markAllAsRead(mockUser);
 
-			// Then -파사드에 userId를 전달하고 처리된 개수를 반환해야 한다
-			expect(mockFacade.markAllAsRead).toHaveBeenCalledWith(mockUser.userId);
+			// Then -use-case에 userId를 전달하고 처리된 개수를 반환해야 한다
+			expect(markAllAsReadUseCase.execute).toHaveBeenCalledWith(
+				mockUser.userId,
+			);
 			expect(result).toEqual({
 				message: "모든 알림을 읽음 처리했습니다.",
 				readCount: 3,

--- a/apps/api/src/notification/presentation/notification.controller.ts
+++ b/apps/api/src/notification/presentation/notification.controller.ts
@@ -37,7 +37,14 @@ import {
 	type CurrentUserPayload,
 	Public,
 } from "../../auth/presentation/decorators";
-import { NotificationFacade } from "../application/facades/notification.facade";
+import { GetNotificationsUseCase } from "../application/use-cases/get-notifications/get-notifications.use-case";
+import { GetUnreadCountUseCase } from "../application/use-cases/get-unread-count/get-unread-count.use-case";
+import { MarkAllAsReadUseCase } from "../application/use-cases/mark-all-as-read/mark-all-as-read.use-case";
+import { MarkAsReadUseCase } from "../application/use-cases/mark-as-read/mark-as-read.use-case";
+import { MarkNotificationOpenedUseCase } from "../application/use-cases/mark-notification-opened/mark-notification-opened.use-case";
+import { OptOutMarketingPushUseCase } from "../application/use-cases/opt-out-marketing-push/opt-out-marketing-push.use-case";
+import { RegisterPushTokenUseCase } from "../application/use-cases/register-push-token/register-push-token.use-case";
+import { UnregisterPushTokenUseCase } from "../application/use-cases/unregister-push-token/unregister-push-token.use-case";
 
 import {
 	GetNotificationsQueryDto,
@@ -59,7 +66,16 @@ import { NotificationMapper } from "./notification.mapper";
 export class NotificationController {
 	readonly #logger = new Logger(NotificationController.name);
 
-	constructor(private readonly notificationFacade: NotificationFacade) {}
+	constructor(
+		private readonly getNotificationsUseCase: GetNotificationsUseCase,
+		private readonly getUnreadCountUseCase: GetUnreadCountUseCase,
+		private readonly markAsReadUseCase: MarkAsReadUseCase,
+		private readonly markNotificationOpenedUseCase: MarkNotificationOpenedUseCase,
+		private readonly markAllAsReadUseCase: MarkAllAsReadUseCase,
+		private readonly registerPushTokenUseCase: RegisterPushTokenUseCase,
+		private readonly unregisterPushTokenUseCase: UnregisterPushTokenUseCase,
+		private readonly optOutMarketingPushUseCase: OptOutMarketingPushUseCase,
+	) {}
 
 	@Post("marketing-push/opt-out")
 	@Public()
@@ -74,7 +90,7 @@ export class NotificationController {
 	async optOutMarketingPush(
 		@Body() dto: MarketingPushOptOutDto,
 	): Promise<MarketingPushOptOutResponseDto> {
-		await this.notificationFacade.optOutMarketingPush(dto.token);
+		await this.optOutMarketingPushUseCase.execute(dto.token);
 		// 토큰 유효 여부를 노출하지 않아 사용자 열거/토큰 탐색을 방지한다.
 		return { optedOut: true };
 	}
@@ -115,7 +131,7 @@ export class NotificationController {
 	): Promise<RegisterTokenResponseDto> {
 		this.#logger.debug(`푸시 토큰 등록: userId=${user.userId}`);
 
-		await this.notificationFacade.registerPushToken({
+		await this.registerPushTokenUseCase.execute({
 			userId: user.userId,
 			token: dto.token,
 			deviceId: dto.deviceId,
@@ -158,7 +174,7 @@ export class NotificationController {
 			`푸시 토큰 해제: userId=${user.userId}, deviceId=${deviceId ?? "all"}`,
 		);
 
-		await this.notificationFacade.unregisterPushToken(user.userId, deviceId);
+		await this.unregisterPushTokenUseCase.execute(user.userId, deviceId);
 
 		this.#logger.log(
 			`푸시 토큰 해제 완료: userId=${user.userId}, deviceId=${deviceId ?? "all"}`,
@@ -213,14 +229,14 @@ export class NotificationController {
 		);
 
 		const [result, unreadCount] = await Promise.all([
-			this.notificationFacade.getNotifications({
+			this.getNotificationsUseCase.execute({
 				userId: user.userId,
 				cursor: query.cursor,
 				size: query.limit,
 				unreadOnly: query.unreadOnly,
 				category: query.category,
 			}),
-			this.notificationFacade.getUnreadCount(user.userId),
+			this.getUnreadCountUseCase.execute(user.userId),
 		]);
 
 		return {
@@ -242,9 +258,7 @@ export class NotificationController {
 	async getUnreadCount(
 		@CurrentUser() user: CurrentUserPayload,
 	): Promise<UnreadCountResponseDto> {
-		const unreadCount = await this.notificationFacade.getUnreadCount(
-			user.userId,
-		);
+		const unreadCount = await this.getUnreadCountUseCase.execute(user.userId);
 
 		return { unreadCount };
 	}
@@ -274,7 +288,7 @@ export class NotificationController {
 			`알림 읽음 처리: userId=${user.userId}, id=${params.id}`,
 		);
 
-		await this.notificationFacade.markAsRead(user.userId, params.id);
+		await this.markAsReadUseCase.execute(user.userId, params.id);
 
 		return {
 			message: "알림을 읽음 처리했습니다.",
@@ -295,7 +309,7 @@ export class NotificationController {
 		@CurrentUser() user: CurrentUserPayload,
 		@Param() params: NotificationIdParamDto,
 	): Promise<NotificationOpenedResponseDto> {
-		const opened = await this.notificationFacade.markOpened(
+		const opened = await this.markNotificationOpenedUseCase.execute(
 			user.userId,
 			params.id,
 		);
@@ -316,7 +330,7 @@ export class NotificationController {
 	): Promise<MarkReadResponseDto> {
 		this.#logger.debug(`모든 알림 읽음 처리: userId=${user.userId}`);
 
-		const result = await this.notificationFacade.markAllAsRead(user.userId);
+		const result = await this.markAllAsReadUseCase.execute(user.userId);
 
 		return {
 			message: "모든 알림을 읽음 처리했습니다.",

--- a/apps/api/test/integration/notification.integration-spec.ts
+++ b/apps/api/test/integration/notification.integration-spec.ts
@@ -27,7 +27,6 @@ import {
 	NOTIFICATION_REPOSITORY,
 	NotificationFacade,
 	NotificationMessageBuilder,
-	NotificationRepository,
 	PUSH_PROVIDER,
 	PUSH_RATE_LIMITER,
 } from "@/notification";
@@ -53,6 +52,7 @@ import { SendNotificationWithDedupUseCase } from "@/notification/application/use
 import { UnregisterPushTokenUseCase } from "@/notification/application/use-cases/unregister-push-token/unregister-push-token.use-case";
 import { NotificationCacheAdapter } from "@/notification/infrastructure/adapters/notification-cache.adapter";
 import { PushDispatcherAdapter } from "@/notification/infrastructure/adapters/push-dispatcher.adapter";
+import { NotificationRepository } from "@/notification/infrastructure/persistence/notification.repository";
 import { PaginationService } from "@/shared/application/pagination/services/pagination.service";
 import { CacheService } from "@/shared/infrastructure/cache/cache.service";
 import { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";


### PR DESCRIPTION
## 📋 개요

Notification endpoint 경계를 정리. Aido API를 실용형 DDD·Clean Architecture로 점진 전환하는 Stack #746의 8/23 PR입니다.

구조와 책임만 정리하며 기존 클라이언트·운영 계약은 변경하지 않습니다. 이 PR은 바로 아래 PR만 base로 사용하므로 순서대로 독립 검토·롤백할 수 있습니다.

## 🏷️ 변경 유형

- [ ] ✨ `feat` - 새로운 기능 추가
- [ ] 🐛 `fix` - 버그 수정
- [ ] 📝 `docs` - 문서 수정
- [x] ♻️ `refactor` - 코드 리팩토링
- [ ] ⚡ `perf` - 성능 개선
- [ ] ✅ `test` - 테스트 추가/수정
- [ ] 👷 `ci` - CI/CD 설정 및 스크립트 변경
- [ ] 🔨 `chore` - 기타 변경사항

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [ ] `apps/mobile` - Expo 모바일 앱
- [ ] `packages/validators` - 공개 Zod 스키마
- [ ] `packages/utils` - 공유 유틸리티
- [ ] `packages/errors` - 에러 정의
- [ ] `tooling/*` - 개발 도구 설정
- [ ] multiple - 여러 영역 동시 변경

## 📝 변경 내용

- Notification Controller가 endpoint UseCase를 직접 사용하도록 경계를 정리합니다.
- 알림 조회·쓰기·푸시 전달 책임을 역할별 capability로 분리합니다.
- dedup, 배치 SQL, 발송 payload 및 읽음 상태 계약을 유지합니다.

## 🔒 불변 계약

- HTTP route/method/header/query/body/response/status 변경 없음
- Zod·Swagger·`@aido/validators` 공개 export 변경 없음
- ErrorCode·message·details·응답 wrapping 변경 없음
- Prisma schema·migration·기존 데이터 변경 없음
- 큐 이름·job payload·Redis key·TTL 변경 없음
- 정렬·페이지네이션·멱등성·부수효과 발생 조건 변경 없음
- OpenAPI snapshot과 배포 클라이언트 fingerprint 갱신 없음

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm lint
pnpm build
pnpm --filter @aido/api lint:arch
pnpm --filter @aido/api test
```

### 테스트 결과

- [x] 타입 체크·린트·빌드 통과
- [x] 해당 모듈 단위 테스트 통과
- [x] 아키텍처·불변 계약 게이트 통과
- [x] 스택 최종 기준 전체 unit 361 suites / 2,598 tests 통과
- [x] 스택 최종 기준 integration 36 suites / 364 tests 통과
- [x] 스택 최종 기준 E2E 및 OpenAPI snapshots 통과
- [ ] 수동 운영 검증 — 배포 PR에서 수행

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다
- [x] Clean Architecture 의존성 방향을 준수합니다
- [x] 변경사항에 대한 테스트를 작성/수정했습니다
- [x] typecheck·lint·build 및 관련 테스트가 통과합니다
- [x] 필요한 아키텍처 문서를 업데이트했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨을 `type: refactor`, `scope: api`와 리뷰 상태로 정리했습니다

### 리뷰어 확인

- [ ] 계층 경계와 유비쿼터스 언어가 적절합니다
- [ ] 상태 전이·트랜잭션·커밋 후 부수효과가 기존과 같습니다
- [ ] 캐시·큐·멱등성·동시성 계약에 회귀가 없습니다
- [ ] 공개 API·오류·DB 계약에 변경이 없습니다

## 🔗 Stack 위치

- Stack: #746
- 이전 PR: #729
- 다음 PR: #731
- 병합 순서: #722부터 번호 순서대로

## 📸 스크린샷

UI 변경 없음 — 서버 내부 구조 리팩토링입니다.

## 💬 추가 정보

최종 스택에서 architecture baseline은 layer import 0, aggregate naming 0, internal barrel export 0, dependency violation 0, cast 0입니다.