### PR TITLE
refactor(api): Nudge와 Cheer endpoint 경계를 정리

### DIFF
--- a/apps/api/src/cheer/application/facades/cheer.facade.ts
+++ b/apps/api/src/cheer/application/facades/cheer.facade.ts
@@ -1,14 +1,5 @@
 import { Injectable } from "@nestjs/common";
-
-import type { CursorPaginatedResponse } from "@/shared/application/pagination";
-
-import type { CheerCooldown } from "../../domain/services/cheer-cooldown";
-import type { CheerWithRelations } from "../ports/cheer.repository.port";
-import {
-	type CheerLimitInfo,
-	CheerReader,
-	type GetCheersParams,
-} from "../services/cheer.reader";
+import { CheerReader } from "../services/cheer.reader";
 import { MarkCheerReadUseCase } from "../use-cases/mark-cheer-read/mark-cheer-read.use-case";
 import { MarkManyCheersReadUseCase } from "../use-cases/mark-many-cheers-read/mark-many-cheers-read.use-case";
 import {
@@ -16,10 +7,7 @@ import {
 	SendCheerUseCase,
 } from "../use-cases/send-cheer/send-cheer.use-case";
 
-/**
- * CheerFacade — cheer 모듈의 유일한 공개 표면.
- * 컨트롤러는 이 파사드만 주입하며, 파사드는 use-case·reader에 직접 위임한다(버스 없음).
- */
+/** @deprecated HTTP 진입점은 endpoint UseCase를 직접 사용한다. */
 @Injectable()
 export class CheerFacade {
 	constructor(
@@ -28,51 +16,34 @@ export class CheerFacade {
 		private readonly markCheerReadUseCase: MarkCheerReadUseCase,
 		private readonly markManyCheersReadUseCase: MarkManyCheersReadUseCase,
 	) {}
-
-	sendCheer(input: SendCheerInput, tz: string): Promise<CheerWithRelations> {
-		return this.sendCheerUseCase.execute(input, tz);
+	sendCheer(input: SendCheerInput, timezone: string) {
+		return this.sendCheerUseCase.execute(input, timezone);
 	}
-
-	getReceivedCheers(
-		params: GetCheersParams,
-	): Promise<CursorPaginatedResponse<CheerWithRelations, number>> {
-		return this.reader.getReceivedCheers(params);
+	getReceivedCheers(input: Parameters<CheerReader["getReceivedCheers"]>[0]) {
+		return this.reader.getReceivedCheers(input);
 	}
-
-	getSentCheers(
-		params: GetCheersParams,
-	): Promise<CursorPaginatedResponse<CheerWithRelations, number>> {
-		return this.reader.getSentCheers(params);
+	getSentCheers(input: Parameters<CheerReader["getSentCheers"]>[0]) {
+		return this.reader.getSentCheers(input);
 	}
-
-	getLimitInfo(userId: string, tz: string): Promise<CheerLimitInfo> {
-		return this.reader.getLimitInfo(userId, tz);
+	getLimitInfo(userId: string, timezone: string) {
+		return this.reader.getLimitInfo(userId, timezone);
 	}
-
-	getCooldownInfoForUser(
-		senderId: string,
-		receiverId: string,
-	): Promise<CheerCooldown> {
+	getCooldownInfoForUser(senderId: string, receiverId: string) {
 		return this.reader.getCooldownInfoForUser(senderId, receiverId);
 	}
-
-	markAsRead(userId: string, cheerId: number): Promise<void> {
+	markAsRead(userId: string, cheerId: number) {
 		return this.markCheerReadUseCase.execute({ userId, cheerId });
 	}
-
-	markManyAsRead(userId: string, cheerIds: number[]): Promise<number> {
+	markManyAsRead(userId: string, cheerIds: number[]) {
 		return this.markManyCheersReadUseCase.execute({ userId, cheerIds });
 	}
-
-	countReceivedCheers(userId: string): Promise<number> {
+	countReceivedCheers(userId: string) {
 		return this.reader.countReceivedCheers(userId);
 	}
-
-	countSentCheers(userId: string): Promise<number> {
+	countSentCheers(userId: string) {
 		return this.reader.countSentCheers(userId);
 	}
-
-	countUnreadReceivedCheers(userId: string): Promise<number> {
+	countUnreadReceivedCheers(userId: string) {
 		return this.reader.countUnreadReceivedCheers(userId);
 	}
 }

--- a/apps/api/src/cheer/application/ports/cheer.repository.port.ts
+++ b/apps/api/src/cheer/application/ports/cheer.repository.port.ts
@@ -1,4 +1,4 @@
-import type { Cheer } from "../../domain/entities/cheer.entity";
+import type { Cheer } from "../../domain/entities/cheer.aggregate";
 
 /** 응원 목록/응답에 필요한 사용자 요약 */
 export interface CheerUserBrief {

--- a/apps/api/src/cheer/application/use-cases/mark-cheer-read/mark-cheer-read.use-case.spec.ts
+++ b/apps/api/src/cheer/application/use-cases/mark-cheer-read/mark-cheer-read.use-case.spec.ts
@@ -5,7 +5,7 @@ import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
 import { createCheerRepositoryMock } from "@test/mocks/ports/cheer.mock";
 
-import { Cheer } from "../../../domain/entities/cheer.entity";
+import { Cheer } from "../../../domain/entities/cheer.aggregate";
 import {
 	CHEER_REPOSITORY,
 	type CheerRepositoryPort,

--- a/apps/api/src/cheer/cheer.module.ts
+++ b/apps/api/src/cheer/cheer.module.ts
@@ -2,8 +2,8 @@ import { Module } from "@nestjs/common";
 
 import { FollowModule } from "@/follow/follow.module";
 import { NotificationModule } from "@/notification/notification.module";
-
 import { CheerFacade } from "./application/facades/cheer.facade";
+
 import { CHEER_REPOSITORY } from "./application/ports/cheer.repository.port";
 import { CHEER_LIMIT_READER } from "./application/ports/cheer-limit-reader.port";
 import { CHEER_NOTIFIER } from "./application/ports/cheer-notifier.port";

--- a/apps/api/src/cheer/domain/entities/cheer.aggregate.spec.ts
+++ b/apps/api/src/cheer/domain/entities/cheer.aggregate.spec.ts
@@ -1,4 +1,4 @@
-import { Cheer } from "./cheer.entity";
+import { Cheer } from "./cheer.aggregate";
 
 const make = (
 	over: Partial<{ readAt: Date | null; receiverId: string }> = {},

--- a/apps/api/src/cheer/domain/entities/cheer.aggregate.ts
+++ b/apps/api/src/cheer/domain/entities/cheer.aggregate.ts
@@ -13,56 +13,46 @@ export interface CheerProps {
  * 한 건의 응원(발신자→수신자, 선택적 메시지)을 나타내며, 읽음 여부·수신자 소유 판별 등
  * 응원에 관한 규칙을 캡슐화한다. 세터는 없다(불변 조회 모델).
  */
-export class Cheer {
-	private constructor(
-		private readonly _id: number,
-		private readonly _senderId: string,
-		private readonly _receiverId: string,
-		private readonly _message: string | null,
-		private readonly _readAt: Date | null,
-		private readonly _createdAt: Date,
-	) {}
-
+export class Cheer extends AggregateRoot<CheerProps> {
 	static reconstitute(props: CheerProps): Cheer {
-		return new Cheer(
-			props.id,
-			props.senderId,
-			props.receiverId,
-			props.message,
-			props.readAt,
-			props.createdAt,
-		);
+		return new Cheer({
+			...props,
+			readAt: props.readAt ? new Date(props.readAt) : null,
+			createdAt: new Date(props.createdAt),
+		});
 	}
 
 	get id(): number {
-		return this._id;
+		return this.props.id;
 	}
 
 	get senderId(): string {
-		return this._senderId;
+		return this.props.senderId;
 	}
 
 	get receiverId(): string {
-		return this._receiverId;
+		return this.props.receiverId;
 	}
 
 	get message(): string | null {
-		return this._message;
+		return this.props.message;
 	}
 
 	get readAt(): Date | null {
-		return this._readAt;
+		return this.props.readAt ? new Date(this.props.readAt) : null;
 	}
 
 	get createdAt(): Date {
-		return this._createdAt;
+		return new Date(this.props.createdAt);
 	}
 
 	isRead(): boolean {
-		return this._readAt !== null;
+		return this.props.readAt !== null;
 	}
 
 	isReceivedBy(userId: string): boolean {
-		return this._receiverId === userId;
+		return this.props.receiverId === userId;
 	}
 }
+
+import { AggregateRoot } from "@/shared/domain";

--- a/apps/api/src/cheer/infrastructure/persistence/prisma-cheer.repository.ts
+++ b/apps/api/src/cheer/infrastructure/persistence/prisma-cheer.repository.ts
@@ -15,7 +15,7 @@ import type {
 	CreateCheerInput,
 	FindCheersParams,
 } from "../../application/ports/cheer.repository.port";
-import { Cheer } from "../../domain/entities/cheer.entity";
+import { Cheer } from "../../domain/entities/cheer.aggregate";
 
 type UserBriefRow = {
 	id: string;

--- a/apps/api/src/cheer/presentation/cheer.controller.spec.ts
+++ b/apps/api/src/cheer/presentation/cheer.controller.spec.ts
@@ -2,8 +2,11 @@ import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
 
 import type { CurrentUserPayload } from "@/auth/presentation/decorators";
-import { CheerFacade } from "../application/facades/cheer.facade";
 import type { CheerWithRelations } from "../application/ports/cheer.repository.port";
+import { CheerReader } from "../application/services/cheer.reader";
+import { MarkCheerReadUseCase } from "../application/use-cases/mark-cheer-read/mark-cheer-read.use-case";
+import { MarkManyCheersReadUseCase } from "../application/use-cases/mark-many-cheers-read/mark-many-cheers-read.use-case";
+import { SendCheerUseCase } from "../application/use-cases/send-cheer/send-cheer.use-case";
 import { CheerController } from "./cheer.controller";
 import type {
 	GetCheersQueryDto,
@@ -31,21 +34,27 @@ const cheer: CheerWithRelations = {
 
 describe("CheerController", () => {
 	let controller: CheerController;
-	let facade: Mocked<CheerFacade>;
+	let cheerReader: Mocked<CheerReader>;
+	let sendCheerUseCase: Mocked<SendCheerUseCase>;
+	let markCheerReadUseCase: Mocked<MarkCheerReadUseCase>;
+	let markManyCheersReadUseCase: Mocked<MarkManyCheersReadUseCase>;
 
 	beforeEach(async () => {
 		const { unit, unitRef } = await TestBed.solitary(CheerController).compile();
 		controller = unit;
-		facade = unitRef.get(CheerFacade);
+		cheerReader = unitRef.get(CheerReader);
+		sendCheerUseCase = unitRef.get(SendCheerUseCase);
+		markCheerReadUseCase = unitRef.get(MarkCheerReadUseCase);
+		markManyCheersReadUseCase = unitRef.get(MarkManyCheersReadUseCase);
 	});
 
 	it("sendCheer는 파사드에 위임하고 응답을 구성한다", async () => {
-		facade.sendCheer.mockResolvedValue(cheer);
+		sendCheerUseCase.execute.mockResolvedValue(cheer);
 		const dto = { receiverId: "receiver", message: "hi" } as SendCheerDto;
 
 		const result = await controller.sendCheer(user, dto, "Asia/Seoul");
 
-		expect(facade.sendCheer).toHaveBeenCalledWith(
+		expect(sendCheerUseCase.execute).toHaveBeenCalledWith(
 			{ senderId: "sender", receiverId: "receiver", message: "hi" },
 			"Asia/Seoul",
 		);
@@ -54,12 +63,12 @@ describe("CheerController", () => {
 	});
 
 	it("getReceivedCheers는 목록/총계/미읽음을 병렬 조회한다", async () => {
-		facade.getReceivedCheers.mockResolvedValue({
+		cheerReader.getReceivedCheers.mockResolvedValue({
 			items: [cheer],
 			pagination: { hasNext: true, nextCursor: 1, size: 20 },
 		});
-		facade.countReceivedCheers.mockResolvedValue(5);
-		facade.countUnreadReceivedCheers.mockResolvedValue(2);
+		cheerReader.countReceivedCheers.mockResolvedValue(5);
+		cheerReader.countUnreadReceivedCheers.mockResolvedValue(2);
 		const query = {
 			cursor: undefined,
 			limit: 20,
@@ -74,7 +83,7 @@ describe("CheerController", () => {
 	});
 
 	it("getLimitInfo는 한도 정보를 매핑한다", async () => {
-		facade.getLimitInfo.mockResolvedValue({
+		cheerReader.getLimitInfo.mockResolvedValue({
 			dailyLimit: 3,
 			used: 1,
 			remaining: 2,
@@ -91,7 +100,7 @@ describe("CheerController", () => {
 	});
 
 	it("getCooldownInfo는 canCheer를 반전한다", async () => {
-		facade.getCooldownInfoForUser.mockResolvedValue({
+		cheerReader.getCooldownInfoForUser.mockResolvedValue({
 			isActive: true,
 			remainingSeconds: 100,
 			canCheerAt: new Date("2026-01-01T01:00:00.000Z"),
@@ -105,21 +114,27 @@ describe("CheerController", () => {
 	});
 
 	it("markAsRead는 파사드에 위임한다", async () => {
-		facade.markAsRead.mockResolvedValue(undefined);
+		markCheerReadUseCase.execute.mockResolvedValue(undefined);
 
 		const result = await controller.markAsRead(user, { id: 9 });
 
-		expect(facade.markAsRead).toHaveBeenCalledWith("sender", 9);
+		expect(markCheerReadUseCase.execute).toHaveBeenCalledWith({
+			userId: "sender",
+			cheerId: 9,
+		});
 		expect(result.readCount).toBe(1);
 	});
 
 	it("markManyAsRead는 처리 개수를 반환한다", async () => {
-		facade.markManyAsRead.mockResolvedValue(3);
+		markManyCheersReadUseCase.execute.mockResolvedValue(3);
 		const dto = { cheerIds: [1, 2, 3] } as MarkCheersReadDto;
 
 		const result = await controller.markManyAsRead(user, dto);
 
-		expect(facade.markManyAsRead).toHaveBeenCalledWith("sender", [1, 2, 3]);
+		expect(markManyCheersReadUseCase.execute).toHaveBeenCalledWith({
+			userId: "sender",
+			cheerIds: [1, 2, 3],
+		});
 		expect(result.readCount).toBe(3);
 	});
 });

--- a/apps/api/src/cheer/presentation/cheer.controller.ts
+++ b/apps/api/src/cheer/presentation/cheer.controller.ts
@@ -32,7 +32,10 @@ import {
 	CurrentUser,
 	type CurrentUserPayload,
 } from "../../auth/presentation/decorators";
-import { CheerFacade } from "../application/facades/cheer.facade";
+import { CheerReader } from "../application/services/cheer.reader";
+import { MarkCheerReadUseCase } from "../application/use-cases/mark-cheer-read/mark-cheer-read.use-case";
+import { MarkManyCheersReadUseCase } from "../application/use-cases/mark-many-cheers-read/mark-many-cheers-read.use-case";
+import { SendCheerUseCase } from "../application/use-cases/send-cheer/send-cheer.use-case";
 import { CheerMapper } from "./cheer.mapper";
 import {
 	CheerCooldownResponseDto,
@@ -53,7 +56,12 @@ import {
 export class CheerController {
 	readonly #logger = new Logger(CheerController.name);
 
-	constructor(private readonly cheerFacade: CheerFacade) {}
+	constructor(
+		private readonly cheerReader: CheerReader,
+		private readonly sendCheerUseCase: SendCheerUseCase,
+		private readonly markCheerReadUseCase: MarkCheerReadUseCase,
+		private readonly markManyCheersReadUseCase: MarkManyCheersReadUseCase,
+	) {}
 
 	@Post()
 	@ApiHeader({
@@ -90,7 +98,7 @@ export class CheerController {
 			`응원 보내기: senderId=${user.userId}, receiverId=${dto.receiverId}`,
 		);
 
-		const cheer = await this.cheerFacade.sendCheer(
+		const cheer = await this.sendCheerUseCase.execute(
 			{
 				senderId: user.userId,
 				receiverId: dto.receiverId,
@@ -128,13 +136,13 @@ export class CheerController {
 		this.#logger.debug(`받은 응원 목록 조회: userId=${user.userId}`);
 
 		const [result, totalCount, unreadCount] = await Promise.all([
-			this.cheerFacade.getReceivedCheers({
+			this.cheerReader.getReceivedCheers({
 				userId: user.userId,
 				cursor: query.cursor,
 				size: query.limit,
 			}),
-			this.cheerFacade.countReceivedCheers(user.userId),
-			this.cheerFacade.countUnreadReceivedCheers(user.userId),
+			this.cheerReader.countReceivedCheers(user.userId),
+			this.cheerReader.countUnreadReceivedCheers(user.userId),
 		]);
 
 		return {
@@ -164,12 +172,12 @@ export class CheerController {
 		this.#logger.debug(`보낸 응원 목록 조회: userId=${user.userId}`);
 
 		const [result, totalCount] = await Promise.all([
-			this.cheerFacade.getSentCheers({
+			this.cheerReader.getSentCheers({
 				userId: user.userId,
 				cursor: query.cursor,
 				size: query.limit,
 			}),
-			this.cheerFacade.countSentCheers(user.userId),
+			this.cheerReader.countSentCheers(user.userId),
 		]);
 
 		return {
@@ -199,7 +207,7 @@ export class CheerController {
 		@CurrentUser() user: CurrentUserPayload,
 		@Timezone() tz: string,
 	): Promise<CheerLimitInfoDto> {
-		const limitInfo = await this.cheerFacade.getLimitInfo(user.userId, tz);
+		const limitInfo = await this.cheerReader.getLimitInfo(user.userId, tz);
 		return CheerMapper.toLimitInfoDto(limitInfo);
 	}
 
@@ -223,7 +231,7 @@ export class CheerController {
 		@CurrentUser() user: CurrentUserPayload,
 		@Param("userId") targetUserId: string,
 	): Promise<CheerCooldownResponseDto> {
-		const cooldownInfo = await this.cheerFacade.getCooldownInfoForUser(
+		const cooldownInfo = await this.cheerReader.getCooldownInfoForUser(
 			user.userId,
 			targetUserId,
 		);
@@ -254,7 +262,10 @@ export class CheerController {
 			`응원 읽음 처리: userId=${user.userId}, id=${params.id}`,
 		);
 
-		await this.cheerFacade.markAsRead(user.userId, params.id);
+		await this.markCheerReadUseCase.execute({
+			userId: user.userId,
+			cheerId: params.id,
+		});
 
 		return {
 			message: "확인했습니다.",
@@ -282,10 +293,10 @@ export class CheerController {
 			`여러 응원 읽음 처리: userId=${user.userId}, count=${dto.cheerIds.length}`,
 		);
 
-		const count = await this.cheerFacade.markManyAsRead(
-			user.userId,
-			dto.cheerIds,
-		);
+		const count = await this.markManyCheersReadUseCase.execute({
+			userId: user.userId,
+			cheerIds: dto.cheerIds,
+		});
 
 		return {
 			message: `${count}개의 응원을 확인했습니다.`,

--- a/apps/api/src/nudge/application/facades/nudge.facade.ts
+++ b/apps/api/src/nudge/application/facades/nudge.facade.ts
@@ -1,17 +1,5 @@
 import { Injectable } from "@nestjs/common";
-
-import type { CursorPaginatedResponse } from "@/shared/application/pagination";
-
-import type { NudgeCooldown } from "../../domain/services/nudge-cooldown";
-import type {
-	NudgeWithRelations,
-	ReminderNudgeWithRelations,
-} from "../ports/nudge.repository.port";
-import {
-	type GetNudgesParams,
-	type NudgeLimitInfo,
-	NudgeReader,
-} from "../services/nudge.reader";
+import { NudgeReader } from "../services/nudge.reader";
 import { MarkNudgeReadUseCase } from "../use-cases/mark-nudge-read/mark-nudge-read.use-case";
 import {
 	type SendNudgeInput,
@@ -22,10 +10,7 @@ import {
 	SendRemindNudgeUseCase,
 } from "../use-cases/send-remind-nudge/send-remind-nudge.use-case";
 
-/**
- * NudgeFacade — nudge 모듈의 유일한 공개 표면.
- * 컨트롤러는 이 파사드만 주입하며, 파사드는 use-case·reader에 직접 위임한다(버스 없음).
- */
+/** @deprecated HTTP 진입점은 endpoint UseCase를 직접 사용한다. */
 @Injectable()
 export class NudgeFacade {
 	constructor(
@@ -34,61 +19,37 @@ export class NudgeFacade {
 		private readonly sendRemindNudgeUseCase: SendRemindNudgeUseCase,
 		private readonly markNudgeReadUseCase: MarkNudgeReadUseCase,
 	) {}
-
-	sendNudge(input: SendNudgeInput, tz: string): Promise<NudgeWithRelations> {
-		return this.sendNudgeUseCase.execute(input, tz);
+	sendNudge(input: SendNudgeInput, timezone: string) {
+		return this.sendNudgeUseCase.execute(input, timezone);
 	}
-
-	sendRemindNudge(
-		input: SendRemindNudgeInput,
-		tz: string,
-	): Promise<ReminderNudgeWithRelations> {
-		return this.sendRemindNudgeUseCase.execute(input, tz);
+	sendRemindNudge(input: SendRemindNudgeInput, timezone: string) {
+		return this.sendRemindNudgeUseCase.execute(input, timezone);
 	}
-
-	getReceivedNudges(
-		params: GetNudgesParams,
-	): Promise<CursorPaginatedResponse<NudgeWithRelations, number>> {
-		return this.reader.getReceivedNudges(params);
+	getReceivedNudges(input: Parameters<NudgeReader["getReceivedNudges"]>[0]) {
+		return this.reader.getReceivedNudges(input);
 	}
-
-	getSentNudges(
-		params: GetNudgesParams,
-	): Promise<CursorPaginatedResponse<NudgeWithRelations, number>> {
-		return this.reader.getSentNudges(params);
+	getSentNudges(input: Parameters<NudgeReader["getSentNudges"]>[0]) {
+		return this.reader.getSentNudges(input);
 	}
-
-	getLimitInfo(userId: string, tz: string): Promise<NudgeLimitInfo> {
-		return this.reader.getLimitInfo(userId, tz);
+	getLimitInfo(userId: string, timezone: string) {
+		return this.reader.getLimitInfo(userId, timezone);
 	}
-
-	getCooldownInfoForUser(
-		senderId: string,
-		receiverId: string,
-	): Promise<NudgeCooldown> {
+	getCooldownInfoForUser(senderId: string, receiverId: string) {
 		return this.reader.getCooldownInfoForUser(senderId, receiverId);
 	}
-
-	getRemindCooldownInfo(
-		senderId: string,
-		receiverId: string,
-	): Promise<NudgeCooldown> {
+	getRemindCooldownInfo(senderId: string, receiverId: string) {
 		return this.reader.getRemindCooldownInfo(senderId, receiverId);
 	}
-
-	markAsRead(userId: string, nudgeId: number): Promise<void> {
+	markAsRead(userId: string, nudgeId: number) {
 		return this.markNudgeReadUseCase.execute({ userId, nudgeId });
 	}
-
-	countReceivedNudges(userId: string): Promise<number> {
+	countReceivedNudges(userId: string) {
 		return this.reader.countReceivedNudges(userId);
 	}
-
-	countSentNudges(userId: string): Promise<number> {
+	countSentNudges(userId: string) {
 		return this.reader.countSentNudges(userId);
 	}
-
-	countUnreadReceivedNudges(userId: string): Promise<number> {
+	countUnreadReceivedNudges(userId: string) {
 		return this.reader.countUnreadReceivedNudges(userId);
 	}
 }

--- a/apps/api/src/nudge/application/ports/nudge.repository.port.ts
+++ b/apps/api/src/nudge/application/ports/nudge.repository.port.ts
@@ -1,4 +1,4 @@
-import type { Nudge } from "../../domain/entities/nudge.entity";
+import type { Nudge } from "../../domain/entities/nudge.aggregate";
 import type { ReminderNudge } from "../../domain/entities/reminder-nudge.entity";
 
 /** 콕 찌르기 목록/응답에 필요한 사용자 요약 */

--- a/apps/api/src/nudge/application/use-cases/mark-nudge-read/mark-nudge-read.use-case.spec.ts
+++ b/apps/api/src/nudge/application/use-cases/mark-nudge-read/mark-nudge-read.use-case.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from "@suites/unit";
 
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 
-import { Nudge } from "../../../domain/entities/nudge.entity";
+import { Nudge } from "../../../domain/entities/nudge.aggregate";
 import {
 	NUDGE_REPOSITORY,
 	type NudgeRepositoryPort,

--- a/apps/api/src/nudge/application/use-cases/send-nudge/send-nudge.use-case.spec.ts
+++ b/apps/api/src/nudge/application/use-cases/send-nudge/send-nudge.use-case.spec.ts
@@ -10,7 +10,7 @@ import {
 import { todayInTimezone } from "@/shared/domain/date/utils/timezone";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 
-import { Nudge } from "../../../domain/entities/nudge.entity";
+import { Nudge } from "../../../domain/entities/nudge.aggregate";
 import {
 	NUDGE_REPOSITORY,
 	type NudgeRepositoryPort,

--- a/apps/api/src/nudge/domain/entities/nudge.aggregate.spec.ts
+++ b/apps/api/src/nudge/domain/entities/nudge.aggregate.spec.ts
@@ -1,4 +1,4 @@
-import { Nudge } from "./nudge.entity";
+import { Nudge } from "./nudge.aggregate";
 
 const base = {
 	id: 1,

--- a/apps/api/src/nudge/domain/entities/nudge.aggregate.ts
+++ b/apps/api/src/nudge/domain/entities/nudge.aggregate.ts
@@ -14,62 +14,50 @@ export interface NudgeProps {
  * 친구의 특정 할 일(todoId)을 콕 찌른 한 건을 나타내며, 읽음 여부·수신자 소유 판별 등
  * 콕 찌르기에 관한 규칙을 캡슐화한다. 세터는 없다(불변 조회 모델).
  */
-export class Nudge {
-	private constructor(
-		private readonly _id: number,
-		private readonly _senderId: string,
-		private readonly _receiverId: string,
-		private readonly _todoId: number,
-		private readonly _message: string | null,
-		private readonly _readAt: Date | null,
-		private readonly _createdAt: Date,
-	) {}
-
+export class Nudge extends AggregateRoot<NudgeProps> {
 	static reconstitute(props: NudgeProps): Nudge {
-		return new Nudge(
-			props.id,
-			props.senderId,
-			props.receiverId,
-			props.todoId,
-			props.message,
-			props.readAt,
-			props.createdAt,
-		);
+		return new Nudge({
+			...props,
+			readAt: props.readAt ? new Date(props.readAt) : null,
+			createdAt: new Date(props.createdAt),
+		});
 	}
 
 	get id(): number {
-		return this._id;
+		return this.props.id;
 	}
 
 	get senderId(): string {
-		return this._senderId;
+		return this.props.senderId;
 	}
 
 	get receiverId(): string {
-		return this._receiverId;
+		return this.props.receiverId;
 	}
 
 	get todoId(): number {
-		return this._todoId;
+		return this.props.todoId;
 	}
 
 	get message(): string | null {
-		return this._message;
+		return this.props.message;
 	}
 
 	get readAt(): Date | null {
-		return this._readAt;
+		return this.props.readAt ? new Date(this.props.readAt) : null;
 	}
 
 	get createdAt(): Date {
-		return this._createdAt;
+		return new Date(this.props.createdAt);
 	}
 
 	isRead(): boolean {
-		return this._readAt !== null;
+		return this.props.readAt !== null;
 	}
 
 	isReceivedBy(userId: string): boolean {
-		return this._receiverId === userId;
+		return this.props.receiverId === userId;
 	}
 }
+
+import { AggregateRoot } from "@/shared/domain";

--- a/apps/api/src/nudge/infrastructure/persistence/prisma-nudge.repository.ts
+++ b/apps/api/src/nudge/infrastructure/persistence/prisma-nudge.repository.ts
@@ -18,7 +18,7 @@ import type {
 	ReminderNudgeWithRelations,
 	TargetTodoRecord,
 } from "../../application/ports/nudge.repository.port";
-import { Nudge } from "../../domain/entities/nudge.entity";
+import { Nudge } from "../../domain/entities/nudge.aggregate";
 import { ReminderNudge } from "../../domain/entities/reminder-nudge.entity";
 
 type UserBriefRow = {

--- a/apps/api/src/nudge/nudge.module.ts
+++ b/apps/api/src/nudge/nudge.module.ts
@@ -2,8 +2,8 @@ import { Module } from "@nestjs/common";
 
 import { FollowModule } from "@/follow/follow.module";
 import { NotificationModule } from "@/notification/notification.module";
-
 import { NudgeFacade } from "./application/facades/nudge.facade";
+
 import { NUDGE_REPOSITORY } from "./application/ports/nudge.repository.port";
 import { NUDGE_LIMIT_READER } from "./application/ports/nudge-limit-reader.port";
 import { NUDGE_NOTIFIER } from "./application/ports/nudge-notifier.port";

--- a/apps/api/src/nudge/presentation/nudge.controller.spec.ts
+++ b/apps/api/src/nudge/presentation/nudge.controller.spec.ts
@@ -2,11 +2,14 @@ import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
 
 import type { CurrentUserPayload } from "@/auth/presentation/decorators";
-import { NudgeFacade } from "../application/facades/nudge.facade";
 import type {
 	NudgeWithRelations,
 	ReminderNudgeWithRelations,
 } from "../application/ports/nudge.repository.port";
+import { NudgeReader } from "../application/services/nudge.reader";
+import { MarkNudgeReadUseCase } from "../application/use-cases/mark-nudge-read/mark-nudge-read.use-case";
+import { SendNudgeUseCase } from "../application/use-cases/send-nudge/send-nudge.use-case";
+import { SendRemindNudgeUseCase } from "../application/use-cases/send-remind-nudge/send-remind-nudge.use-case";
 import type {
 	GetNudgesQueryDto,
 	SendNudgeDto,
@@ -45,16 +48,22 @@ const remindNudge: ReminderNudgeWithRelations = {
 
 describe("NudgeController", () => {
 	let controller: NudgeController;
-	let facade: Mocked<NudgeFacade>;
+	let nudgeReader: Mocked<NudgeReader>;
+	let sendNudgeUseCase: Mocked<SendNudgeUseCase>;
+	let sendRemindNudgeUseCase: Mocked<SendRemindNudgeUseCase>;
+	let markNudgeReadUseCase: Mocked<MarkNudgeReadUseCase>;
 
 	beforeEach(async () => {
 		const { unit, unitRef } = await TestBed.solitary(NudgeController).compile();
 		controller = unit;
-		facade = unitRef.get(NudgeFacade);
+		nudgeReader = unitRef.get(NudgeReader);
+		sendNudgeUseCase = unitRef.get(SendNudgeUseCase);
+		sendRemindNudgeUseCase = unitRef.get(SendRemindNudgeUseCase);
+		markNudgeReadUseCase = unitRef.get(MarkNudgeReadUseCase);
 	});
 
 	it("sendNudge는 파사드에 위임하고 응답을 구성한다", async () => {
-		facade.sendNudge.mockResolvedValue(nudge);
+		sendNudgeUseCase.execute.mockResolvedValue(nudge);
 		const dto = {
 			receiverId: "receiver",
 			todoId: 10,
@@ -63,7 +72,7 @@ describe("NudgeController", () => {
 
 		const result = await controller.sendNudge(user, dto, "Asia/Seoul");
 
-		expect(facade.sendNudge).toHaveBeenCalledWith(
+		expect(sendNudgeUseCase.execute).toHaveBeenCalledWith(
 			{ senderId: "sender", receiverId: "receiver", todoId: 10, message: "hi" },
 			"Asia/Seoul",
 		);
@@ -72,12 +81,12 @@ describe("NudgeController", () => {
 	});
 
 	it("getReceivedNudges는 목록/총계/미읽음을 병렬 조회한다", async () => {
-		facade.getReceivedNudges.mockResolvedValue({
+		nudgeReader.getReceivedNudges.mockResolvedValue({
 			items: [nudge],
 			pagination: { hasNext: true, nextCursor: 1, size: 20 },
 		});
-		facade.countReceivedNudges.mockResolvedValue(5);
-		facade.countUnreadReceivedNudges.mockResolvedValue(2);
+		nudgeReader.countReceivedNudges.mockResolvedValue(5);
+		nudgeReader.countUnreadReceivedNudges.mockResolvedValue(2);
 		const query = {
 			cursor: undefined,
 			limit: 20,
@@ -92,7 +101,7 @@ describe("NudgeController", () => {
 	});
 
 	it("getLimitInfo는 한도 정보를 매핑한다", async () => {
-		facade.getLimitInfo.mockResolvedValue({
+		nudgeReader.getLimitInfo.mockResolvedValue({
 			dailyLimit: 3,
 			used: 1,
 			remaining: 2,
@@ -109,7 +118,7 @@ describe("NudgeController", () => {
 	});
 
 	it("getCooldownInfo는 canNudge를 반전한다", async () => {
-		facade.getCooldownInfoForUser.mockResolvedValue({
+		nudgeReader.getCooldownInfoForUser.mockResolvedValue({
 			isActive: true,
 			remainingSeconds: 100,
 			cooldownEndsAt: new Date("2026-01-01T01:00:00.000Z"),
@@ -122,12 +131,12 @@ describe("NudgeController", () => {
 	});
 
 	it("sendRemindNudge는 파사드에 위임한다", async () => {
-		facade.sendRemindNudge.mockResolvedValue(remindNudge);
+		sendRemindNudgeUseCase.execute.mockResolvedValue(remindNudge);
 		const dto = { receiverId: "receiver" } as SendRemindNudgeDto;
 
 		const result = await controller.sendRemindNudge(user, dto, "UTC");
 
-		expect(facade.sendRemindNudge).toHaveBeenCalledWith(
+		expect(sendRemindNudgeUseCase.execute).toHaveBeenCalledWith(
 			{ senderId: "sender", receiverId: "receiver", message: undefined },
 			"UTC",
 		);
@@ -136,7 +145,7 @@ describe("NudgeController", () => {
 	});
 
 	it("getRemindCooldownInfo는 canNudge를 반전한다", async () => {
-		facade.getRemindCooldownInfo.mockResolvedValue({
+		nudgeReader.getRemindCooldownInfo.mockResolvedValue({
 			isActive: false,
 			remainingSeconds: 0,
 			cooldownEndsAt: null,
@@ -149,11 +158,14 @@ describe("NudgeController", () => {
 	});
 
 	it("markAsRead는 파사드에 위임한다", async () => {
-		facade.markAsRead.mockResolvedValue(undefined);
+		markNudgeReadUseCase.execute.mockResolvedValue(undefined);
 
 		const result = await controller.markAsRead(user, { id: 9 });
 
-		expect(facade.markAsRead).toHaveBeenCalledWith("sender", 9);
+		expect(markNudgeReadUseCase.execute).toHaveBeenCalledWith({
+			userId: "sender",
+			nudgeId: 9,
+		});
 		expect(result.readCount).toBe(1);
 	});
 });

--- a/apps/api/src/nudge/presentation/nudge.controller.ts
+++ b/apps/api/src/nudge/presentation/nudge.controller.ts
@@ -32,7 +32,10 @@ import {
 	CurrentUser,
 	type CurrentUserPayload,
 } from "../../auth/presentation/decorators";
-import { NudgeFacade } from "../application/facades/nudge.facade";
+import { NudgeReader } from "../application/services/nudge.reader";
+import { MarkNudgeReadUseCase } from "../application/use-cases/mark-nudge-read/mark-nudge-read.use-case";
+import { SendNudgeUseCase } from "../application/use-cases/send-nudge/send-nudge.use-case";
+import { SendRemindNudgeUseCase } from "../application/use-cases/send-remind-nudge/send-remind-nudge.use-case";
 import {
 	CreateNudgeResponseDto,
 	CreateRemindNudgeResponseDto,
@@ -54,7 +57,12 @@ import { NudgeMapper } from "./nudge.mapper";
 export class NudgeController {
 	readonly #logger = new Logger(NudgeController.name);
 
-	constructor(private readonly nudgeFacade: NudgeFacade) {}
+	constructor(
+		private readonly nudgeReader: NudgeReader,
+		private readonly sendNudgeUseCase: SendNudgeUseCase,
+		private readonly sendRemindNudgeUseCase: SendRemindNudgeUseCase,
+		private readonly markNudgeReadUseCase: MarkNudgeReadUseCase,
+	) {}
 
 	@Post()
 	@ApiHeader({
@@ -95,7 +103,7 @@ export class NudgeController {
 			`콕 찌르기: senderId=${user.userId}, receiverId=${dto.receiverId}, todoId=${dto.todoId}`,
 		);
 
-		const nudge = await this.nudgeFacade.sendNudge(
+		const nudge = await this.sendNudgeUseCase.execute(
 			{
 				senderId: user.userId,
 				receiverId: dto.receiverId,
@@ -134,13 +142,13 @@ export class NudgeController {
 		this.#logger.debug(`받은 콕 찌름 목록 조회: userId=${user.userId}`);
 
 		const [result, totalCount, unreadCount] = await Promise.all([
-			this.nudgeFacade.getReceivedNudges({
+			this.nudgeReader.getReceivedNudges({
 				userId: user.userId,
 				cursor: query.cursor,
 				size: query.limit,
 			}),
-			this.nudgeFacade.countReceivedNudges(user.userId),
-			this.nudgeFacade.countUnreadReceivedNudges(user.userId),
+			this.nudgeReader.countReceivedNudges(user.userId),
+			this.nudgeReader.countUnreadReceivedNudges(user.userId),
 		]);
 
 		return {
@@ -170,12 +178,12 @@ export class NudgeController {
 		this.#logger.debug(`보낸 콕 찌름 목록 조회: userId=${user.userId}`);
 
 		const [result, totalCount] = await Promise.all([
-			this.nudgeFacade.getSentNudges({
+			this.nudgeReader.getSentNudges({
 				userId: user.userId,
 				cursor: query.cursor,
 				size: query.limit,
 			}),
-			this.nudgeFacade.countSentNudges(user.userId),
+			this.nudgeReader.countSentNudges(user.userId),
 		]);
 
 		return {
@@ -205,7 +213,7 @@ export class NudgeController {
 		@CurrentUser() user: CurrentUserPayload,
 		@Timezone() tz: string,
 	): Promise<NudgeLimitInfoDto> {
-		const limitInfo = await this.nudgeFacade.getLimitInfo(user.userId, tz);
+		const limitInfo = await this.nudgeReader.getLimitInfo(user.userId, tz);
 
 		return NudgeMapper.toLimitInfoDto(limitInfo);
 	}
@@ -231,7 +239,7 @@ export class NudgeController {
 		@CurrentUser() user: CurrentUserPayload,
 		@Param("userId") targetUserId: string,
 	): Promise<NudgeCooldownResponseDto> {
-		const cooldownInfo = await this.nudgeFacade.getCooldownInfoForUser(
+		const cooldownInfo = await this.nudgeReader.getCooldownInfoForUser(
 			user.userId,
 			targetUserId,
 		);
@@ -282,7 +290,7 @@ export class NudgeController {
 			`리마인드 콕 찌르기: senderId=${user.userId}, receiverId=${dto.receiverId}`,
 		);
 
-		const remindNudge = await this.nudgeFacade.sendRemindNudge(
+		const remindNudge = await this.sendRemindNudgeUseCase.execute(
 			{
 				senderId: user.userId,
 				receiverId: dto.receiverId,
@@ -321,7 +329,7 @@ export class NudgeController {
 		@CurrentUser() user: CurrentUserPayload,
 		@Param("userId") targetUserId: string,
 	): Promise<NudgeCooldownResponseDto> {
-		const cooldownInfo = await this.nudgeFacade.getRemindCooldownInfo(
+		const cooldownInfo = await this.nudgeReader.getRemindCooldownInfo(
 			user.userId,
 			targetUserId,
 		);
@@ -354,7 +362,10 @@ export class NudgeController {
 			`콕 찌름 읽음 처리: userId=${user.userId}, id=${params.id}`,
 		);
 
-		await this.nudgeFacade.markAsRead(user.userId, params.id);
+		await this.markNudgeReadUseCase.execute({
+			userId: user.userId,
+			nudgeId: params.id,
+		});
 
 		return {
 			message: "확인했습니다.",


### PR DESCRIPTION
## 📋 개요

Nudge와 Cheer endpoint 경계를 정리. Aido API를 실용형 DDD·Clean Architecture로 점진 전환하는 Stack #746의 10/23 PR입니다.

구조와 책임만 정리하며 기존 클라이언트·운영 계약은 변경하지 않습니다. 이 PR은 바로 아래 PR만 base로 사용하므로 순서대로 독립 검토·롤백할 수 있습니다.

## 🏷️ 변경 유형

- [ ] ✨ `feat` - 새로운 기능 추가
- [ ] 🐛 `fix` - 버그 수정
- [ ] 📝 `docs` - 문서 수정
- [x] ♻️ `refactor` - 코드 리팩토링
- [ ] ⚡ `perf` - 성능 개선
- [ ] ✅ `test` - 테스트 추가/수정
- [ ] 👷 `ci` - CI/CD 설정 및 스크립트 변경
- [ ] 🔨 `chore` - 기타 변경사항

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드
- [ ] `apps/mobile` - Expo 모바일 앱
- [ ] `packages/validators` - 공개 Zod 스키마
- [ ] `packages/utils` - 공유 유틸리티
- [ ] `packages/errors` - 에러 정의
- [ ] `tooling/*` - 개발 도구 설정
- [ ] multiple - 여러 영역 동시 변경

## 📝 변경 내용

- Nudge와 Cheer Controller의 Facade를 제거하고 endpoint UseCase를 직접 주입합니다.
- 발송 한도·쿨다운·읽음 전이를 도메인 규칙과 명명된 capability로 정리합니다.
- 알림 enqueue 조건·payload·동시성 제한을 유지합니다.

## 🔒 불변 계약

- HTTP route/method/header/query/body/response/status 변경 없음
- Zod·Swagger·`@aido/validators` 공개 export 변경 없음
- ErrorCode·message·details·응답 wrapping 변경 없음
- Prisma schema·migration·기존 데이터 변경 없음
- 큐 이름·job payload·Redis key·TTL 변경 없음
- 정렬·페이지네이션·멱등성·부수효과 발생 조건 변경 없음
- OpenAPI snapshot과 배포 클라이언트 fingerprint 갱신 없음

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm lint
pnpm build
pnpm --filter @aido/api lint:arch
pnpm --filter @aido/api test
```

### 테스트 결과

- [x] 타입 체크·린트·빌드 통과
- [x] 해당 모듈 단위 테스트 통과
- [x] 아키텍처·불변 계약 게이트 통과
- [x] 스택 최종 기준 전체 unit 361 suites / 2,598 tests 통과
- [x] 스택 최종 기준 integration 36 suites / 364 tests 통과
- [x] 스택 최종 기준 E2E 및 OpenAPI snapshots 통과
- [ ] 수동 운영 검증 — 배포 PR에서 수행

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다
- [x] Clean Architecture 의존성 방향을 준수합니다
- [x] 변경사항에 대한 테스트를 작성/수정했습니다
- [x] typecheck·lint·build 및 관련 테스트가 통과합니다
- [x] 필요한 아키텍처 문서를 업데이트했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨을 `type: refactor`, `scope: api`와 리뷰 상태로 정리했습니다

### 리뷰어 확인

- [ ] 계층 경계와 유비쿼터스 언어가 적절합니다
- [ ] 상태 전이·트랜잭션·커밋 후 부수효과가 기존과 같습니다
- [ ] 캐시·큐·멱등성·동시성 계약에 회귀가 없습니다
- [ ] 공개 API·오류·DB 계약에 변경이 없습니다

## 🔗 Stack 위치

- Stack: #746
- 이전 PR: #731
- 다음 PR: #733
- 병합 순서: #722부터 번호 순서대로

## 📸 스크린샷

UI 변경 없음 — 서버 내부 구조 리팩토링입니다.

## 💬 추가 정보

최종 스택에서 architecture baseline은 layer import 0, aggregate naming 0, internal barrel export 0, dependency violation 0, cast 0입니다.