### PR TITLE
refactor(api): 기본 Todo Category 시딩 책임을 명확히 명명

### DIFF
--- a/apps/api/src/auth/infrastructure/adapters/user-provisioning-seeder.adapter.ts
+++ b/apps/api/src/auth/infrastructure/adapters/user-provisioning-seeder.adapter.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 
-import { DEFAULT_CATEGORIES, TodoCategoryRepository } from "@/todo-category";
+import { DefaultTodoCategorySeeder } from "@/todo-category";
 import { UserSettingsFacade } from "@/user-settings";
 import type {
 	ProvisioningConsent,
@@ -17,7 +17,7 @@ export class UserProvisioningSeederAdapter
 {
 	constructor(
 		private readonly userSettings: UserSettingsFacade,
-		private readonly todoCategoryRepository: TodoCategoryRepository,
+		private readonly defaultTodoCategorySeeder: DefaultTodoCategorySeeder,
 	) {}
 
 	seedDefaultSettings(
@@ -28,13 +28,6 @@ export class UserProvisioningSeederAdapter
 	}
 
 	async seedDefaultCategories(userId: string): Promise<void> {
-		await this.todoCategoryRepository.createMany(
-			DEFAULT_CATEGORIES.map((category) => ({
-				userId,
-				name: category.name,
-				color: category.color,
-				sortOrder: category.sortOrder,
-			})),
-		);
+		await this.defaultTodoCategorySeeder.seed(userId);
 	}
 }

--- a/apps/api/src/todo-category/index.ts
+++ b/apps/api/src/todo-category/index.ts
@@ -1,4 +1,4 @@
 export { TodoCategoryReader } from "./application/services/todo-category.reader";
 export { DEFAULT_CATEGORIES } from "./domain/default-categories";
+export { DefaultTodoCategorySeeder } from "./infrastructure/seeders/default-todo-category.seeder";
 export { TodoCategoryModule } from "./todo-category.module";
-export { TodoCategoryRepository } from "./todo-category.repository";

--- a/apps/api/src/todo-category/infrastructure/seeders/default-todo-category.seeder.spec.ts
+++ b/apps/api/src/todo-category/infrastructure/seeders/default-todo-category.seeder.spec.ts
@@ -1,5 +1,5 @@
 /**
- * TodoCategoryRepository(시딩 전용) 단위 테스트
+ * DefaultTodoCategorySeeder(시딩 전용) 단위 테스트
  *
  * 회원가입 기본 카테고리 시딩 경로만 검증한다. 컨트롤러 경로는 클린아키텍처 어댑터
  * (PrismaTodoCategoryRepository)가 담당한다.
@@ -11,47 +11,46 @@ import { TestBed } from "@suites/unit";
 import { createMockPrisma, type MockPrismaClient } from "@test/mocks";
 import type { DatabaseService } from "@/shared/infrastructure/database/database.service";
 
-import { TodoCategoryRepository } from "./todo-category.repository";
+import { DefaultTodoCategorySeeder } from "./default-todo-category.seeder";
 
-describe("TodoCategoryRepository — 기본 카테고리 시딩", () => {
-	let repository: TodoCategoryRepository;
+describe("DefaultTodoCategorySeeder — 기본 카테고리 시딩", () => {
+	let seeder: DefaultTodoCategorySeeder;
 	let db: MockPrismaClient;
 
 	beforeEach(async () => {
 		db = createMockPrisma();
 
-		const { unit } = await TestBed.solitary(TodoCategoryRepository)
+		const { unit } = await TestBed.solitary(DefaultTodoCategorySeeder)
 			.mock<TransactionHost<TransactionalAdapterPrisma<DatabaseService>>>(
 				TransactionHost,
 			)
 			.impl(() => ({ tx: db }))
 			.compile();
 
-		repository = unit;
+		seeder = unit;
 	});
 
-	it("createMany는 활성 트랜잭션 클라이언트로 위임하고 개수를 반환한다", async () => {
+	it("seed는 활성 트랜잭션에 기본 카테고리를 생성한다", async () => {
 		db.todoCategory.createMany.mockResolvedValue({ count: 2 });
-		const data = [
-			{ userId: "u1", name: "중요한 일", color: "#FFB3B3", sortOrder: 0 },
-			{ userId: "u1", name: "할 일", color: "#FF6B43", sortOrder: 1 },
-		];
 
-		const count = await repository.createMany(data);
+		const count = await seeder.seed("u1");
 
 		expect(count).toBe(2);
-		expect(db.todoCategory.createMany).toHaveBeenCalledWith({ data });
+		expect(db.todoCategory.createMany).toHaveBeenCalledWith({
+			data: [
+				{ userId: "u1", name: "중요한 일", color: "#FFB3B3", sortOrder: 0 },
+				{ userId: "u1", name: "할 일", color: "#FF6B43", sortOrder: 1 },
+			],
+		});
 	});
 
 	it("명시적 tx가 주어지면 그 클라이언트를 사용한다", async () => {
 		const txClient = createMockPrisma();
 		txClient.todoCategory.createMany.mockResolvedValue({ count: 1 });
-		const data = [{ userId: "u1", name: "x", color: "#000000", sortOrder: 0 }];
-
-		const count = await repository.createMany(data, txClient);
+		const count = await seeder.seed("u1", txClient);
 
 		expect(count).toBe(1);
-		expect(txClient.todoCategory.createMany).toHaveBeenCalledWith({ data });
+		expect(txClient.todoCategory.createMany).toHaveBeenCalled();
 		expect(db.todoCategory.createMany).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/todo-category/infrastructure/seeders/default-todo-category.seeder.ts
+++ b/apps/api/src/todo-category/infrastructure/seeders/default-todo-category.seeder.ts
@@ -3,17 +3,10 @@ import { TransactionHost } from "@nestjs-cls/transactional";
 import type { TransactionalAdapterPrisma } from "@nestjs-cls/transactional-adapter-prisma";
 import type { DatabaseService } from "@/shared/infrastructure/database/database.service";
 import type { TransactionClient } from "@/shared/infrastructure/database/prisma.types";
-
-/** 기본 카테고리 시딩 입력 */
-export interface SeedCategoryInput {
-	userId: string;
-	name: string;
-	color: string;
-	sortOrder: number;
-}
+import { DEFAULT_CATEGORIES } from "../../domain/default-categories";
 
 /**
- * TodoCategoryRepository — 회원가입 기본 카테고리 시딩 전용 레거시 저장소.
+ * 회원가입 기본 카테고리 생성 전용 capability.
  *
  * auth·oauth 회원가입은 아직 레거시 `database.$transaction(tx)`를 사용하며, 기본 카테고리 생성을
  * 그 트랜잭션에 명시적으로 참여시키기 위해 `tx`를 받는 이 경로를 유지한다. auth 이관(Wave 7) 시
@@ -23,7 +16,7 @@ export interface SeedCategoryInput {
  * DatabaseService를 반환한다.
  */
 @Injectable()
-export class TodoCategoryRepository {
+export class DefaultTodoCategorySeeder {
 	constructor(
 		private readonly txHost: TransactionHost<
 			TransactionalAdapterPrisma<DatabaseService>
@@ -36,11 +29,12 @@ export class TodoCategoryRepository {
 	}
 
 	/** 기본 카테고리 일괄 생성 (레거시 명시적 tx 경로 지원) */
-	async createMany(
-		data: SeedCategoryInput[],
-		tx?: TransactionClient,
-	): Promise<number> {
+	async seed(userId: string, tx?: TransactionClient): Promise<number> {
 		const client = tx ?? this.client;
+		const data = DEFAULT_CATEGORIES.map((category) => ({
+			userId,
+			...category,
+		}));
 		const result = await client.todoCategory.createMany({ data });
 		return result.count;
 	}

--- a/apps/api/src/todo-category/todo-category.module.ts
+++ b/apps/api/src/todo-category/todo-category.module.ts
@@ -11,8 +11,8 @@ import { UpdateTodoCategoryUseCase } from "./application/use-cases/update-todo-c
 import { TodoCategoryCacheAdapter } from "./infrastructure/adapters/todo-category-cache.adapter";
 import { TodoCategoryLimitReaderAdapter } from "./infrastructure/adapters/todo-category-limit-reader.adapter";
 import { PrismaTodoCategoryRepository } from "./infrastructure/persistence/prisma-todo-category.repository";
+import { DefaultTodoCategorySeeder } from "./infrastructure/seeders/default-todo-category.seeder";
 import { TodoCategoryController } from "./presentation/todo-category.controller";
-import { TodoCategoryRepository } from "./todo-category.repository";
 
 /**
  * TodoCategory 모듈 (DDD 클린아키텍처 · use-case 기반).
@@ -21,7 +21,7 @@ import { TodoCategoryRepository } from "./todo-category.repository";
  * Controller는 endpoint UseCase와 Reader를 직접 주입한다.
  *
  * 회원가입 기본 카테고리 시딩은 CLS 트랜잭션에 참여하는
- * TodoCategoryRepository(createMany)를 사용한다.
+ * DefaultTodoCategorySeeder를 사용한다.
  */
 @Module({
 	controllers: [TodoCategoryController],
@@ -40,8 +40,8 @@ import { TodoCategoryRepository } from "./todo-category.repository";
 		UpdateTodoCategoryUseCase,
 		DeleteTodoCategoryUseCase,
 		ReorderTodoCategoryUseCase,
-		TodoCategoryRepository,
+		DefaultTodoCategorySeeder,
 	],
-	exports: [TodoCategoryReader, TodoCategoryRepository],
+	exports: [TodoCategoryReader, DefaultTodoCategorySeeder],
 })
 export class TodoCategoryModule {}

--- a/apps/api/test/integration/account-deletion.integration-spec.ts
+++ b/apps/api/test/integration/account-deletion.integration-spec.ts
@@ -66,7 +66,7 @@ import { CACHE_SERVICE } from "@/shared/infrastructure/cache/interfaces/cache.in
 import { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";
 import { DatabaseService } from "@/shared/infrastructure/database/database.service";
 import { EncryptionService } from "@/shared/infrastructure/encryption";
-import { TodoCategoryRepository } from "@/todo-category/todo-category.repository";
+import { DefaultTodoCategorySeeder } from "@/todo-category/infrastructure/seeders/default-todo-category.seeder";
 import { UserConsentRepository } from "@/user-settings/infrastructure/persistence/user-consent.repository";
 import { UserPreferenceRepository } from "@/user-settings/infrastructure/persistence/user-preference.repository";
 import { FakeEmailService } from "../mocks/fake-email.service";
@@ -155,7 +155,7 @@ describe("회원 탈퇴 통합 테스트 (실제 DB)", () => {
 				},
 				UserConsentRepository,
 				UserPreferenceRepository,
-				TodoCategoryRepository,
+				DefaultTodoCategorySeeder,
 				provisioningSeederTestProvider,
 				retentionEnrollerTestProvider,
 				{

--- a/apps/api/test/integration/helpers/auth-test-module.factory.ts
+++ b/apps/api/test/integration/helpers/auth-test-module.factory.ts
@@ -48,7 +48,7 @@ import { CACHE_SERVICE } from "@/shared/infrastructure/cache/interfaces/cache.in
 import { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";
 import { DatabaseService } from "@/shared/infrastructure/database/database.service";
 import { EncryptionService } from "@/shared/infrastructure/encryption";
-import { TodoCategoryRepository } from "@/todo-category/todo-category.repository";
+import { DefaultTodoCategorySeeder } from "@/todo-category/infrastructure/seeders/default-todo-category.seeder";
 import { UserConsentRepository } from "@/user-settings/infrastructure/persistence/user-consent.repository";
 import { UserPreferenceRepository } from "@/user-settings/infrastructure/persistence/user-preference.repository";
 import type { FakeEmailService } from "../../mocks/fake-email.service";
@@ -113,7 +113,7 @@ export async function createAuthTestModule(
 			},
 			UserConsentRepository,
 			UserPreferenceRepository,
-			TodoCategoryRepository,
+			DefaultTodoCategorySeeder,
 			provisioningSeederTestProvider,
 			retentionEnrollerTestProvider,
 			{

--- a/apps/api/test/integration/helpers/provisioning-seeder.provider.ts
+++ b/apps/api/test/integration/helpers/provisioning-seeder.provider.ts
@@ -14,8 +14,7 @@ import {
 	USER_PROVISIONING_SEEDER,
 	type UserProvisioningSeederPort,
 } from "@/auth/application/ports/user-provisioning-seeder.port";
-import { DEFAULT_CATEGORIES } from "@/todo-category";
-import { TodoCategoryRepository } from "@/todo-category/todo-category.repository";
+import { DefaultTodoCategorySeeder } from "@/todo-category/infrastructure/seeders/default-todo-category.seeder";
 import { UserConsentRepository } from "@/user-settings/infrastructure/persistence/user-consent.repository";
 import { UserPreferenceRepository } from "@/user-settings/infrastructure/persistence/user-preference.repository";
 
@@ -24,7 +23,7 @@ export const provisioningSeederTestProvider: Provider = {
 	useFactory: (
 		consentRepository: UserConsentRepository,
 		preferenceRepository: UserPreferenceRepository,
-		categoryRepository: TodoCategoryRepository,
+		defaultTodoCategorySeeder: DefaultTodoCategorySeeder,
 	): UserProvisioningSeederPort => ({
 		async seedDefaultSettings(
 			userId: string,
@@ -37,19 +36,12 @@ export const provisioningSeederTestProvider: Provider = {
 			});
 		},
 		async seedDefaultCategories(userId: string): Promise<void> {
-			await categoryRepository.createMany(
-				DEFAULT_CATEGORIES.map((category) => ({
-					userId,
-					name: category.name,
-					color: category.color,
-					sortOrder: category.sortOrder,
-				})),
-			);
+			await defaultTodoCategorySeeder.seed(userId);
 		},
 	}),
 	inject: [
 		UserConsentRepository,
 		UserPreferenceRepository,
-		TodoCategoryRepository,
+		DefaultTodoCategorySeeder,
 	],
 };

--- a/apps/api/test/integration/oauth.integration-spec.ts
+++ b/apps/api/test/integration/oauth.integration-spec.ts
@@ -72,7 +72,7 @@ import { CACHE_SERVICE } from "@/shared/infrastructure/cache/interfaces/cache.in
 import { TypedConfigService } from "@/shared/infrastructure/config/services/config.service";
 import { DatabaseService } from "@/shared/infrastructure/database/database.service";
 import { EncryptionService } from "@/shared/infrastructure/encryption";
-import { TodoCategoryRepository } from "@/todo-category/todo-category.repository";
+import { DefaultTodoCategorySeeder } from "@/todo-category/infrastructure/seeders/default-todo-category.seeder";
 import { UserConsentRepository } from "@/user-settings/infrastructure/persistence/user-consent.repository";
 import { UserPreferenceRepository } from "@/user-settings/infrastructure/persistence/user-preference.repository";
 import { FakeOAuthTokenVerifierService } from "../mocks/fake-oauth-token-verifier.service";
@@ -182,7 +182,7 @@ describe("OAuth 통합 테스트 (실제 DB)", () => {
 				},
 				UserConsentRepository,
 				UserPreferenceRepository,
-				TodoCategoryRepository,
+				DefaultTodoCategorySeeder,
 				provisioningSeederTestProvider,
 				retentionEnrollerTestProvider,
 				{

--- a/apps/api/test/integration/todo-category.integration-spec.ts
+++ b/apps/api/test/integration/todo-category.integration-spec.ts
@@ -30,7 +30,7 @@ import { ReorderTodoCategoryUseCase } from "@/todo-category/application/use-case
 import { UpdateTodoCategoryUseCase } from "@/todo-category/application/use-cases/update-todo-category/update-todo-category.use-case";
 import { TodoCategoryCacheAdapter } from "@/todo-category/infrastructure/adapters/todo-category-cache.adapter";
 import { PrismaTodoCategoryRepository } from "@/todo-category/infrastructure/persistence/prisma-todo-category.repository";
-import { TodoCategoryRepository } from "@/todo-category/todo-category.repository";
+import { DefaultTodoCategorySeeder } from "@/todo-category/infrastructure/seeders/default-todo-category.seeder";
 
 describe("TodoCategory 모듈 통합 테스트 (Mock DB)", () => {
 	let module: TestingModule;
@@ -89,7 +89,7 @@ describe("TodoCategory 모듈 통합 테스트 (Mock DB)", () => {
 				UpdateTodoCategoryUseCase,
 				DeleteTodoCategoryUseCase,
 				ReorderTodoCategoryUseCase,
-				TodoCategoryRepository,
+				DefaultTodoCategorySeeder,
 				{
 					provide: TODO_CATEGORY_REPOSITORY,
 					useClass: PrismaTodoCategoryRepository,


### PR DESCRIPTION
## 📋 개요

기본 Todo Category 시딩 책임을 명확히 명명. Aido API를 실용형 DDD·Clean Architecture로 점진 전환하는 Stack #746의 9/23 PR입니다.

구조와 책임만 정리하며 기존 클라이언트·운영 계약은 변경하지 않습니다. 이 PR은 바로 아래 PR만 base로 사용하므로 순서대로 독립 검토·롤백할 수 있습니다.

## 🏷️ 변경 유형

- [ ] ✨ `feat` - 새로운 기능 추가
- [ ] 🐛 `fix` - 버그 수정
- [ ] 📝 `docs` - 문서 수정
- [x] ♻️ `refactor` - 코드 리팩토링
- [ ] ⚡ `perf` - 성능 개선
- [ ] ✅ `test` - 테스트 추가/수정
- [ ] 👷 `ci` - CI/CD 설정 및 스크립트 변경
- [ ] 🔨 `chore` - 기타 변경사항

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [ ] `apps/mobile` - Expo 모바일 앱
- [ ] `packages/validators` - 공개 Zod 스키마
- [ ] `packages/utils` - 공유 유틸리티
- [ ] `packages/errors` - 에러 정의
- [ ] `tooling/*` - 개발 도구 설정
- [ ] multiple - 여러 영역 동시 변경

## 📝 변경 내용

- 회원 가입 기본 카테고리 생성을 DefaultTodoCategorySeeder라는 유비쿼터스 언어로 명명합니다.
- 가입 Unit of Work 안에서 동일 repository와 트랜잭션에 참여하도록 유지합니다.
- 불필요한 포트를 추가하지 않고 실제 capability만 노출합니다.

## 🔒 불변 계약

- HTTP route/method/header/query/body/response/status 변경 없음
- Zod·Swagger·`@aido/validators` 공개 export 변경 없음
- ErrorCode·message·details·응답 wrapping 변경 없음
- Prisma schema·migration·기존 데이터 변경 없음
- 큐 이름·job payload·Redis key·TTL 변경 없음
- 정렬·페이지네이션·멱등성·부수효과 발생 조건 변경 없음
- OpenAPI snapshot과 배포 클라이언트 fingerprint 갱신 없음

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm lint
pnpm build
pnpm --filter @aido/api lint:arch
pnpm --filter @aido/api test
```

### 테스트 결과

- [x] 타입 체크·린트·빌드 통과
- [x] 해당 모듈 단위 테스트 통과
- [x] 아키텍처·불변 계약 게이트 통과
- [x] 스택 최종 기준 전체 unit 361 suites / 2,598 tests 통과
- [x] 스택 최종 기준 integration 36 suites / 364 tests 통과
- [x] 스택 최종 기준 E2E 및 OpenAPI snapshots 통과
- [ ] 수동 운영 검증 — 배포 PR에서 수행

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다
- [x] Clean Architecture 의존성 방향을 준수합니다
- [x] 변경사항에 대한 테스트를 작성/수정했습니다
- [x] typecheck·lint·build 및 관련 테스트가 통과합니다
- [x] 필요한 아키텍처 문서를 업데이트했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨을 `type: refactor`, `scope: api`와 리뷰 상태로 정리했습니다

### 리뷰어 확인

- [ ] 계층 경계와 유비쿼터스 언어가 적절합니다
- [ ] 상태 전이·트랜잭션·커밋 후 부수효과가 기존과 같습니다
- [ ] 캐시·큐·멱등성·동시성 계약에 회귀가 없습니다
- [ ] 공개 API·오류·DB 계약에 변경이 없습니다

## 🔗 Stack 위치

- Stack: #746
- 이전 PR: #730
- 다음 PR: #732
- 병합 순서: #722부터 번호 순서대로

## 📸 스크린샷

UI 변경 없음 — 서버 내부 구조 리팩토링입니다.

## 💬 추가 정보

최종 스택에서 architecture baseline은 layer import 0, aggregate naming 0, internal barrel export 0, dependency violation 0, cast 0입니다.