### PR TITLE
docs(api): 서버 아키텍처 가이드를 AI 친화적으로 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ tooling/*           공유 설정 (biome, jest, vitest, typescript)
 
 | 하려는 일 | 읽을 문서 |
 |-----------|-----------|
-| API 기능 추가 (클린아키텍처 use-case 표준 — 전 모듈, 참조 구현: todo) | [`apps/api/AGENTS.md`](apps/api/AGENTS.md) → [`apps/api/.claude/architecture.md`](apps/api/.claude/architecture.md) |
+| API 기능 추가 (실용형 DDD·Clean Architecture, 참조 구현: todo) | [`apps/api/AGENTS.md`](apps/api/AGENTS.md) → [`apps/api/.claude/architecture.md`](apps/api/.claude/architecture.md) → [`apps/api/.claude/api-conventions.md`](apps/api/.claude/api-conventions.md) |
 | Mobile 기능 추가 (Feature-based) | [`apps/mobile/AGENTS.md`](apps/mobile/AGENTS.md) → [`apps/mobile/.claude/architecture.md`](apps/mobile/.claude/architecture.md) |
 | Zod 스키마 / DTO 추가 | [`apps/api/.claude/validators.md`](apps/api/.claude/validators.md) |
 | Prisma 스키마 변경 | [`apps/api/.claude/prisma.md`](apps/api/.claude/prisma.md) |

--- a/apps/api/.claude/api-conventions.md
+++ b/apps/api/.claude/api-conventions.md
@@ -1,760 +1,270 @@
-# API 코드 규칙
+# API Code Conventions
 
-**Version**: 2.0.0 · **Last Updated**: 2026-08-14 · **Owner**: Aido Platform Team
+> Version 3.0.0 · Updated 2026-08-14 · Owner: Aido Platform Team
 
-> Controller, DTO/Swagger, Module 계층별 코드 작성 규칙
->
-> ✅ **적용 범위**: 신규·전환 코드는 §9의 실용형 DDD·Clean Architecture 표준을 따른다. Controller/DTO/Swagger 공통 계약은 유지한다. 단순 위임 Facade와 §3 Service·§4 Repository 패턴은 전환 중인 기존 코드 설명이다.
+이 문서는 신규·수정 코드의 작성 규칙이다. 구조적 이유는 [architecture.md](./architecture.md), DTO는 [validators.md](./validators.md), DB는 [prisma.md](./prisma.md), 테스트는 [testing-guide.md](./testing-guide.md)를 따른다.
 
-## 관련 문서
+## 1. 기본 원칙
 
-| 문서 | 설명 |
-|------|------|
-| [AGENTS.md](../AGENTS.md) | API 앱 진입점 (기술 스택, 핵심 규칙, 문서 네비게이션) |
-| [architecture.md](./architecture.md) | 전체 아키텍처, 에러 처리, 이벤트, 보안, 공통 모듈 |
-| [validators.md](./validators.md) | @aido/validators 패키지 규칙 (Zod 스키마, NestJS DTO) |
-| [prisma.md](./prisma.md) | Prisma 7 가이드 (스키마, 마이그레이션, 트랜잭션) |
-| [unit-test.md](./unit-test.md) | 단위 테스트 가이드 (Jest, Mock) |
-| [e2e-test.md](./e2e-test.md) | E2E 테스트 가이드 (supertest, Testcontainers) |
+- 기존 모듈의 현재 패턴과 `src/todo`를 먼저 읽는다.
+- 한 클래스는 하나의 역할과 하나의 변경 이유를 가진다.
+- 전달만 하는 Facade, Service, Manager, Helper, Utils, Impl을 만들지 않는다.
+- 추상화는 교체·격리·모듈 경계 가치가 있을 때만 추가한다.
+- 공개 계약을 유지하는 리팩터링에서는 snapshot을 갱신해 회귀를 승인하지 않는다.
 
----
+## 2. 파일과 역할
 
-## 개요
+| 역할 | 위치·형식 |
+|---|---|
+| Aggregate Root | `domain/entities/<name>.aggregate.ts` |
+| 자식 Entity | `domain/entities/<name>.entity.ts` |
+| Value Object | `domain/value-objects/<name>.vo.ts` |
+| 순수 판단 | `domain/policies/<name>.policy.ts` 또는 기존 `domain/services/<specific-name>.ts` |
+| Domain event | `domain/events/<event>.event.ts` |
+| 쓰기 UseCase | `application/use-cases/<verb-object>/<verb-object>.use-case.ts` |
+| 읽기 UseCase | `application/queries/<verb-object>/<verb-object>.use-case.ts` |
+| Port | `application/ports/<capability>.<role>.port.ts` |
+| Adapter | `infrastructure/adapters/<purpose>.adapter.ts` |
+| Prisma 구현 | `infrastructure/adapters/prisma-<capability>.<role>.ts` 또는 모듈의 기존 persistence 구조 |
+| Cache keyspace | `infrastructure/cache/<context>-cache.keyspace.ts` |
+| Queue contract | `infrastructure/queue/<context>-queue.constants.ts` |
+| Queue consumer | `<purpose>.processor.ts` 또는 `<purpose>.job-handler.ts` |
+| HTTP mapper | `presentation/<purpose>.mapper.ts` |
 
-| 계층 | 역할 | 핵심 규칙 |
-|------|------|----------|
-| Controller | HTTP 요청/응답 처리 | 비즈니스 로직 금지, endpoint UseCase 직접 주입, Swagger 문서화 필수 |
-| UseCase | 비즈니스 로직 | 순수 클래스의 단일 `execute()`, `ApplicationException`/`DomainException` throw, 포트로 데이터 접근 |
-| Port/Adapter | 외부 의존 추상화 | 포트=인터페이스+Symbol, 어댑터가 구현(Prisma·벤더·큐) |
-| Repository | 데이터 액세스 | 포트 구현, CLS(`TransactionHost.tx`)에서 활성 TX 읽음 |
-| Module | 의존성 주입 | 모듈 경계 정의, `app.module.ts`에 등록 |
+역할 접미사:
 
-> 상세 규칙은 **§9**. 아래 §1~§8은 공통(Controller/DTO/Swagger/Module) + 역사적 참고(§3·§4)다.
+- 상태 저장: `Repository`
+- 조회: `Reader`
+- 임시 상태: `Store`
+- 외부 API/SDK: `Client`
+- 발송: `Sender`
+- append-only 기록: `Recorder`
+- 이벤트 발행: `Publisher`
+- 경계 변환: `Adapter`
+- 순수 판단: `Policy`
+- 복수 정보 해석: `Resolver`
+- 구현 선택: `Registry`
+- 큐 소비: `JobHandler` 또는 기존 Nest 관례의 `Processor`
 
----
+## 3. Controller
 
-## 1. 디렉토리 구조
+Controller는 HTTP 경계다.
 
-**전 모듈 표준 = 클린아키텍처 4계층** (참조 구현: todo). 상세는 **§9**.
+해야 하는 일:
 
-```
-src/{name}/
-├── {name}.module.ts                 # DI 와이어링 (배럴 use-case 배열 등록)
-├── index.ts                         # 공개 배럴 (Facade + DTO — 외부는 이것만 임포트)
-├── domain/
-│   ├── entities/{name}.entity.ts    # AggregateRoot (private ctor + reconstitute + planCreation)
-│   ├── value-objects/*.vo.ts        # 값 객체 (불변식 = DomainException)
-│   ├── events/*.event.ts            # 도메인 이벤트
-│   └── services/*.ts                # 순수 도메인 정책
-├── application/
-│   ├── facades/{name}.facade.ts     # 컨트롤러의 유일 주입 대상
-│   ├── ports/*.port.ts              # 인터페이스 + Symbol 토큰
-│   ├── use-cases/<name>/<name>.use-case.ts   # 쓰기 (+ .spec)
-│   └── queries/<name>/<name>.use-case.ts     # 읽기 (+ 캐싱)
-├── infrastructure/
-│   ├── adapters/*.adapter.ts        # 포트 구현 (벤더·큐)
-│   ├── persistence/*.repository.ts  # Prisma 저장소 (포트 구현, CLS tx)
-│   ├── guards/                      # 인증/권한 가드 (필요시)
-│   ├── listeners/                   # @OnEvent 베스트에포트 리스너
-│   └── strategies/                  # Passport 전략 (auth 한정)
-└── presentation/
-    ├── dtos/*.request.dto.ts / *.response.dto.ts
-    └── {name}.controller.ts
-```
+- decorator, auth/role guard, Swagger 선언
+- `@aido/validators` DTO 수신
+- header/param/query/body를 application input으로 변환
+- endpoint UseCase 직접 호출
+- 응답 DTO 또는 mapper로 변환
 
----
+하지 않는 일:
 
-## 2. Controller 규칙
+- repository/Prisma 직접 호출
+- 상태 전이와 비즈니스 분기
+- transaction 시작
+- 외부 SDK 호출
+- 전달 전용 Facade 호출
 
-> **Why**: 얇은 진입점. 비즈니스 로직 없이 DTO 검증 + Service 위임만 담당하여 변경 지점 최소화.
-
-### 기본 구조
-
-```typescript
-import { Controller, Get, Post, Body, Param, Query, Req } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
-import { ApiDoc, ApiSuccessResponse, ApiCreatedResponse } from '@/shared/presentation/swagger';
-
-import { CurrentUser, type CurrentUserPayload } from '../auth/decorators';
-import { ExampleResponseDto } from './dtos';
-
-@ApiTags('examples')
-@ApiBearerAuth()
-@Controller('examples')
-export class ExampleController {
-  constructor(private readonly exampleService: ExampleService) {}
-
-  @Get()
-  @ApiDoc({
-    summary: '목록 조회',
-    operationId: 'findAllExamples',
-    description: `
-## 📋 예시 목록 조회
-
-페이지네이션된 예시 목록을 조회합니다.
-
-### 📝 쿼리 파라미터
-- \`page\`: 페이지 번호 (기본값: 1)
-- \`size\`: 페이지 크기 (기본값: 20, 최대: 100)
-    `,
-  })
-  @ApiSuccessResponse({ type: ExampleResponseDto, isArray: true })
-  async findAll(@Query() query: PaginationDto) {
-    return this.exampleService.findAll(query);
-  }
-}
-```
-
-### 필수 데코레이터
-
-| 데코레이터 | 용도 | 필수 여부 |
-|-----------|------|----------|
-| `@ApiTags()` | Swagger 그룹 | 필수 |
-| `@Controller()` | 라우트 경로 | 필수 |
-| `@ApiDoc()` | 엔드포인트 문서 | 필수 |
-| `@ApiBearerAuth()` | 인증 필요 표시 | 인증 필요시 |
-| `@ApiSuccessResponse()` | 성공 응답 타입 | 필수 |
-
-### Swagger description 작성법
-
-마크다운 형식으로 상세 설명:
-
-```typescript
-@ApiDoc({
-  summary: '짧은 요약 (50자 이내)',
-  description: `
-## 🎯 기능 제목
-
-기능에 대한 상세 설명
-
-### 🔐 인증 요구사항
-\`Authorization: Bearer {accessToken}\`
-
-### 📝 요청 필드
-- \`field1\`: 설명 (필수/선택)
-
-### ⚠️ 주의사항
-- 주의할 점
-
-### 🚫 에러 케이스
-- \`ERROR_CODE\`: 에러 상황 설명
-  `,
-})
-```
-
-### Request 메타데이터 추출
-
-```typescript
-private extractMetadata(req: Request): SessionMetadata {
-  return {
-    // Express trust proxy가 host-local Nginx 한 홉을 검증해 확정한 canonical IP
-    ipAddress: req.ip || 'unknown',
-    userAgent: req.headers['user-agent'] || 'unknown',
-    deviceName: req.body?.deviceName,
-    deviceType: req.body?.deviceType,
-  };
-}
-```
-
-### DO ✅
-
-- Service 메서드 호출 및 결과 반환
-- Request 메타데이터 추출 (IP, User-Agent)
-- DTO를 통한 입력 검증
-- Swagger 문서화 (`@ApiDoc`, `@ApiSuccessResponse`)
-- `@Timezone()` 데코레이터로 타임존 추출 (필요시)
-
-### DON'T ❌
-
-- 비즈니스 로직 포함
-- 직접 Repository/Prisma 호출
-- try-catch 예외 처리 (GlobalExceptionFilter가 담당)
-- 응답 형식 직접 변환 (ResponseTransformInterceptor가 담당)
-
----
-
-## 3. Service 규칙
-
-> ⚠️ **역사적 참고 (현재 미사용)** — 이관 이전 3계층의 Service 패턴이다. **신규/전 모듈은 §9의 use-case 표준**(`@Injectable` `execute()`, `ApplicationException`/`DomainException` throw, `UNIT_OF_WORK.run` CLS 트랜잭션)을 따른다. 아래는 마이그레이션 이력 이해용으로만 남긴다.
->
-> **Why(당시)**: 비즈니스 로직의 유일한 거처. 트랜잭션 경계를 관리하고, 큐 enqueue는 커밋 후 실행하여 데이터 정합성 보장.
-
-### 기본 구조
-
-```typescript
-import { Injectable, Logger } from '@nestjs/common';
-import { BusinessExceptions } from '@/shared/application/exceptions';
-import { DatabaseService } from '@/shared/application/ports';
-import { [Feature]QueueService } from '../queue';
-import { [Feature]Repository } from '../repositories';
-
-@Injectable()
-export class [Feature]Service {
-  readonly #logger = new Logger([Feature]Service.name);
-
-  constructor(
-    private readonly [feature]Repository: [Feature]Repository,
-    private readonly database: DatabaseService,  // 트랜잭션용
-    private readonly [feature]QueueService: [Feature]QueueService, // 비동기 큐 (필요시)
-  ) {}
-
-  async findById(id: string) {
-    const result = await this.[feature]Repository.findById(id);
-    if (!result) {
-      throw BusinessExceptions.[feature]NotFound(id);
-    }
-    return result;
-  }
-
-  async create(input: CreateInput) {
-    const result = await this.[feature]Repository.create(input);
-    this.#logger.log(`[Feature] created: ${result.id}`);
-
-    // 부수효과는 QueueService로 비동기 위임 (fire-and-forget)
-    this.[feature]QueueService.enqueueXxx({ ... });
-
-    return result;
-  }
-}
-```
-
-### 의존성 주입 규칙
-
-```typescript
-// DO: Repository + DatabaseService(트랜잭션용) + QueueService(비동기 큐용)
-constructor(
-  private readonly [feature]Repository: [Feature]Repository,
-  private readonly database: DatabaseService,
-  private readonly [feature]QueueService: [Feature]QueueService,
-) {}
-
-// DO: 다른 Service 주입 (교차 모듈 로직)
-constructor(
-  private readonly {other}Service: {Other}Service,
-) {}
-
-// DON'T: DatabaseService를 직접 쿼리에 사용 (Repository 통해야 함)
-```
-
-### 트랜잭션 사용
-
-다중 테이블 작업 시 반드시 트랜잭션 사용:
-
-```typescript
-async createWithRelated(input: CreateInput) {
-  return this.database.$transaction(async (tx) => {
-    const entity = await this.{feature}Repository.create(input, tx);
-    await this.{related}Repository.create({ {feature}Id: entity.id }, tx);
-    return entity;
+```ts
+@Post()
+async create(
+  @CurrentUser('id') userId: string,
+  @Body() request: CreateTodoRequestDto,
+): Promise<TodoResponseDto> {
+  return this.createTodoUseCase.execute({
+    userId,
+    title: request.title,
+    scheduledAt: request.scheduledAt,
   });
 }
 ```
 
-### 비동기 큐 enqueue
+## 4. UseCase
 
-```typescript
-async update(id: string, userId: string, data: UpdateInput) {
-  const existing = await this.[feature]Repository.findByIdAndUserId(id, userId);
-  if (!existing) {
-    throw BusinessExceptions.[feature]NotFound(id);
-  }
+- 클래스명은 `<Verb><Object>UseCase`다.
+- 공개 실행 메서드는 `execute` 하나다.
+- 입력이 있으면 단일 `XxxInput`, 없으면 무인자다.
+- 입력 속성은 재할당하지 않는 계약이므로 `readonly`를 사용한다. 지역 변수나 mutable domain state에 기계적으로 붙이지 않는다.
+- 반환 객체는 `XxxResult` 또는 실제 read model 이름을 사용한다.
+- Nest의 `@Injectable`, `@Inject`, Logger는 허용한다.
+- Prisma와 vendor 타입은 금지한다.
+- 권한, orchestration, transaction, port 호출 순서를 담당한다.
+- 상태 전이 규칙은 Aggregate/VO/Policy에 위임한다.
 
-  const updated = await this.[feature]Repository.update(id, { ... });
-
-  // 부수효과는 QueueService로 비동기 위임 (fire-and-forget)
-  if (shouldNotify) {
-    this.[feature]QueueService.enqueueXxx({
-      userId,
-      [feature]Id: updated.id,
-    });
-  }
-
-  return updated;
+```ts
+export interface UpdateTodoTitleInput {
+  readonly userId: string;
+  readonly todoId: string;
+  readonly title: string;
 }
-```
-
-### 결과 타입 정의
-
-```typescript
-// types/{name}.types.ts
-export interface {Feature}Result {
-  id: string;
-  // ... 도메인별 필드
-}
-```
-
-### 로깅 규칙
-
-```typescript
-// 중요한 비즈니스 이벤트만 로깅
-this.logger.log(`User registered: ${user.id}`);
-this.logger.log(`Password changed for user: ${userId}`);
-this.logger.warn(`Login attempt failed for: ${email}`);
-this.logger.error(`Payment failed for order: ${orderId}`, error.stack);
-```
-
-> 상세 로깅 가이드: [logging-guide.md](./logging-guide.md)
-
-### DO ✅
-
-- `BusinessExceptions.xxx()` 팩토리 메서드로 예외 발생
-- Repository를 통한 데이터 액세스
-- `database.$transaction()`으로 트랜잭션 관리
-- `[feature]QueueService.enqueueXxx()`로 비동기 부수효과 위임
-- Logger 사용한 중요 작업 로깅
-- 크론 작업에서 DB 기반 중복 방지
-
-### DON'T ❌
-
-- Repository 거치지 않고 직접 Prisma 호출
-- HTTP 관련 코드 (`@Res()`, 상태코드 설정)
-- Controller 로직 포함 (요청 파싱 등)
-- `new HttpException()` 직접 사용 (BusinessExceptions 사용)
-- 크론 작업에서 in-memory Set/Map으로 상태 관리 (서버 재시작 시 유실)
-
----
-
-## 4. Repository 규칙
-
-> ⚠️ **역사적 참고 (현재 미사용)** — 이관 이전의 `tx?` 파라미터 Repository 패턴이다. **전 모듈은 §9처럼** 저장소를 포트로 두고 어댑터가 CLS(`TransactionHost.tx`)에서 활성 TX를 읽는다(무인자). 아래는 이력용.
->
-> **Why(당시)**: DB 접근의 유일한 지점. `tx?` 파라미터로 트랜잭션 참여를 선택적으로 허용하여 Service가 트랜잭션을 제어.
-
-### 기본 구조
-
-```typescript
-import { Injectable } from '@nestjs/common';
-import { DatabaseService, type TransactionClient } from '@/shared/application/ports';
 
 @Injectable()
-export class [Feature]Repository {
-  constructor(private readonly database: DatabaseService) {}
-
-  async findById(
-    id: string,
-    tx?: TransactionClient,
-  ): Promise<Example | null> {
-    const client = tx ?? this.database;
-    return client.example.findUnique({ where: { id } });
-  }
-
-  async create(
-    data: Prisma.ExampleUncheckedCreateInput,
-    tx?: TransactionClient,
-  ): Promise<Example> {
-    const client = tx ?? this.database;
-    return client.example.create({ data });
-  }
-
-  async update(
-    id: string,
-    data: Prisma.ExampleUncheckedUpdateInput,
-    tx?: TransactionClient,
-  ): Promise<Example> {
-    const client = tx ?? this.database;
-    return client.example.update({ where: { id }, data });
-  }
-
-  async delete(
-    id: string,
-    tx?: TransactionClient,
-  ): Promise<void> {
-    const client = tx ?? this.database;
-    await client.example.delete({ where: { id } });
-  }
-}
-```
-
-### 트랜잭션 클라이언트 패턴
-
-모든 메서드에 옵셔널 트랜잭션 클라이언트 지원:
-
-```typescript
-async someMethod(
-  param: string,
-  tx?: TransactionClient,  // 항상 마지막 파라미터
-): Promise<Result> {
-  const client = tx ?? this.database;  // 트랜잭션 또는 기본 클라이언트
-  return client.model.findUnique({ ... });
-}
-```
-
-### 복잡한 쿼리 (페이지네이션)
-
-```typescript
-async findAllWithPagination(params: {
-  skip: number;
-  take: number;
-  where?: Prisma.ExampleWhereInput;
-}) {
-  const [items, total] = await this.database.$transaction([
-    this.database.example.findMany({
-      skip: params.skip,
-      take: params.take,
-      where: params.where,
-      orderBy: { createdAt: 'desc' },
-    }),
-    this.database.example.count({ where: params.where }),
-  ]);
-  return { items, total };
-}
-```
-
-### 관계 포함 조회
-
-```typescript
-async findByIdWithRelations(id: string): Promise<{Feature}WithRelations | null> {
-  return this.database.{feature}.findUnique({
-    where: { id },
-    include: {
-      relatedEntity: true,
-      otherEntity: { select: { field: true } },
-    },
-  });
-}
-```
-
-### 민감 데이터 암호화
-
-OAuth 토큰 등 민감 데이터를 DB에 저장할 때 EncryptionService 사용:
-
-```typescript
-@Injectable()
-export class {Feature}Repository {
+export class UpdateTodoTitleUseCase {
   constructor(
-    private readonly database: DatabaseService,
-    private readonly encryptionService: EncryptionService,
+    @Inject(TODO_REPOSITORY)
+    private readonly todoRepository: TodoRepositoryPort,
+    @Inject(UNIT_OF_WORK)
+    private readonly unitOfWork: UnitOfWorkPort,
   ) {}
 
-  async createOAuthAccount(data: CreateOAuthData): Promise<Account> {
-    return this.database.account.create({
-      data: {
-        ...data,
-        accessToken: data.accessToken
-          ? this.encryptionService.encrypt(data.accessToken) : null,
-        refreshToken: data.refreshToken
-          ? this.encryptionService.encrypt(data.refreshToken) : null,
-      },
+  async execute(input: UpdateTodoTitleInput): Promise<TodoResponse> {
+    return this.unitOfWork.run(async () => {
+      const todo = await this.todoRepository.findOwnedById(input.todoId, input.userId);
+      todo.changeTitle(input.title);
+      await this.todoRepository.updateTitle(todo);
+      return this.todoRepository.findResponseById(input.todoId, input.userId);
     });
   }
 }
 ```
 
-복호화 시 `decryptSafe()` 사용 (평문 fallback 지원):
+실제 repository 메서드명과 반환 타입은 해당 모듈을 따른다. 예제의 이름을 존재 확인 없이 복사하지 않는다.
 
-```typescript
-const token = this.encryptionService.decryptSafe(account.accessToken);
+## 5. Partial update
+
+`patch.completed !== undefined` 자체는 잘못이 아니지만 여러 필드에 반복하면 의도가 흐려진다. 입력 presence와 도메인 행동을 명시적으로 분리한다.
+
+```ts
+if (patch.completed !== undefined) {
+  todo.changeCompletion(patch.completed);
+}
 ```
 
-### DO ✅
+필드가 많으면 순수 presence 함수 또는 mapper로 정리하되 truthy 검사로 바꾸지 않는다. `false`, `0`, 빈 문자열이 유효한 값일 수 있기 때문이다.
 
-- DatabaseService 주입하여 Prisma 사용
-- 타입이 명확한 반환값 정의
-- 단일 엔티티 책임 (단일 엔티티 → {Feature}Repository)
-- 모든 메서드에 `tx?: Prisma.TransactionClient` 지원
-- 민감 데이터는 EncryptionService로 암호화하여 저장
+```ts
+const hasValue = <T>(value: T | undefined): value is T => value !== undefined;
 
-### DON'T ❌
-
-- 예외 발생 (Service에서 담당)
-- 비즈니스 로직 포함
-- 다른 Repository 직접 호출
-- 데이터 변환 로직 포함
-- 민감 토큰을 평문으로 DB에 저장
-
----
-
-## 5. Module 구성
-
-### 기본 구조
-
-```typescript
-import { Module } from '@nestjs/common';
-import { ExampleController } from './example.controller';
-import { ExampleService } from './services';
-import { ExampleRepository } from './repositories';
-
-@Module({
-  controllers: [ExampleController],
-  providers: [
-    ExampleService,
-    ExampleRepository,
-  ],
-  exports: [ExampleService], // 다른 모듈에서 사용 시
-})
-export class ExampleModule {}
+if (hasValue(patch.completed)) {
+  todo.changeCompletion(patch.completed);
+}
 ```
 
-### 다른 모듈 의존성
+도메인 상태 변경은 `Object.assign`이나 범용 patch 메서드보다 명명된 행동을 우선한다. DB에는 실제 영향 필드만 저장할 수 있다.
 
-```typescript
-import { Module } from '@nestjs/common';
-import { {Other}Module } from '../{other}';
+## 6. Domain
 
-@Module({
-  imports: [{Other}Module], // {Other}Service 사용 가능
-  controllers: [{Feature}Controller],
-  providers: [{Feature}Service, {Feature}Repository],
-})
-export class {Feature}Module {}
+- constructor는 외부에서 직접 호출하지 않는다.
+- 생성과 복원을 구분한다.
+- 원시값은 VO로 변환한 뒤 Aggregate 상태로 유지한다.
+- getter가 `Date`나 mutable collection을 그대로 노출하지 않게 한다.
+- boolean은 `is/has/can/should`, 시각은 `*At`, 기간은 `*Ms/*Seconds/*Minutes`를 사용한다.
+- vendor의 enum/필드명은 presentation 또는 infrastructure mapper 안에서만 유지한다.
+- 주석은 코드 동작이 아니라 결정 이유, transaction 이유, 호환성 이유를 설명한다.
+
+Aggregate가 필요하지 않은 경우:
+
+- 단순 조회 projection
+- 통계와 report read model
+- 상태 없는 formatter/mapper
+- 집합 단위 batch/claim/counter
+
+## 7. Port와 Adapter
+
+Port는 application의 언어로 정의한다.
+
+```ts
+export const AI_TEXT_GENERATOR = Symbol('AI_TEXT_GENERATOR');
+
+export interface AiTextGeneratorPort {
+  generateTodo(input: GenerateTodoTextInput): Promise<GeneratedTodoText>;
+}
 ```
 
-> `@Global()` 모듈 (DatabaseModule, EncryptionModule, CacheModule 등)은 `imports` 없이 바로 주입 가능.
+나쁜 예:
 
----
+- vendor SDK 메서드와 타입을 그대로 복사한 Port
+- 한 concrete class를 감싸기만 하는 Port
+- `ServicePort`, `ManagerPort`처럼 capability가 드러나지 않는 이름
+- 같은 DB 모듈 내부 호출마다 추가한 인터페이스
 
-## 6. Import 별칭
+Adapter는 변환과 외부 I/O를 담당하며 비즈니스 규칙을 만들지 않는다. vendor 교체는 Adapter와 module binding에서 끝나야 한다.
 
-```typescript
-// @/shared/* — 공유 커널 (tsconfig paths: "@/*" → "src/*")
-import { DatabaseService } from '@/shared/application/ports';
-import { ApiDoc, ApiSuccessResponse } from '@/shared/presentation/swagger';
-import { BusinessExceptions } from '@/shared/application/exceptions';
-import { PaginationService } from '@/shared/application/pagination';
-import { EncryptionService } from '@/shared/infrastructure/encryption';
-import { TypedConfigService } from '@/shared/infrastructure/config';
-import { getUserToday, toScheduledTime } from '@/shared/domain/date';
-import { Timezone } from '@/shared/presentation/decorators';
+## 8. Repository와 Transaction
 
-// Auth 데코레이터 — auth 모듈에서 import
-import { CurrentUser, type CurrentUserPayload } from '../auth/decorators';
+- 영속 상태 변경은 `Repository`, 읽기 projection은 `Reader`로 구분한다.
+- repository는 Prisma row와 domain/read model 사이를 매핑한다.
+- UseCase에 Prisma model 또는 transaction client를 반환하지 않는다.
+- 활성 transaction은 CLS에서 읽는다. `transaction`, `tx`를 계층마다 전달하지 않는다.
+- unique/foreign-key 오류는 기존 canonical error mapping을 유지한다.
+- 회원가입 기본 카테고리처럼 특정 업무를 수행하는 클래스는 `DefaultTodoCategorySeeder`처럼 업무 이름을 사용한다. 내부에서 repository를 사용해 같은 UoW에 참여하는 것은 허용한다.
 
-// @aido/validators — 공유 스키마 패키지
-import { LoginInput, LoginResponse } from '@aido/validators';
+## 9. Domain event와 Queue
 
-// 모듈 내부 — 상대 경로
-import { {Feature}Repository } from '../repositories';
-import { {Feature}Service } from './{feature}.service';
-```
+- domain event는 이미 발생한 사실을 과거형으로 명명한다.
+- Aggregate가 event를 적립하고 UseCase가 성공한 commit 뒤 발행한다.
+- 같은 transaction 안에서 반드시 성공해야 하는 핵심 저장을 비동기 event로 넘기지 않는다.
+- queue payload는 producer/consumer가 공유하는 schema로 검증한다.
+- queue/job/key 문자열과 retry/concurrency 숫자는 이름 있는 상수로 관리한다.
+- processor는 payload 검증, UseCase 호출, 재시도 가능한 오류의 로깅에 집중한다.
 
----
+## 10. Cache
 
-## 7. 새 모듈 추가 체크리스트
+- cache key와 TTL은 컨텍스트별 keyspace 파일이 소유한다.
+- application에는 `getTodoSummary`, `invalidateUserTodos` 같은 의미 기반 메서드를 노출한다.
+- raw key 조립, wildcard pattern, Redis command는 infrastructure에 둔다.
+- 쓰기 성공 후 필요한 범위만 무효화한다.
+- 필터 조합이 많고 변경이 잦은 데이터는 캐시를 기본 선택으로 보지 않는다.
 
-### 1. Prisma 스키마
+## 11. Module과 public API
 
-- [ ] `prisma/schema.prisma`에 모델 추가
-- [ ] `pnpm db:migrate` 실행
+- Module이 UseCase와 `Port → Adapter` binding을 명시적으로 등록한다.
+- provider 배열은 반복 등록을 줄일 때만 사용하며 `todo-use-case.providers.ts` 같은 별도 파일을 기본 규칙으로 만들지 않는다.
+- 공개 `index.ts`는 타 모듈이 실제로 소비하는 capability, event contract, DTO만 export한다.
+- UseCase, concrete repository, queue 구현, test helper는 공개하지 않는다.
+- 순환 의존을 `forwardRef`로 덮기 전에 capability 방향을 재검토한다.
 
-### 2. @aido/validators
+## 12. Error와 logging
 
-- [ ] Request/Response 스키마 추가 ([validators.md](./validators.md) 참고)
-- [ ] NestJS DTO 추가
-- [ ] `pnpm build` 실행
+- Domain invariant: `DomainException`
+- Application rule: `ApplicationException`
+- Public code: `ErrorCode`
+- 비즈니스 코드에서 `HttpException`과 임의 문자열 code를 만들지 않는다.
+- log context에는 module/use-case/job과 안정적인 식별자를 포함한다.
+- token, password, authorization code, 원문 개인정보와 전체 vendor payload는 기록하지 않는다.
 
-### 3. API 모듈 (클린아키텍처 — 상세는 §9)
+## 13. Test
 
-- [ ] `domain/` 애그리게잇·VO·도메인 서비스·이벤트 (불변식은 DomainException)
-- [ ] `application/ports/*.port.ts` (인터페이스 + Symbol 토큰)
-- [ ] `application/use-cases/<name>/<name>.use-case.ts` (쓰기) · `queries/<name>/<name>.use-case.ts` (읽기)
-- [ ] `application/facades/{name}.facade.ts` (컨트롤러의 유일 주입 대상)
-- [ ] `infrastructure/adapters`·`persistence` (포트 구현, Prisma·벤더·큐)
-- [ ] `presentation/{name}.controller.ts` (Facade 주입, Swagger) + `presentation/dtos`
-- [ ] `{name}.module.ts` (use-case 배럴 등록) + `index.ts` (Facade·DTO 공개)
+- Aggregate/VO/Policy: 프레임워크 없는 단위 테스트
+- UseCase: `@suites/unit`의 `TestBed.solitary` 또는 명시적 fake/mock
+- Module wiring/decorator/guard: Nest testing module
+- Repository/UoW/concurrency: 실제 PostgreSQL 통합 테스트
+- HTTP/error/OpenAPI: E2E
 
-### 4. 등록
+TestBed는 금지 대상이 아니다. domain 테스트에 Nest container를 불필요하게 올리지 않고, UseCase DI 자동 mock에 선택적으로 사용한다.
 
-- [ ] `app.module.ts`에 모듈 import 추가
+## 14. 신규·수정 체크리스트
 
-### 5. 에러 처리
-
-- [ ] `@aido/errors`에 `ErrorCode` 추가 → use-case/도메인에서 `ApplicationException`/`DomainException`으로 throw
-- [ ] 새 Unique Constraint가 있으면 `GlobalExceptionFilter`의 constraintMap에 매핑 추가
-
-### 6. 테스트
-
-- [ ] use-case / 애그리게잇 / VO 단위 테스트
-- [ ] 통합 테스트 (실 저장소 + 어댑터)
-- [ ] E2E 테스트 (openapi 스냅샷 diff 0 확인) + `lint:no-cast`·`lint:boundaries`
-
----
-
-## 8. 개발 환경 설정
-
-### Docker 실행 (필수)
-
-API 개발 및 테스트를 위해 **반드시 Docker가 실행 중이어야** 합니다.
+1. 공개 HTTP/Zod/error/DB/queue/cache 계약의 변경 여부를 먼저 확인한다.
+2. 상태 전이와 invariant가 있으면 기존 Aggregate에 행동을 추가한다.
+3. endpoint orchestration은 하나의 UseCase `execute(input)`에 둔다.
+4. 외부 기술 또는 cross-context capability가 있을 때만 Port를 정의한다.
+5. Adapter에서 Prisma/vendor/Redis/BullMQ 타입을 변환한다.
+6. Controller에서 DTO를 input으로 변환하고 UseCase를 직접 호출한다.
+7. Module binding과 최소 public export를 추가한다.
+8. unit → integration → E2E → architecture/contract 순으로 위험에 비례해 검증한다.
 
 ```bash
-# PostgreSQL 컨테이너 시작 (프로젝트 루트에서)
-pnpm docker:up
-
-# 컨테이너 상태 확인
-docker ps
-
-# 컨테이너 중지
-pnpm docker:down
+pnpm typecheck
+pnpm lint
+pnpm --filter @aido/api lint:arch
 ```
 
-### 환경 변수 파일
+## 15. 금지 검색어 점검
 
-| 파일 | 용도 | Git |
-|------|------|-----|
-| `.env` | 프로덕션 | 절대 커밋 금지 |
-| `.env.development` | 개발 | 커밋 가능 |
-| `.env.example` | 템플릿 | 커밋 가능 |
-| `.env.test` | 테스트 | 커밋 가능 |
+신규 코드에서 아래 항목을 발견하면 역할과 경계를 다시 검토한다.
 
-#### 환경 변수 로드 우선순위
-
-1. `NODE_ENV=development` → `.env.development`
-2. `NODE_ENV=production` → `.env`
-3. `NODE_ENV=test` → `.env.test`
-
-#### 새 환경 변수 추가 시
-
-1. `.env.example`에 변수 추가 (예시 값)
-2. `.env.development`에 실제 개발 값 추가
-3. `src/shared/infrastructure/config/schemas/`에 Zod 검증 스키마 추가
-
-### 필수 환경변수
-
-| 변수 | 설명 | 비고 |
-|------|------|------|
-| `TOKEN_ENCRYPTION_KEY` | AES-256-GCM 암호화 키 | 최소 32자 |
-| `JWT_SECRET` | JWT 서명 키 | |
-| `DATABASE_URL` | PostgreSQL 연결 문자열 | |
-
-### 개발 시작 전 체크리스트
-
-1. [ ] Docker Desktop 실행 확인
-2. [ ] `pnpm docker:up`으로 PostgreSQL 컨테이너 시작
-3. [ ] `.env.development` 파일 존재 확인
-4. [ ] `pnpm db:migrate`로 DB 마이그레이션 적용
-5. [ ] `pnpm dev`로 개발 서버 시작
-
----
-
-## 9. 실용형 DDD·Clean Architecture 모듈 규칙
-
-> **최종 표준** (참조 구현: todo). 모듈별 stacked PR로 전환하며 기존 위반은 exact baseline으로만 격리한다.
-> **@nestjs/cqrs 사용 금지** — UseCase는 `@Injectable` 클래스이고 포트는 `@Inject(Symbol)`로 주입한다. domain만 순수 TypeScript로 유지한다.
-
-전환 완료 코드의 필수 조건:
-
-- Controller → endpoint UseCase 직접 주입. Facade 금지.
-- domain → `@nestjs/*`, Prisma, infrastructure, presentation import 금지.
-- application → Prisma, vendor SDK, infrastructure, presentation import 금지. Nest DI와 Logger는 허용.
-- 쓰기는 `application/use-cases/`, 읽기는 `application/queries/`에 둔다.
-- 입력은 하나의 `readonly XxxInput`, 무입력은 무인자. 반환 객체는 `XxxResult`로 명명.
-- `repo`, `svc`, `ctx`, `tx`, `res`, `req`, `impl`, `idem`과 단독 `data`, `result`, `repository`, `effects`, `service` 금지.
-- Aggregate는 `.aggregate.ts`, 일반 Entity는 `.entity.ts`; 판단 규칙은 `domain/policies/*.policy.ts`.
-- 역할 접미사는 `Repository`, `Reader`, `Store`, `Client`, `Sender`, `Recorder`, `Publisher`, `Adapter`, `Policy`, `Resolver`, `Registry`, `JobHandler` 중 실제 책임에 맞게 사용.
-- Controller/infrastructure mapper만 Zod DTO와 원시 ID를 경계 타입으로 변환.
-- cross-module 호출은 consumer-owned capability port/access module만 사용. UseCase나 구현체 직접 호출 금지.
-- 단건 전이는 Aggregate, 다중 행 batch SQL·atomic claim/counter는 명시적 예외.
-
-### 디렉터리 구조
-
-```
-modules/{name}/
-  domain/
-    entities/{name}.entity.ts        # AggregateRoot 상속, private ctor + reconstitute + planCreation
-    entities/{child}.entity.ts       # 자식 엔티티 (Entity 상속 — 예: todo-item)
-    events/*.event.ts                # plain readonly-param 클래스 (과거형 사실, 전이 후 상태를 실음)
-    events/{name}-event-names.ts     # eventName 라우팅 키 상수 (예: TODO_EVENTS.CREATED = "todo.created")
-    value-objects/*.vo.ts            # EntityId/ValueObject 상속, static create 검증 + reconstitute 무검증
-    services/*.ts                    # 순수 도메인 정책 함수 (예: completion-policy, reorder-position)
-  application/
-    ports/*.port.ts                  # Symbol 토큰 + 인터페이스 (파일당 1포트, 페이로드 계약 소유)
-    types.ts                         # 애플리케이션 파라미터 타입 (프레임워크·Prisma 무의존)
-    facades/{name}.facade.ts         # 컨트롤러가 주입하는 유일한 지점 — use-case 한 줄 위임
-    use-cases/<kebab>/               # 쓰기 use-case 1개 = 엔드포인트 1개 (SRP)
-      <kebab>.use-case.ts / .use-case.spec.ts
-    queries/<kebab>/                 # 읽기 use-case — 쓰기와 대칭 (read/write 저장소 분리와 미러링)
-      <kebab>.use-case.ts / .use-case.spec.ts
-    events/*.handler.ts              # @OnEvent 부수효과 구독자
-  infrastructure/
-    adapters/*.ts                    # 포트 구현 — persistence DAO/타 모듈 Facade에 위임(쿼리 중복 금지)
-    persistence/                     # 행 DAO({name}-row.repository) · 응답 매퍼 · Prisma 행 타입
-  presentation/                      # {name}.controller.ts · dtos/
+```text
+application/facades
+*Facade
+*Manager
+*Helper
+*Utils
+*Impl
+deep import of another module
+Prisma type in application/domain
+shared CacheKeys in application
 ```
 
-**배럴 규칙:**
-
-- `use-cases/index.ts`는 `XxxUseCases` 배열, `queries/index.ts`는 `XxxQueryUseCases` 배열을 export — 모듈 providers에 스프레드로 등록
-- 공개 배럴(`src/{name}/index.ts`)은 **Facade(+DTO)만** export — use-case·포트·리포지토리는 내부 구현으로 비공개. 예외: 타 모듈이 `@OnEvent`로 구독하는 도메인 이벤트 클래스·이벤트명 상수는 배럴에 export (예: todo의 `TODO_EVENTS`)
-
-### Use-case 규칙
-
-| 규칙 | 내용 |
-|------|------|
-| 클래스 | plain `@Injectable()` `XxxUseCase` — 단일 `async execute(input: XxxInput): Promise<R>` 메서드, 반환 타입 명시 필수 |
-| 입력 타입 | `XxxInput` 인터페이스를 같은 파일에서 export (또는 `application/types.ts` 타입의 별칭) — 커맨드/쿼리 클래스 없음 |
-| 예외 | `ApplicationException(ErrorCode.XXX, context)` — 유스케이스 규칙 위반. 도메인 불변식은 `DomainException` |
-| 트랜잭션 | `@Inject(UNIT_OF_WORK)` → `uow.run(async () => ...)` — 콜백 무인자, 리포지토리가 CLS(AsyncLocalStorage)에서 활성 TX를 직접 읽는다 (전파 Required). load→mutate→write를 TX 안에 묶는다. `database.$transaction` 직접 호출 금지 |
-| 부수효과 | 도메인 이벤트로 — 애그리게잇 `raise()` 적립 → TX 안에서 영속화 + `pullDomainEvents()` 드레인 → **run resolve 후** `await DOMAIN_EVENT_PUBLISHER.publishAll(events)` (커밋 후 `@OnEvent` 구독자가 처리) |
-| 캐시 무효화 | 영속화 후 use-case에서 명시적 호출 (`TodoCachePort` 등 캐시 포트) — 도메인 이벤트가 없는 쓰기 경로 포함. 또는 `@OnEvent` 구독으로 처리 |
-| 응답 | 애그리게잇에서 직접 만들지 않는다 — 항상 read 포트(`~ReadRepositoryPort`) 재조회 |
-| 이벤트 발행 | 발행은 반드시 커밋 후(`run` 콜백 밖) `await`. 퍼블리셔가 EventEmitter2 `emitAsync`를 이벤트 단위로 await하고 비동기 실패를 기록·격리한다 (도메인·애플리케이션은 EventEmitter2 무의존, 포트만 의존) |
-| 크로스 모듈 | 타 모듈 구체 클래스 import 금지 — 포트 + 어댑터로 역전, 어댑터는 타 모듈 배럴의 **Facade**에 위임 (예: memo의 `TODO_CREATOR` 포트 → `TodoCreatorAdapter` → `TodoFacade`) |
-| 타입 | `as`/`!` 금지(`as`: `pnpm lint:no-cast` · `!`: Biome), 임포트 경계는 `pnpm lint:boundaries`(dependency-cruiser) — CI `lint:arch` 게이트 |
-| 가독성 | JSDoc에 흐름 요약, `execute()` 본문은 번호 주석으로 위→아래 단일 경로 |
-
-**작성 예시** (todo `create-todo` — 골격):
-
-```typescript
-// application/use-cases/create-todo/create-todo.use-case.ts
-export interface CreateTodoInput {
-  userId: string;
-  data: CreateTodoData; // application/types.ts
-  timezone: string;
-}
-
-@Injectable()
-export class CreateTodoUseCase {
-  constructor(
-    @Inject(TODO_REPOSITORY) private readonly todoRepository: TodoRepositoryPort,
-    @Inject(TODO_READ_REPOSITORY) private readonly todoReadRepository: TodoReadRepositoryPort,
-    @Inject(UNIT_OF_WORK) private readonly uow: UnitOfWorkPort,
-    @Inject(DOMAIN_EVENT_PUBLISHER) private readonly eventPublisher: DomainEventPublisherPort,
-  ) {}
-
-  async execute(input: CreateTodoInput): Promise<TodoResponse> {
-    // 1. 도메인 생성 계획 (birth 불변식·기본값 — Todo.planCreation)
-    // 2. TX: 영속화 + 이벤트 드레인 (콜백 무인자 — 리포지토리가 CLS에서 TX를 읽음)
-    const { todoId, events } = await this.uow.run(async () => {
-      /* 저장 → todo.pullDomainEvents() 반환 */
-    });
-    // 3. 커밋 후 도메인 이벤트 발행 (비동기 구독자 완료·실패 관측, 실패는 publisher가 격리)
-    await this.eventPublisher.publishAll(events);
-    // 4. 응답은 read 포트 재조회
-    return this.todoReadRepository.findByIdOrThrow(todoId, input.userId);
-  }
-}
-```
-
-### Facade 규칙
-
-- 위치: `application/facades/{name}.facade.ts` — **컨트롤러(및 타 모듈 어댑터)가 주입하는 유일한 지점**
-- use-case들을 생성자 주입하고 메서드마다 **한 줄 위임** (`return this.createTodoUseCase.execute(input);`) — 로직·분기 금지
-- Facade의 공개 시그니처가 모듈의 공개 계약 — 시그니처 변경은 계약 변경으로 취급
-- 공개 배럴(`src/{name}/index.ts`)은 Facade(+DTO)만 export (+구독용 도메인 이벤트 — 위 배럴 규칙 참조)
-
-### 컨트롤러 규칙 (클린아키텍처 전환분)
-
-- **Facade만 주입** — use-case/리포지토리 직접 주입 금지
-- DTO → Input 매핑과 날짜/타임존 파싱(`parseDateOnly`, `parseLocalDateTime`)은 컨트롤러 책임
-- Swagger 데코레이터는 마이그레이션 중 **절대 변경 금지** (openapi-contract 스냅샷이 게이트)
-
-### 도메인 이벤트 구독 규칙
-
-- 위치: `application/events/*.handler.ts` — `@Injectable()` 클래스 + `@OnEvent(TODO_EVENTS.CREATED)` 등 이벤트명 상수로 구독
-- 실패 전파가 필요한 핸들러는 `@OnEvent(..., { suppressErrors: false })` + `async`로 rejection을 퍼블리셔까지 보존한다. 퍼블리셔가 비동기 실패를 한 번 기록·격리해 다른 이벤트·이미 커밋된 요청에 전파하지 않는다
-- 이는 durable retry 보장이 아니다. 유실 불가 부수효과는 별도 내구성 큐/아웃박스를 사용한다
-- 판단 규칙(마일스톤·전체완료 등)은 `domain/services/` 정책 함수 호출 — 구독자에 도메인 로직 상주 금지
-
-### 도메인 규칙
-
-- 애그리게잇: `private constructor` + `static reconstitute(props)`. 행동 메서드에서만 상태 전이 + `raise(event)` (이벤트는 전이 후 **사실**을 실음 — 명령 에코 금지)
-- 생성 불변식·기본값은 `static planCreation(input)` 단일 지점 — autoincrement id 제약으로 `create()` 팩토리 대신 계획 패턴 (엔티티 JSDoc 참조)
-- props는 가능하면 VO로 저장 (예: `schedule: TodoSchedule`) — 불변식이 타입 수준에서 유지
-- 자식 엔티티(예: TodoItem)의 불변식(개수 한도·존재·제목)은 애그리게잇 행동 메서드가 소유 — 핸들러의 직접 검증 금지
-- 판단 규칙(마일스톤·전체완료·재정렬 계산 등)은 `domain/services/`의 순수 정책 함수로 — 이벤트 핸들러에 상주 금지
-- VO: `static create()` 검증(위반 시 `DomainException`) + `static reconstitute()` 무검증 복원(DB 전용)
-- Zod는 경계 검증, 도메인 불변식은 자기방어 — 역할이 다르므로 중복이 아니다
-
----
-
-**문서 버전**: 3.2.0
-**최종 수정일**: 2026-07-11
+이름만으로 실패시키지 말고 실제 책임을 확인한다. 외부 라이브러리 고유명과 기존 호환 API는 예외일 수 있다.

--- a/apps/api/.claude/architecture.md
+++ b/apps/api/.claude/architecture.md
@@ -1,1415 +1,213 @@
-# API 아키텍처 가이드
+# API Architecture
 
-**Version**: 5.0.0 · **Last Updated**: 2026-08-14 · **Owner**: Aido Platform Team
+> Version 6.0.0 · Updated 2026-08-14 · Owner: Aido Platform Team
 
-> NestJS 기반 백엔드 API의 전체 아키텍처 · 에러 처리 · BullMQ 큐 · 보안 · 공통 모듈
+이 문서는 Aido API의 구조적 결정만 설명한다. 코드 작성 형식은 [api-conventions.md](./api-conventions.md), 저장소와 트랜잭션은 [prisma.md](./prisma.md), 테스트는 [testing-guide.md](./testing-guide.md)를 따른다.
 
-## 관련 문서
+## 1. 목표와 비목표
 
-| 문서 | 내용 |
-|------|------|
-| [AGENTS.md](../AGENTS.md) | API 앱 진입점 (기술 스택, 핵심 규칙, 문서 네비게이션) |
-| [api-conventions.md](./api-conventions.md) | Controller/Service/Repository 계층별 코드 작성 규칙 |
-| [validators.md](./validators.md) | @aido/validators 패키지 규칙 (Zod 스키마, NestJS DTO) |
-| [prisma.md](./prisma.md) | Prisma 7 가이드 (스키마, 마이그레이션, 트랜잭션) |
-| [testing-guide.md](./testing-guide.md) | 종합 테스팅 가이드 (Unit → Integration → E2E) |
-| [logging-guide.md](./logging-guide.md) | 로깅 레벨 및 레이어별 패턴 |
+Aido API는 싱글 PostgreSQL 기반의 모듈러 모놀리스다. 실용형 DDD와 Clean Architecture를 사용하되, 레이어 수나 인터페이스 수 자체를 품질로 보지 않는다.
 
----
+목표:
 
-## 개요
+- 비즈니스 규칙과 외부 기술을 분리한다.
+- 모듈 간 결합을 공개 capability로 제한한다.
+- 상태 전이, 트랜잭션, 캐시, 큐의 소유권을 명확히 한다.
+- 기존 클라이언트와 운영 계약을 자동 테스트로 보호한다.
 
-| 항목 | 값 |
-|------|-----|
-| 프레임워크 | NestJS 11 |
-| ORM | Prisma 7 |
-| 데이터베이스 | PostgreSQL |
-| 검증 | Zod 4.3 + nestjs-zod |
-| 문서화 | Swagger (OpenAPI) |
-| 비동기 큐 | BullMQ (Redis) — 알림, AI, 스케줄러 등 |
-| 캐시 | Memory / Redis (Strategy Pattern) |
-| 분산 락 | ILockProvider (Redis / InMemory Strategy) |
-| 암호화 | AES-256-GCM (EncryptionService) |
+비목표:
 
----
+- 모든 모델을 Aggregate로 만들지 않는다.
+- 모든 repository 호출 앞에 Port를 추가하지 않는다.
+- application을 프레임워크 제로 의존으로 만들지 않는다.
+- CQRS bus, 별도 command/query 객체, 추상 factory를 일괄 도입하지 않는다.
 
-## 1. 아키텍처 개요
-
-### 1.1 계층 다이어그램 (클린아키텍처 use-case 표준 — 전 모듈)
-
-> 전환 완료 모듈은 `presentation → endpoint UseCase → domain + 필요한 port` 흐름을 따른다. domain은 순수 TypeScript이고 application은 Nest DI를 사용할 수 있다. 외부 SDK·DB·캐시 구현은 infrastructure adapter 뒤에 둔다.
-
-```
-HTTP Request
-     ↓
-Middleware (CORS)
-     ↓
-Guard (JwtAuthGuard → ThrottlerGuard → AdminGuard)   ── @Public()로 인증 스킵
-     ↓
-Controller (presentation/)  ── HTTP 요청/응답, DTO 검증, Swagger, Input 변환
-     ↓
-Endpoint UseCase (application/use-cases/)  ── @Injectable 클래스, 단일 execute(input)
-     │  · 포트(Symbol 토큰 인터페이스)에만 의존
-     │  · UNIT_OF_WORK.run(async () => ...) — 리포지토리가 CLS에서 활성 TX를 읽음
-     │  · 규칙 위반은 ApplicationException(ErrorCode)
-     ↓                                          ↓ 도메인 이벤트 (커밋 후)
-Domain (애그리게잇·VO·정책·이벤트)          DOMAIN_EVENT_PUBLISHER.publishAll()
-     │  · 불변식 위반은 DomainException           → EventEmitter2 → @OnEvent 핸들러(부수효과)
-     ↓
-Adapter (infrastructure/adapters/)  ── 포트 구현. Prisma 저장소·벤더 SDK·크로스모듈 위임
-     ↓
-Repository → DatabaseService (Prisma) → PostgreSQL
-
-     ── 내구성 부수효과 (커밋 후 enqueue) ──
-UseCase/Adapter → QueueService.enqueueXxx() → BullMQ Queue → Processor → Provider(Expo 등)
-   · 3회 재시도, exponential backoff (1s → 2s → 4s)
-```
-
-### 1.2 의존성 방향 규칙
-
-의존성 방향은 §1.4의 클린아키텍처 규칙(안쪽으로만: presentation → application → domain, infrastructure는 포트로 역전)을 따르며 `pnpm lint:boundaries`가 기계적으로 강제한다. 상세 표는 §1.4 참조.
-
-| 방향 | 허용 | 비고 |
-|------|------|------|
-| Controller → endpoint UseCase | ✅ | 엔드포인트별 직접 주입 |
-| application → domain / 포트 | ✅ | use-case가 도메인·포트 사용 |
-| infrastructure → application 포트 | ✅ | 어댑터가 포트 구현 |
-| domain → application/infrastructure/@nestjs/DB | ❌ | 도메인은 프레임워크 제로 의존 |
-| application → Prisma 타입/타 모듈 내부 | ❌ | 포트·CLS UnitOfWork로 역전 |
-| 외부 모듈 → capability port/access module | ✅ | 소비자가 소유한 좁은 계약만 사용 |
-| 외부 모듈 → UseCase/구현체 직접 호출 | ❌ | 컨텍스트 결합 금지 |
-
-### 1.3 디렉토리 구조
-
-```
-apps/api/
-├── prisma/
-│   ├── schema.prisma           # 데이터베이스 스키마
-│   └── migrations/             # 마이그레이션 파일
-├── src/
-│   ├── main.ts                 # 애플리케이션 진입점
-│   ├── app.module.ts           # 루트 모듈
-│   ├── shared/                 # 공통 인프라·유틸 (4계층, @/shared/* 별칭)
-│   │   ├── domain/             # 공유 VO·날짜·도메인 예외(DomainException)·프롬프트
-│   │   ├── application/        # 공유 포트·exceptions(ApplicationException)·pagination·entitlement·utils
-│   │   ├── infrastructure/     # database·cache·redis·lock·encryption·throttle·events·bullmq·dedup·http·jose·config·logging·filters(GlobalExceptionFilter)
-│   │   └── presentation/       # interceptors(ResponseTransform)·swagger·decorators·dtos
-│   ├── todo/                   # 할 일 — 클린아키텍처 참조 구현 (§1.4)
-│   │   ├── domain/             #   애그리게잇·VO·이벤트·도메인 서비스
-│   │   ├── application/        #   포트·facade·use-case(쓰기)·queries(읽기)·@OnEvent 구독자
-│   │   ├── infrastructure/     #   어댑터 (포트 구현)·행 repository·mapper
-│   │   └── presentation/       #   controller·dtos
-│   │   ── 나머지 도메인 모듈도 동일한 4계층 구조 (전 모듈 클린아키) ──
-│   ├── admin/                  # 관리자 기능
-│   ├── admin-notification/     # 관리자 알림 (Discord 등)
-│   ├── ai/                     # AI 자연어 파싱 (Gemini)
-│   ├── ai-report/              # AI 주간/월간 리포트
-│   ├── ai-suggestion/          # AI 반복 제안
-│   ├── auth/                   # 인증 (JWT, OAuth 4사)
-│   ├── cheer/                  # 응원 메시지
-│   ├── daily-completion/       # 일일 완료 통계
-│   ├── email/                  # 이메일 발송
-│   ├── follow/                 # 팔로우 관계
-│   ├── health/                 # 헬스체크
-│   ├── inquiry/                # 문의
-│   ├── memo/                   # 메모 (→ 할 일 변환)
-│   ├── notification/           # 알림 (BullMQ + 푸시)
-│   ├── nudge/                  # 찌르기
-│   ├── retention/              # 리텐션 캠페인 (백그라운드, presentation 없음)
-│   ├── scheduler/              # 스케줄러 (리마인더)
-│   ├── subscription/           # 구독/결제
-│   ├── todo-category/          # 할 일 카테고리
-│   ├── user-settings/          # 사용자 설정/프로필
-│   ├── weather/                # 날씨 예보/부가정보 (KMA·에어코리아·KASI)
-│   └── weekly-achievement/     # 주간 달성 통계
-└── test/
-    ├── e2e/                    # E2E 테스트
-    ├── integration/            # 통합 테스트
-    ├── mocks/                  # 테스트 Mock
-    └── setup/                  # 테스트 설정
-```
-
----
-
-### 1.4 실용형 DDD·Clean Architecture — 최종 표준
-
-**참조 구현은 todo 모듈**이며 모듈별 stacked PR로 순차 전환한다. **@nestjs/cqrs는 사용하지 않는다.** UseCase는 `@Injectable`·`@Inject`로 Nest DI에 참여하며 Controller가 직접 주입한다. domain만 프레임워크 비의존을 강제한다.
-
-핵심 규칙:
-
-- Controller가 endpoint UseCase를 직접 주입하며 Facade는 제거한다.
-- 쓰기는 `application/use-cases/`, 읽기는 `application/queries/`에 두고 모두 `<Verb><Object>UseCase`로 명명한다.
-- domain은 `@nestjs/*`, Prisma, infrastructure, presentation에 의존하지 않는다. application은 Nest DI와 Logger만 허용하며 Prisma·vendor SDK·바깥 계층 타입에는 의존하지 않는다.
-- Zod DTO와 원시 HTTP 값은 presentation mapper에서 application input으로 변환한다.
-- 같은 컨텍스트의 식별자는 branded `EntityId` VO를 쓰고 원시값 변환은 controller/infrastructure mapper에서만 한다.
-- 단건 상태 전이는 Aggregate가, 다중 행 batch/claim/counter는 명명된 port 뒤의 원자적 SQL이 담당한다.
-- 커밋 후·크로스모듈 부수효과만 도메인 이벤트로 전달한다. 큐 payload·Redis key·TTL은 기존 계약을 유지한다.
-- `AggregateRoot` 상속 클래스는 `.aggregate.ts`, 일반 `Entity` 상속 클래스는 `.entity.ts`로 양방향 강제한다.
-
-최종 의존성은 다음과 같다.
+## 2. 의존성 방향
 
 ```text
-presentation   → endpoint UseCase
-application    → domain + consumer-owned port
-domain         → pure TypeScript
-infrastructure → port implementation + Nest/Prisma/BullMQ/vendor SDK
+presentation ───────────────→ application ───────────────→ domain
+      │                            ↑                         ↑
+      │                            │ implements ports        │ maps/reconstitutes
+      └────────────────────→ infrastructure ─────────────────┘
+                                  │
+                                  └→ Prisma / Redis / BullMQ / vendor SDK
 ```
 
-전환 기준선과 계약 고정:
+| 레이어 | 소유 책임 | 허용 의존성 |
+|---|---|---|
+| `domain` | Aggregate, Entity, VO, Policy, domain event | 순수 TypeScript와 shared domain |
+| `application` | endpoint UseCase, orchestration, port, application error | domain, application 내부, 제한된 Nest DI/Logger |
+| `infrastructure` | Prisma/Redis/queue/vendor 구현, mapper, listener | application port, domain, 외부 기술 |
+| `presentation` | HTTP DTO, validation, Swagger, input/output mapper | application 진입점, validator |
 
-- `scripts/check-ddd-architecture.mjs`는 계층 import, vendor SDK 누출, Aggregate 파일명, public barrel을 검사한다.
-- 기존 위반은 exact baseline 이하만 허용한다. 새 파일·새 위치·증가한 개수는 즉시 실패하며 baseline은 위반 제거 시에만 줄인다.
-- `scripts/check-immutable-contracts.mjs`는 OpenAPI snapshot, 배포 fingerprint, Prisma schema/migrations의 내용 해시를 고정한다. 리팩터링을 승인하기 위한 snapshot 갱신은 금지한다.
-- 각 stacked PR은 독립적으로 typecheck/lint/arch/unit/integration/E2E를 통과하고 바로 아래 브랜치만 base로 삼는다.
+금지:
 
-아래 Facade 기반 설명은 아직 전환되지 않은 코드의 **현행 기준선 설명**이며 신규 코드의 표준이 아니다. `@Injectable` UseCase와 Nest TestBed 사용은 최종 표준이다.
-코드 작성 규칙 상세: [api-conventions.md §9](./api-conventions.md#9-클린아키텍처-모듈-규칙)
+- domain → Nest, Prisma, application, infrastructure, presentation
+- application → Prisma type, vendor SDK, infrastructure, presentation
+- 외부 모듈 → 다른 모듈의 내부 UseCase, concrete adapter/repository, deep path
+- public barrel → 내부 repository, queue 구현, 테스트 helper
 
-```
-HTTP Request
-     ↓
-Controller ── Facade만 주입. DTO→Input 매핑, 날짜·타임존 파싱만 담당
-     ↓
-Facade (application/facades/) ── use-case들을 주입해 한 줄 위임.
-     │                            공개 시그니처가 모듈의 공개 계약
-     ↓
-Application: use-case (엔드포인트당 1개, SRP)
-     │  · plain @Injectable() 클래스 — 단일 async execute(input): Promise<R>
-     │  · 포트(Symbol 토큰 인터페이스)에만 의존 — 8종 (repo 쓰기/읽기,
-     │    category-ownership, cache, friend, streak, notification, reminder)
-     │  · UNIT_OF_WORK.run(async () => ...) — 콜백 무인자. 리포지토리가 CLS에서
-     │    활성 TX를 직접 읽음 (tx 핸들 계층 전달 없음, 전파는 Required)
-     │  · load→mutate→write는 TX 안에서 (동시 수정 레이스 창 축소)
-     │  · ApplicationException(ErrorCode)으로 유스케이스 규칙 위반 표현
-     │  · 커밋 후 DOMAIN_EVENT_PUBLISHER.publishAll(pullDomainEvents())
-     ↓
-Domain: 애그리게잇 · 자식 엔티티 · VO · 도메인 서비스/정책 · 도메인 이벤트
-     │  · 불변식 위반은 DomainException
-     │  · props는 VO로 저장 (TodoSchedule — 날짜 불변식이 타입 수준 보장)
-     │  · 하위 항목은 TodoItem 자식 엔티티 — 개수 한도·존재·제목 불변식을
-     │    애그리게잇 행동 메서드(planItemAddition/updateItem/removeItem/
-     │    validateItemsReorder)가 소유
-     │  · 생성은 Todo.planCreation() (birth 불변식·기본값의 단일 지점 —
-     │    id가 autoincrement라 팩토리 대신 계획 패턴)
-     │  · 판단 규칙은 도메인 정책 함수 (completion-policy, reorder-position,
-     │    expand-recurring-dates — 전부 순수 함수)
-     │  · 상태 전이 메서드에서 raise(event) 적립 → use-case가 TX 커밋 후
-     │    DOMAIN_EVENT_PUBLISHER.publishAll(pullDomainEvents())
-     ↓
-Infrastructure: 어댑터 (포트 구현)
-     │  · PrismaTodo{Read}Repository → persistence/의 행 DAO(TodoRowRepository)에
-     │    위임 + 도메인/응답 매핑 (reconstitute는 불변식 재검증 없음)
-     │  · 크로스모듈 어댑터 → 타 모듈 서비스에 thin delegation
-     │  · 페이로드 계약(알림 등)은 todo 포트가 소유, 어댑터가 구조 매핑
-     ↓
-TodoRowRepository (행 DAO) → DatabaseService (Prisma) → PostgreSQL
+`pnpm --filter @aido/api lint:arch`가 import 경계, Aggregate 파일명, public barrel, cast를 검사한다.
 
-     ── 부수효과 (커밋 후, EventEmitter2) ──
-@OnEvent(TODO_EVENTS.X) ── TodoCreated/Updated/Rescheduled/Deleted → 리마인더 스케줄/취소
-                        └─ TodoToggled → 리마인더 취소 + 스트릭 + 친구완료/마일스톤 큐
+## 3. 요청 흐름
+
+```text
+Request
+  → Guard / Interceptor
+  → Controller
+  → Endpoint UseCase.execute(input)
+  → Aggregate/Policy + Port
+  → Infrastructure Adapter
+  → PostgreSQL/Redis/Queue/Vendor
 ```
 
-**도메인 이벤트 파이프라인** (use-case → EventEmitter2 → @OnEvent):
+- Controller는 Zod DTO와 HTTP 원시값을 application input으로 변환한다.
+- Controller는 endpoint UseCase를 직접 주입한다. 단순 위임 Facade는 금지한다.
+- UseCase는 한 endpoint의 흐름, 권한 확인, transaction, port 호출 순서를 조정한다.
+- Domain은 상태 전이와 불변식을 판단하고 HTTP/DB 표현을 알지 않는다.
+- 응답은 Aggregate가 만들지 않는다. read model 또는 presentation mapper가 만든다.
 
-- `DomainEvent` 인터페이스는 `eventName` 라우팅 키를 보유 (`shared/domain/aggregate-root.ts`). 이벤트명 상수는 모듈 소유 — 예: `todo/domain/events/todo-event-names.ts`의 `TODO_EVENTS` (`"todo.created"` 등)
-- 발행 포트는 `DOMAIN_EVENT_PUBLISHER` (`shared/application/ports/domain-event-publisher.port.ts`) — `@Global` `DomainEventsModule`이 제공, EventEmitter2 어댑터는 `shared/infrastructure/events/`
-- 발행은 **반드시 트랜잭션 커밋 후** (`UNIT_OF_WORK`의 `run` 콜백 밖). TX 안에서는 `pullDomainEvents()`로 드레인만 한다
-- EventEmitter2 `emitAsync`를 퍼블리셔가 이벤트 단위로 await한다. 비동기 구독자 실패까지 한 번 기록한 뒤 격리하므로 이미 커밋된 요청을 500으로 뒤집지 않는다
-- 구독은 `application/events/`의 `@Injectable()` 클래스 + `@OnEvent(TODO_EVENTS.X)` — 실패 전파가 필요한 핸들러는 `suppressErrors: false`로 rejection을 퍼블리셔 경계까지 보존한다
-- 이 경계는 **관측성**만 제공한다. durable retry/outbox가 아니므로 유실 불가 부수효과는 별도 내구성 큐/아웃박스로 설계한다
+## 4. Domain 모델링
 
-**폴더 규칙** (쓰기·읽기 대칭 — read/write 저장소 분리와 미러링):
+Aggregate는 동시 변경되어야 하는 단건 상태와 불변식이 있을 때만 사용한다.
 
-```
-modules/todo/
-├── domain/            entities/ (todo, todo-item) · value-objects/ · events/ (+ todo-event-names.ts) · services/
-├── application/       ports/ (8종) · types.ts · facades/ (todo.facade.ts)
-│                      · use-cases/<kebab>/<kebab>.use-case.ts(+spec) — 쓰기
-│                      · queries/<kebab>/<kebab>.use-case.ts(+spec) — 읽기
-│                      · events/ (5종 @OnEvent 부수효과 구독자)
-├── infrastructure/    adapters/ (포트 구현 8종) · persistence/ (행 DAO·응답 매퍼·행 타입)
-├── presentation/      todo.controller.ts · dtos/
-├── todo.module.ts  index.ts (공개 API = Facade + DTO)
-```
+| 종류 | 사용 기준 | 예시 |
+|---|---|---|
+| Aggregate Root | 상태 전이와 불변식의 일관성 경계 | `Todo`, `AuthSession`, `Friendship` |
+| Entity | Aggregate 안에서 식별되는 자식 | `TodoItem` |
+| Value Object | 값 자체에 검증·동등성·불변성이 있음 | `TodoId`, `TodoTitle`, `TodoSchedule` |
+| Policy | 여러 입력으로 순수 판단 | 완료, 재정렬, retry 계산 |
+| Read model | 조회·집계가 목적이며 상태 전이를 소유하지 않음 | daily/weekly 통계 |
 
-**의존성 방향 (클린아키텍처 모듈)** — `pnpm lint:boundaries`가 기계적으로 강제
+규칙:
 
-| 방향 | 허용 여부 | 비고 |
-|------|----------|------|
-| Controller → Facade | ✅ | 컨트롤러가 주입하는 유일한 지점 — use-case/리포지토리 직접 주입 금지 |
-| Facade → use-case | ✅ | 한 줄 위임 (로직 금지) |
-| application → domain | ✅ | use-case가 애그리게잇/VO/도메인 서비스 사용 |
-| application → 포트(인터페이스) | ✅ | `@Inject(SYMBOL_TOKEN)` |
-| infrastructure → application 포트 | ✅ | 어댑터가 포트 구현 |
-| infrastructure → 행 DAO/타 모듈 Facade | ✅ | 위임 전용 (쿼리 중복 금지) |
-| domain → application/infrastructure/@nestjs/DB | ❌ | 도메인은 프레임워크 제로 의존 |
-| application → Prisma 타입/타 모듈 내부 | ❌ | CLS 기반 UnitOfWork·포트로 역전 |
-| 외부 모듈 → 이 모듈 내부 깊은 경로 | ❌ | 배럴(index)의 Facade 호출만 — 예: memo의 `TODO_CREATOR` 포트 → `TodoCreatorAdapter`가 `TodoFacade`에 위임 |
-| domain/application/infrastructure에서 `as`/`!` | ❌ | `as`: `pnpm lint:no-cast` · `!`: Biome `noNonNullAssertion` |
+- `AggregateRoot` 상속 파일은 `.aggregate.ts`, `Entity` 상속 파일은 `.entity.ts`다.
+- 생성은 invariant와 기본값을 한곳에 모은다. DB autoincrement 모델은 `planCreation()` 후 저장하고 `reconstitute()`한다.
+- `reconstitute()`는 신뢰한 영속 상태를 복원하며 생성 검증을 반복하지 않는다.
+- mutable `Date`는 입출력 시 방어적으로 복사한다.
+- 상태 문자열과 부분 update 판단을 UseCase에 흩뿌리지 않고 명명된 도메인 행동으로 표현한다.
+- 다중 Aggregate 조정은 application transaction에서 수행한다.
+- batch/claim/counter처럼 집합 원자성이 핵심이면 Aggregate를 거치지 않는 명명된 SQL port를 허용한다.
 
-> 두 게이트는 CI `lint:arch` 태스크로 실행된다(배포 차단 게이트). 경계는 dependency-cruiser
-> (`.dependency-cruiser.cjs` — `src/<module>/` 구조에서 자동 유도, 모듈 목록 하드코딩 없음),
-> `as` 단언은 `scripts/check-no-cast.mjs`(새 모듈 전환 시 `TARGET_DIRS`에 추가), `!` 단언은
-> Biome `noNonNullAssertion`(biome.json override)이 담당한다.
+## 5. Port와 모듈 경계
 
-**의도적 트레이드오프** (재검토 시점과 함께 기록):
+Port는 변화 가능성 또는 격리 가치가 명확할 때 사용한다.
 
-| 결정 | 이유 | 재검토 시점 |
-|------|------|------------|
-| `reconstitute` 무검증 복원 | 가드 도입 이전 데이터도 복원은 성공해야 함 | 데이터 정합 백필 후 |
-| `create()` 팩토리 대신 `planCreation()` 계획 패턴 | id가 DB autoincrement | id 전략을 UUID로 바꿀 때 |
-| 행 단위 저장(필드별 update) — 컬렉션형 save(todo) 아님 | 동시 필드 쓰기 클로버 방지, Prisma partial update 적합 | 낙관적 잠금(version) 도입 시 |
-| version 컬럼(낙관적 잠금) 미도입 | 스키마·충돌 에러 시맨틱 변경 = 클라 영향 | 충돌 빈도가 문제 될 때 (현재는 TX 감싸기로 창 축소) |
-| 이벤트 아웃박스 없음 | post-commit 구독자 완료·실패를 관측하고 요청 성공은 유지 | 부수효과가 유실 불가 요건이 될 때 |
-| TodoTitle을 props에 string으로 저장 | 매핑 노이즈 대비 이득 없음 (모든 쓰기 경로가 VO 게이트 통과) | 제목 규칙이 늘어날 때 |
+Port가 적합한 경우:
 
-**계약 안전장치**: `test/e2e/openapi-contract.e2e-spec.ts` 스냅샷이 전체 API 계약을 고정 —
-마이그레이션 중 스냅샷 diff 0 = 클라이언트 영향 0.
+- AI, 결제, 이메일, push처럼 공급자를 교체할 수 있다.
+- Redis, BullMQ, clock, ID 생성기처럼 테스트 대역이 필요하다.
+- 다른 bounded context가 제공하는 좁은 capability를 소비한다.
+- 원자적 DB 연산을 application 언어로 표현해야 한다.
 
-### 1.5 표준 예외 (의도된 이탈 — 강제 금지)
+Port가 불필요한 경우:
 
-전 모듈 클린아키 표준이 원칙이나, 아래는 **의도적으로 4계층/use-case 형태를 따르지 않는다.**
-표준을 억지로 씌우면 불변식 없는 계층에 의식(ceremony)만 늘기 때문이다.
+- 같은 모듈의 단순 내부 함수 호출이다.
+- 구현이 하나뿐이고 교체·격리·경계 가치가 없다.
+- 기존 클래스를 한 번 더 전달하기 위한 wrapper다.
 
-| 이탈 | 이유 |
-|------|------|
-| **scheduler** — Facade·use-case 없음, `application/strategies/` + `services/` 전략 기반 크론 오케스트레이터. 공개는 `scheduler/queue.ts` 서브엔트리(`.dependency-cruiser.cjs` PUBLIC_SUBENTRIES 화이트리스트) | 자기 불변식이 없고 타 모듈 Facade를 조합·스윕할 뿐. 4계층은 과함 |
-| **presentation 없는 백그라운드 모듈** — `admin-notification`·`email`·`retention` | HTTP 진입점이 없는 큐/이벤트 소비 모듈 |
-| **read-model / anemic 도메인** — `daily-completion`·`weekly-achievement`(플랫 모델)·`inquiry`·`ai`·`email`(VO/서비스만) | 애그리게잇 불변식이 없는 조회·변환·벤더 경계 모듈 |
-| **auth `workflows/`·`services/` 내부 계층** — use-case는 얇은 위임, 실제 오케스트레이션은 `workflows/`(credential-auth·oauth·password), 세션/검증은 `services/` | 인증은 도메인 규모가 커 엔드포인트당 단일 use-case로는 응집이 깨짐. use-case 파일 자체는 표준대로 폴더당 1개(§7.2) |
-| **infrastructure 계층의 `CacheService` 직접 사용** — 캐시 어댑터·`prisma-scheduler.reader`·`push-dispatcher.adapter` | 어댑터는 인프라 경계라 §5.3.2 포트 규칙 대상이 아님 |
+Port는 소비자가 필요한 최소 동작으로 정의한다. 공급자의 전체 API나 vendor 용어를 복제하지 않는다. 타 모듈 연결은 공개 access module 또는 좁은 capability를 사용하며 UseCase를 직접 공유하지 않는다.
 
-> 큐/알림 페이로드 DTO는 도메인 이벤트가 아니므로 `domain/events/`가 아니라
-> `application/types/`(subscription) 또는 `domain/types/`(admin-notification)에 둔다.
+## 6. Transaction과 side effect
 
-## 2. 에러 처리 체계
-
-### 2.1 에러 흐름
-
-```
-예외 발생
-  ├── ApplicationException / DomainException (모듈 코드가 던지는 타입)
-  │     → 둘 다 ErrorCodedException(ErrorCode 보유). 필터가 BusinessException으로
-  │       정규화해 errorCode + message + httpStatus 응답 생성
-  │
-  ├── BusinessException (필터의 canonical 에러 타입 + 공유 카탈로그)
-  │     → 정의된 errorCode + message + httpStatus 그대로 반환
-  │     → 신규 비즈니스 로직은 직접 던지지 않음(벤더 어댑터 극소수 예외)
-  │
-  ├── HttpException (NestJS 내장 — 검증 실패 등)
-  │     → SYS_0002 (validation) 또는 SYS_0001로 래핑
-  │     → isDevelopment일 때만 details 포함
-  │
-  ├── Prisma P2002 (Unique constraint violation)
-  │     → constraintMap으로 BusinessException 매핑
-  │     → 매핑 없으면 concurrentModification()
-  │
-  └── Unknown (예기치 못한 에러)
-        → 500 + SYS_0001
-        → isDevelopment일 때만 details + stack 포함
-
-모든 에러 → GlobalExceptionFilter → 통일된 JSON 응답
+```text
+UNIT_OF_WORK.run
+  → load
+  → Aggregate mutate
+  → conditional write / repository save
+commit
+  → domain event publish
+  → durable queue enqueue
 ```
 
-> **모듈 코드는 `ApplicationException`(유스케이스 규칙 위반)·`DomainException`(도메인 불변식 위반)을 던진다.** 둘 다 `ErrorCode`를 보유하며, `GlobalExceptionFilter`가 이를 `BusinessException`으로 정규화한다. 같은 `errorCode`+`details`면 어느 경로든 **byte-identical HTTP 응답**을 만든다 — `BusinessException`은 필터의 내부 표현이자 공유 에러 카탈로그(P2002 매핑 등)일 뿐, 신규 로직에서 직접 던지지 않는다.
-
-### 2.2 예외 계층: ApplicationException/DomainException + BusinessException 카탈로그
-
-> **throw 표준**: 모듈 코드는 `ApplicationException`(응용 규칙)/`DomainException`(도메인 불변식)을 던진다. 둘 다 `ErrorCodedException`을 확장하고 `ErrorCode`를 보유한다. `GlobalExceptionFilter`가 이를 `BusinessException`으로 정규화해 HTTP 응답을 만든다(§2.3).
->
-> **`BusinessException`/`BusinessExceptions`의 역할**: `HttpException`을 확장한 필터의 canonical 에러 타입 + 공유 에러 카탈로그(도메인별 정적 팩토리). Prisma P2002 constraintMap 매핑이 이 팩토리를 쓰고, 벤더 어댑터 2곳(weather KMA·ai Gemini)이 직접 던진다. **신규 비즈니스 로직에서 직접 던지지 않는다** — `ApplicationException`/`DomainException`(+`ErrorCode`)을 쓴다. `new HttpException()` 금지.
-
-**위치**: `BusinessException` = `src/shared/application/exceptions/`, `ApplicationException` = `src/shared/domain/exceptions/application.exception.ts`, `DomainException` = `src/shared/domain/exceptions/domain.exception.ts`.
-
-카탈로그 위치: `src/shared/application/exceptions/business-exception.service.ts`
-
-```typescript
-// BusinessException 클래스 (필터 내부 표현 — 신규 코드가 직접 인스턴스화하지 않음)
-export class BusinessException extends HttpException {
-  constructor(
-    public readonly errorCode: ErrorCodeType,
-    public readonly details?: unknown,
-    message?: string,
-    statusCode?: number,
-  ) {
-    const errorDef = Errors[errorCode];
-    super({
-      success: false,
-      error: { code: errorCode, message: message || errorDef.message, details },
-      timestamp: Date.now(),
-    }, statusCode || errorDef.httpStatus);
-  }
-}
-```
-
-```typescript
-// 모듈 코드 throw 표준 — ApplicationException/DomainException(+ErrorCode)
-throw new ApplicationException(ErrorCode.TODO_1201, { todoId });          // 유스케이스 규칙
-throw new DomainException(ErrorCode.TODO_1210, { itemCount, limit });     // 도메인 불변식
-// 필터가 위 예외를 아래 카탈로그의 errorCode 정의로 정규화해 HTTP 응답 생성
-```
-
-**공유 에러 카탈로그 — 도메인별 정적 팩토리 메서드 목록** (필터·P2002 매핑이 사용):
-
-| 도메인 | 주요 메서드 |
-|--------|-----------|
-| Common | `userNotFound()`, `todoNotFound()`, `invalidParameter()`, `internalServerError()` |
-| Concurrency | `optimisticLockError()`, `concurrentModification()` |
-| JWT | `invalidToken()`, `tokenExpired()`, `tokenMalformed()`, `refreshTokenInvalid()`, `authenticationRequired()` |
-| Social Login | `socialAuthFailed()`, `socialTokenInvalid()`, `socialEmailNotProvided()`, `socialAccountNotLinked()` |
-| Email Auth | `emailAlreadyRegistered()`, `emailNotVerified()`, `invalidCredentials()`, `invalidPassword()` |
-| Account | `accountNotFound()`, `accountAlreadyExists()`, `accountSuspended()`, `accountLocked()`, `cannotUnlinkLastAccount()` |
-| Session | `sessionNotFound()`, `sessionExpired()`, `sessionRevoked()`, `tokenReuseDetected()` |
-| Verification | `verificationCodeInvalid()`, `verificationCodeExpired()`, `verificationResendTooSoon()` |
-| Follow | `followRequestAlreadySent()`, `alreadyFriends()`, `cannotFollowSelf()`, `notFriends()` |
-| Notification | `invalidPushToken()`, `pushSendFailed()`, `notificationNotFound()` |
-| Nudge/Cheer | `nudgeLimitExceeded()`, `cheerLimitExceeded()`, `nudgeTargetNotFound()` |
-| AI | `aiServiceUnavailable()`, `aiParseFailed()`, `aiUsageLimitExceeded()` |
-| TodoCategory | `todoCategoryNotFound()`, `todoCategoryNameDuplicate()`, `todoCategoryMinimumRequired()` |
-| Admin | `adminRequired()`, `adminNotificationTargetNotFound()` |
-| Achievement | `weeklyAchievementAlreadyExists()` |
-
-### 2.3 GlobalExceptionFilter 3단계 처리
-
-**위치**: `src/shared/infrastructure/filters/global-exception.filter.ts`
-
-```typescript
-@Catch()
-export class GlobalExceptionFilter implements ExceptionFilter {
-  catch(exception: unknown, host: ArgumentsHost) {
-    // 1단계: BusinessException → 정의된 응답 그대로
-    if (exception instanceof BusinessException) { ... }
-
-    // 2단계: HttpException → SYS_0002 (validation) 또는 SYS_0001
-    else if (exception instanceof HttpException) { ... }
-
-    // 3단계: Prisma P2002 → constraintMap 매핑
-    else if (exception instanceof PrismaClientKnownRequestError
-             && exception.code === "P2002") {
-      const businessException = this.mapP2002ToBusinessException(exception);
-    }
-
-    // Fallback: Unknown → 500 + SYS_0001
-    else { ... }
-  }
-}
-```
-
-**로깅 전략:**
-- HTTP 500+ → `logger.error()` (stack trace 포함)
-- HTTP 4xx → `logger.warn()`
-- `isDevelopment`일 때만 응답에 `details` 필드 포함
-
-### 2.4 P2002 constraintMap 매핑
-
-Prisma Unique Constraint 위반 시 비즈니스 예외로 자동 매핑:
-
-| Constraint Key | 매핑되는 BusinessException |
-|---------------|--------------------------|
-| `User_email_key` / `email` | `emailAlreadyRegistered()` |
-| `User_userTag_key` / `userTag` | `internalServerError({ detail: "userTag collision" })` |
-| `TodoCategory_userId_name_key` / `userId_name` | `todoCategoryNameDuplicate()` |
-| `Follow_followerId_followingId_key` / `followerId_followingId` | `followRequestAlreadySent()` |
-| `Account_provider_providerAccountId_key` / `provider_providerAccountId` | `accountAlreadyExists()` |
-| `Account_userId_provider_key` / `userId_provider` | `accountAlreadyExists()` |
-| `Notification_daily_dedup` / `userId_type_notificationDate` | `concurrentModification()` |
-| `Notification_friend_dedup` / `userId_type_friendId_notificationDate` | `concurrentModification()` |
-| (매핑 없음) | `concurrentModification()` (기본값) |
-
-> 각 constraint에 대해 Prisma naming(`Table_col_key`)과 축약형(`col`) 양쪽 모두 등록.
-
-### 2.5 응답 형식
-
-**성공 응답** — `ResponseTransformInterceptor`가 자동 래핑:
-
-```json
-{
-  "success": true,
-  "data": { ... },
-  "timestamp": 1707200000000
-}
-```
-
-**에러 응답** — `GlobalExceptionFilter`가 자동 래핑:
-
-```json
-{
-  "success": false,
-  "error": {
-    "code": "USER_NOT_FOUND",
-    "message": "사용자를 찾을 수 없습니다",
-    "details": { ... }       // isDevelopment일 때만
-  },
-  "timestamp": 1707200000000
-}
-```
-
-**페이지네이션 응답 (오프셋):**
-
-```json
-{
-  "success": true,
-  "data": {
-    "items": [...],
-    "pagination": {
-      "page": 1,
-      "size": 20,
-      "total": 100,
-      "totalPages": 5,
-      "hasNext": true,
-      "hasPrevious": false
-    }
-  },
-  "timestamp": 1707200000000
-}
-```
-
-**페이지네이션 응답 (커서):**
-
-```json
-{
-  "success": true,
-  "data": {
-    "items": [...],
-    "pagination": {
-      "nextCursor": "cuid_or_number",
-      "hasNext": true,
-      "size": 20
-    }
-  },
-  "timestamp": 1707200000000
-}
-```
-
-### 2.6 DO / DON'T
-
-**DO ✅**
-- use-case에서 `new ApplicationException(ErrorCode.X, details)`, 도메인 불변식은 `new DomainException(...)`로 예외 발생
-- 새 Unique Constraint 추가 시 constraintMap에 매핑 등록
-- QueueService `enqueueXxx()` 메서드로 비동기 부수효과 위임 (커밋 후)
-
-**DON'T ❌**
-- Controller에서 try-catch (GlobalExceptionFilter가 담당)
-- `new HttpException()` 직접 사용, 신규 로직에서 `BusinessExceptions` 직접 던지기 (ApplicationException/DomainException 사용)
-- 에러 응답 형식 직접 구성 (GlobalExceptionFilter가 담당)
-- 리포지토리(어댑터)에서 비즈니스 예외 발생 (use-case/도메인이 담당)
-
----
-
-## 3. BullMQ 큐 아키텍처
-
-### 3.1 큐 목록
-
-| 큐 이름 | 모듈 | 용도 |
-|---------|------|------|
-| `notification` | Notification | 푸시 알림 발송 |
-| `admin-notification` | AdminNotification | Discord 관리자 알림 |
-| `timezone-reminder` | Scheduler | 타임존별 리마인더 스윕 |
-| `todo-reminder` | Scheduler | 개별 할 일 리마인더 |
-| `ai-suggestion-analysis` | AiSuggestion | AI 반복 패턴 분석 |
-| `ai-report-generation` | AiReport | AI 주간/월간 리포트 |
-| `account-purge` | Auth | 탈퇴 계정 정리 |
-
-### 3.2 BullMQ 글로벌 설정
-
-**위치**: `src/app.module.ts`
-
-```typescript
-BullModule.forRootAsync({
-  inject: [REDIS_CLIENT],
-  useFactory: (redis: Redis) => ({
-    connection: redis,
-    defaultJobOptions: {
-      attempts: 3,
-      backoff: { type: "exponential" as const, delay: 1_000 },
-      removeOnComplete: true,
-      removeOnFail: { count: 100, age: 86_400 },
-    },
-  }),
-}),
-```
-
-| 옵션 | 값 | 설명 |
-|------|-----|------|
-| `attempts` | 3 | 최대 재시도 횟수 |
-| `backoff` | exponential, 1s | 1s → 2s → 4s |
-| `removeOnComplete` | true | 성공 시 job 삭제 |
-| `removeOnFail` | count: 100, age: 1일 | 실패 job 보관 제한 |
-
-### 3.3 QueueService 패턴 (enqueue 담당)
-
-```typescript
-// src/{name}/infrastructure/queue/{name}-queue.service.ts
-import { Injectable, Logger } from "@nestjs/common";
-import { InjectQueue } from "@nestjs/bullmq";
-import type { Queue } from "bullmq";
-import { QUEUE_NAME } from "./{name}-queue.constants";
-
-@Injectable()
-export class [Feature]QueueService {
-  readonly #logger = new Logger([Feature]QueueService.name);
-
-  constructor(
-    @InjectQueue(QUEUE_NAME) private readonly queue: Queue<[Feature]JobData>,
-  ) {}
-
-  /** fire-and-forget: 에러가 호출자에 전파되지 않음 */
-  enqueueXxx(data: XxxPayload): void {
-    this.#enqueueAsync(JobName.XXX, data).catch((error) => {
-      this.#logger.error(`큐 등록 실패: ${error.message}`);
-    });
-  }
-
-  async #enqueueAsync(name: string, data: unknown): Promise<void> {
-    await this.queue.add(name, data);
-  }
-}
-```
-
-### 3.4 Processor 패턴 (job 처리 담당)
-
-```typescript
-// src/{name}/infrastructure/queue/{name}-queue.processor.ts
-import { Processor, WorkerHost, OnWorkerEvent } from "@nestjs/bullmq";
-import type { Job } from "bullmq";
-import { QUEUE_NAME } from "./{name}-queue.constants";
-
-@Processor(QUEUE_NAME)
-export class [Feature]Processor extends WorkerHost {
-  async process(job: Job<[Feature]JobData>): Promise<void> {
-    switch (job.name) {
-      case JobName.TYPE_A:
-        return this.#handleTypeA(job.data as TypeAData);
-      case JobName.TYPE_B:
-        return this.#handleTypeB(job.data as TypeBData);
-    }
-  }
-
-  @OnWorkerEvent("failed")
-  onFailed(job: Job | undefined, error: Error): void {
-    this.logger.error(`Job 실패: ${job?.id} / ${job?.name}`, error.stack);
-  }
-}
-```
-
-### 3.5 Job 패턴 (스케줄러 등록 담당)
-
-```typescript
-// src/{name}/infrastructure/jobs/{name}.job.ts
-import { Injectable, type OnModuleInit } from "@nestjs/common";
-
-@Injectable()
-export class [Feature]Job implements OnModuleInit {
-  async onModuleInit(): Promise<void> {
-    // cron 스케줄러 등록
-    await this.queue.upsertJobScheduler("scheduler-id", {
-      pattern: "0 * * * *",  // 매시 정각
-    }, { name: JobName.SWEEP, data: {} });
-  }
-
-  async handleSweep(): Promise<void> {
-    // Processor에서 호출됨
-  }
-}
-```
-
-### 3.6 use-case에서 큐 사용 패턴
-
-```typescript
-// src/{name}/application/use-cases/create-xxx/create-xxx.use-case.ts
-@Injectable()
-export class CreateXxxUseCase {
-  constructor(
-    @Inject(UNIT_OF_WORK) private readonly uow: UnitOfWorkPort,
-    @Inject(XXX_REPOSITORY) private readonly repository: XxxRepositoryPort,
-    private readonly [feature]QueueService: [Feature]QueueService,
-  ) {}
-
-  async execute(input: CreateInput): Promise<Result> {
-    // 1. 비즈니스 로직 (CLS 트랜잭션 — 리포지토리가 활성 TX를 읽음)
-    const result = await this.uow.run(async () => {
-      // ... 도메인 로드→변경→저장
-      return created;
-    });
-
-    // 2. 트랜잭션 커밋 후 비동기 큐 enqueue (fire-and-forget)
-    this.[feature]QueueService.enqueueXxx({ ... });
-
-    return result;
-  }
-}
-```
-
-> **핵심 규칙**: 트랜잭션 커밋 후 enqueue. 트랜잭션 내부에서 enqueue하면 롤백 시 고아 job 발생.
-
-### 3.7 새 큐 추가 체크리스트
-
-1. [ ] `{name}-queue.constants.ts` — 큐 이름 상수, Job 이름 enum
-2. [ ] `{name}-queue.service.ts` — `enqueueXxx()` 메서드 (fire-and-forget)
-3. [ ] `{name}-queue.processor.ts` — `@Processor` + `WorkerHost` + switch/case
-4. [ ] `{name}.module.ts` — `BullModule.registerQueue({ name: QUEUE_NAME })` imports에 추가
-5. [ ] `test/e2e/helpers/e2e-app-factory.ts` — `BULL_QUEUES`, `BULL_PROCESSORS`, `BULL_JOBS`에 등록
-
-### 3.8 PushProvider Strategy Pattern
-
-**위치**: `src/notification/infrastructure/providers/` (포트/토큰: `src/notification/application/ports/push-provider.port.ts`)
-
-```typescript
-// push-provider.interface.ts
-export interface PushProvider {
-  readonly name: string;
-  send(payload: PushPayload): Promise<PushResult>;
-  sendBatch(payloads: PushPayload[]): Promise<BatchPushResult>;
-  validateToken(token: string): boolean;
-}
-
-export const PUSH_PROVIDER = Symbol('PUSH_PROVIDER');
-```
-
-| 항목 | PushPayload 필드 |
-|------|-----------------|
-| 필수 | `token`, `title`, `body` |
-| 선택 | `data?`, `badge?`, `sound?`, `channelId?`, `priority?`, `ttl?` |
-
-| 항목 | BatchPushResult 필드 |
-|------|---------------------|
-| 통계 | `total`, `successCount`, `failureCount` |
-| 상세 | `results: PushResult[]`, `invalidTokens: string[]` |
-
-**현재 구현**: `ExpoPushProvider` (Expo Push Notification Service)
-
-```typescript
-// expo-push.provider.ts
-@Injectable()
-export class ExpoPushProvider implements PushProvider {
-  readonly name = 'expo';
-
-  validateToken(token: string): boolean {
-    return Expo.isExpoPushToken(token);
-  }
-
-  async sendBatch(payloads: PushPayload[]): Promise<BatchPushResult> {
-    // 유효 토큰 필터링 → chunk 분할 → Expo API 호출
-    // invalidTokens 리스트 반환 (토큰 정리용)
-  }
-}
-```
-
----
-
-## 4. 보안/인증 체계
-
-### 4.1 JWT 이중 토큰
-
-| 토큰 | 용도 | 만료 |
-|------|------|------|
-| Access Token | API 인증 | 짧음 (분 단위) |
-| Refresh Token | Access Token 재발급 | 길음 (일 단위) |
-
-- Refresh Token은 DB에 저장, Token Family 기반 재사용 탐지
-- `tokenReuseDetected()` 시 해당 Family의 모든 세션 무효화
-
-### 4.2 Guard 체계
-
-**Guard 적용 순서** (app.module.ts 글로벌 등록):
-
-```
-JwtAuthGuard (인증, 글로벌 — @Public()으로 스킵)
-     ↓
-ThrottlerGuard (Rate Limiting, 글로벌)
-     ↓
-AdminGuard (관리자 권한, 엔드포인트별)
-```
-
-**위치**: `src/auth/infrastructure/guards/`
-
-| Guard | 파일 | 역할 |
-|-------|------|------|
-| `JwtAuthGuard` | `jwt-auth.guard.ts` | JWT Access Token 검증, `@Public()` 지원 |
-| `JwtRefreshGuard` | `jwt-refresh.guard.ts` | JWT Refresh Token 검증 |
-| `AdminGuard` | `admin.guard.ts` | `user.role === 'ADMIN'` 확인 |
-
-```typescript
-// JwtAuthGuard — @Public() 스킵 패턴
-@Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {
-  canActivate(context: ExecutionContext) {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
-    if (isPublic) {
-      return true;
-    }
-    return super.canActivate(context);
-  }
-
-  handleRequest<TUser>(err: Error | null, user: TUser | false): TUser {
-    if (err || !user) {
-      throw new ApplicationException(ErrorCode.AUTH_0101, {
-        reason: err?.message || "Access token is missing or invalid",
-      });
-    }
-    return user;
-  }
-}
-```
-
-**위치**: `src/auth/infrastructure/guards/jwt-auth.guard.ts`
-
-### 4.3 LastActiveInterceptor (글로벌)
-
-**위치**: `src/auth/presentation/interceptors/last-active.interceptor.ts`
-
-`APP_INTERCEPTOR`로 글로벌 등록. 모든 인증된 요청에서 `User.lastActiveAt`을 업데이트.
-
-```typescript
-// 패턴: in-memory 쓰로틀 + fire-and-forget DB 업데이트
-@Injectable()
-export class LastActiveInterceptor implements NestInterceptor {
-  static readonly THROTTLE_MS = 60 * 60 * 1000; // 1시간
-  readonly #throttleMap = new Map<string, number>(); // userId → lastUpdatedAt
-
-  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const user = context.switchToHttp().getRequest().user;
-    if (user?.userId) {
-      this.#touchLastActive(user.userId); // fire-and-forget
-    }
-    return next.handle();
-  }
-}
-```
-
-| 항목 | 설명 |
-|------|------|
-| 쓰로틀 | 같은 userId에 대해 1시간 내 중복 업데이트 방지 |
-| 비차단 | `.catch()`로 에러 처리, 응답 지연 없음 |
-| 메모리 정리 | 1시간 주기 `setInterval`로 만료 항목 삭제 |
-
-### 4.4 OAuth 4사 자동연동 규칙
-
-**위치**: `src/auth/application/workflows/oauth.workflow.ts`
-
-**Trusted vs Untrusted Provider:**
-
-| 분류 | Provider | 이메일 검증 |
-|------|----------|-----------|
-| Trusted | Google, Apple | 이메일이 플랫폼 차원에서 검증됨 |
-| Untrusted | Kakao, Naver | 이메일 검증 보장 안 됨 |
-
-**자동연동 규칙:**
-
-```
-같은 이메일의 기존 사용자가 있을 때:
-  ├── Trusted Provider + emailVerified → 자동 계정 연동 (Auto-Link)
-  │   └── CLS 트랜잭션: Account 생성 + SecurityLog("OAUTH_AUTO_LINKED")
-  │
-  └── Untrusted Provider 또는 !emailVerified → 수동 연동 요구
-      └── throw ApplicationException(SOCIAL_0206) + SecurityLog("OAUTH_LINK_REQUIRED")
-```
-
-```typescript
-// oauth.workflow.ts — 핵심 로직 (uow.run = CLS 트랜잭션, 리포지토리가 활성 TX를 읽음)
-private async handleEmailConflict(...) {
-  const isTrusted = this.isTrustedProvider(provider);  // Google, Apple
-  const isEmailVerified = options.emailVerified === true;
-
-  if (isTrusted && isEmailVerified) {
-    // Auto-link: 신뢰할 수 있는 제공자의 검증된 이메일
-    await this.uow.run(async () => {
-      await this.accountRepository.createOAuthAccount({ ... });
-      await this.securityLogRepository.create({
-        event: SECURITY_EVENT.OAUTH_AUTO_LINKED,
-        metadata: { provider, autoLinked: true, reason: 'trusted_provider_verified_email' },
-      });
-    });
-    return this.createSessionAndTokens(...);
-  }
-
-  // 수동 연동 필요
-  throw new ApplicationException(ErrorCode.SOCIAL_0206, { provider, providerAccountId, email });
-}
-```
-
-### 4.5 EncryptionService (AES-256-GCM)
-
-**위치**: `src/shared/infrastructure/encryption/encryption.service.ts`
-
-| 항목 | 값 |
-|------|-----|
-| 알고리즘 | AES-256-GCM |
-| 키 파생 | `scryptSync(TOKEN_ENCRYPTION_KEY, SALT, 32)` |
-| 저장 형식 | `iv:authTag:encrypted` (각각 base64) |
-| 환경변수 | `TOKEN_ENCRYPTION_KEY` (최소 32자) |
-| 모듈 | `@Global()` 등록 → 어디서든 주입 가능 |
-
-```typescript
-@Injectable()
-export class EncryptionService {
-  encrypt(plaintext: string): string { ... }
-  decrypt(ciphertext: string): string { ... }
-  isEncrypted(value: string): boolean { ... }
-  decryptSafe(value: string): string {
-    // 암호화된 값이면 복호화, 평문이면 그대로 반환 (마이그레이션 호환)
-    return this.isEncrypted(value) ? this.decrypt(value) : value;
-  }
-}
-```
-
-**사용 위치**: `{Feature}Repository`에서 민감 데이터 암호화/복호화
-
-```typescript
-// Repository에서 저장 시
-data.accessToken ? this.encryptionService.encrypt(data.accessToken) : null
-
-// Repository에서 조회 시
-this.encryptionService.decryptSafe(account.accessToken)
-```
-
----
-
-## 5. 공통 모듈 패턴
-
-### 5.1 @Global() 모듈 목록
-
-| 모듈 | 파일 | 제공 서비스 |
-|------|------|-----------|
-| `DatabaseModule` | `shared/infrastructure/database/` | `DatabaseService` (Prisma 래퍼) |
-| `EncryptionModule` | `shared/infrastructure/encryption/` | `EncryptionService` |
-| `CacheModule` | `shared/infrastructure/cache/` | `ICacheService`, `CacheService` |
-| `LoggerModule` | `shared/infrastructure/logging/` | 글로벌 Logger |
-| `ExceptionModule` | `shared/infrastructure/filters/` | `GlobalExceptionFilter` |
-| `ResponseModule` | `shared/presentation/interceptors/` | `ResponseTransformInterceptor` |
-| `PaginationModule` | `shared/application/pagination/` | `PaginationService` |
-| `RedisModule` | `shared/infrastructure/redis/` | `REDIS_CLIENT` (BullMQ 전용), `REDIS_COMMAND_CLIENT` (명령용 fail-fast) |
-| `LockModule` | `shared/infrastructure/lock/` | `ILockProvider` (Redis/InMemory Strategy) |
-| `EntitlementModule` | `shared/application/entitlement/` | `EntitlementService` (플랜별 제한) |
-| `DedupModule` | `shared/infrastructure/dedup/` | 알림 중복 방지 |
-| `DomainEventsModule` | `shared/infrastructure/events/` | `DOMAIN_EVENT_PUBLISHER` (도메인 이벤트 발행 포트, EventEmitter2 어댑터) |
-
-> `@Global()` 모듈은 `imports` 없이 어디서든 DI 가능.
-
-### 5.1.1 Redis 연결 이원화 & 장애 격리 (포트 계약)
-
-Redis 장애 시 API가 hang하지 않도록 연결을 용도별로 분리한다:
-
-| 토큰 | 옵션 | 사용처 |
-|------|------|--------|
-| `REDIS_CLIENT` | `maxRetriesPerRequest: null`, 오프라인 큐 유지 | **BullMQ 전용** (블로킹 명령 호환). 다른 곳에 주입 금지 |
-| `REDIS_COMMAND_CLIENT` | `enableOfflineQueue: false`, `commandTimeout` 1.5s, `maxRetriesPerRequest: 1` | 캐시/락/스로틀/dedup/푸시 레이트리미터/헬스 ping — 단절 시 즉시 reject |
-
-포트별 장애 계약 (인터페이스 JSDoc에 명문화, 새 어댑터도 준수 필수):
-
-| 포트 | 정책 | 장애 시 동작 |
-|------|------|------------|
-| `ICacheService` | fail-open | 읽기=미스 취급(→DB 폴백), 쓰기=무시. 계약 스펙: `cache-adapter.contract.ts` |
-| `ILockProvider` | fail-closed | acquire=null(busy), release=무시(TTL 정리), isLocked=true |
-| `IDedupProvider` | fail-open | 비중복 취급 (DB unique index가 최종 방어선) |
-| `ThrottlerStorage` (`THROTTLER_STORAGE`) | fail-open | 요청 허용 |
-
-관련 규칙:
-- 에러 로그는 `RedisErrorLogSampler`(30초 윈도우당 1회 + suppressed 카운트)로 남긴다
-- `JwtStrategy`는 세션 캐시 실패 시 DB로 폴백 — Redis 완전 다운이어도 인증 정상
-- `JwtAuthGuard.handleRequest`는 비-HttpException(인프라 오류)을 401로 위장하지 않고 rethrow (401은 클라 강제 로그아웃 유발 — 5xx는 토큰 보존)
-- `/health`의 `queues`는 절대 down(503)을 만들지 않는다 — Redis 다운 시 `up + degraded: true` (재시작으로 해결 불가하므로 ALB가 태스크를 죽이면 안 됨)
-- 연결 종료는 `onApplicationShutdown`에서 quit(3s 타임아웃) → disconnect 폴백
-
-### 5.2 Dynamic Module 패턴
-
-```typescript
-// CacheModule.forRoot() 패턴
-@Global()
-@Module({})
-export class CacheModule {
-  static forRoot(): DynamicModule {
-    return {
-      module: CacheModule,
-      providers: [cacheProvider, CacheService],
-      exports: [CACHE_SERVICE, CacheService],
-    };
-  }
-
-  static forTesting(adapter: ICacheService): DynamicModule { ... }
-}
-```
-
-```typescript
-// LoggerModule.forRootAsync() 패턴
-@Global()
-@Module({})
-export class LoggerModule {
-  static forRootAsync(): DynamicModule { ... }
-}
-```
-
-### 5.3 Strategy Pattern: CacheAdapter (Memory/Redis)
-
-**위치**: `src/shared/infrastructure/cache/`
-
-```
-CacheModule.forRoot()
-     │
-     ├── CACHE_TYPE === 'redis' → RedisCacheAdapter
-     └── CACHE_TYPE === 'memory' → InMemoryCacheAdapter
-                                         │
-                                   둘 다 ICacheService 구현
-```
-
-**ICacheService 인터페이스:**
-
-```typescript
-export interface ICacheService {
-  get<T>(key: string): Promise<T | undefined>;
-  set<T>(key: string, value: T, ttl?: TtlValue): Promise<void>;
-  del(key: string): Promise<void>;
-  delByPattern(pattern: string): Promise<number>;
-  reset(): Promise<void>;
-  wrap<T>(key: string, factory: () => Promise<T>, ttl?: TtlValue): Promise<T>;
-  mget<T>(keys: string[]): Promise<(T | undefined)[]>;
-  mset<T>(entries: Array<{ key: string; value: T; ttl?: TtlValue }>): Promise<void>;
-  has(key: string): Promise<boolean>;
-  ttl(key: string): Promise<number>;
-  touch(key: string, ttl: TtlValue): Promise<boolean>;
-}
-
-export type TtlValue = number | `${number}${'s' | 'm' | 'h' | 'd'}`;
-```
-
-**TTL 표현**: `60000` (ms), `'30s'`, `'5m'`, `'1h'`, `'7d'`
-
-### 5.3.1 조회 캐싱 표준 (Redis)
-
-| 항목 | 규칙 |
-|------|------|
-| 적용 대상 | 적중률 높고 churn 낮은 조회에만 **선별 적용** — 전면 캐싱 금지 |
-| 캐시 키 | `shared/infrastructure/cache/constants/cache-keys.ts`의 `CacheKeys`에서 중앙 관리. 신규 키는 `v1` 버전 세그먼트 포함 |
-| TTL | 데이터 변동성 기반으로 결정 (`CacheKeys.TTL` 상수에 근거 주석과 함께 정의) |
-| 무효화 | 쓰기 use-case에서 **명시적 호출** (도메인 이벤트가 없는 쓰기 경로 포함) 또는 `@OnEvent` 구독으로 처리 |
-| 장애 계약 | fail-open (`ICacheService` 계약, §5.1.1) — 캐시 실패는 미스 취급, DB 폴백 |
-
-### 5.3.2 모듈 캐시 포트 표준 (Pattern A — 필수)
-
-**application 계층은 공유 `CacheService`/`CacheKeys`를 직접 주입하지 않는다.** 각 모듈은
-자신의 캐시 포트(Symbol 토큰 인터페이스)에만 의존하고, 인프라 어댑터가 그 포트를
-`ICacheService`(→`CacheService`/`CacheKeys`) 위에 구현한다. 이로써 캐시 키·TTL·직렬화는
-어댑터가 소유하고, use-case는 도메인 캐시 시맨틱만 본다(교체 유연성·클린아키 경계).
-
-```
-application/ports/<module>-cache.port.ts     ── Symbol 토큰 + 시맨틱 메서드
-infrastructure/adapters/<module>-cache.adapter.ts ── CacheService 위임(키/TTL 소유)
-<module>.module.ts: { provide: X_CACHE, useClass: XCacheAdapter }
-```
-
-| 항목 | 규칙 |
-|------|------|
-| 적용 | 캐시를 쓰는 **모든** 모듈. 현재 포트: `TODO_CACHE`·`FOLLOW_CACHE`·`SUBSCRIPTION_CACHE`·`DAILY_COMPLETION_CACHE`·`TODO_CATEGORY_CACHE`·`AUTH_CACHE`·`NOTIFICATION_CACHE`·`USER_SETTINGS_CACHE`·`WEATHER_CACHE` |
-| 금지 | 모듈 `application/`에서 `@/shared/infrastructure/cache/cache.service` 또는 `constants/cache-keys` 직접 import — `.dependency-cruiser.cjs`의 `application-no-shared-cache-service` 규칙이 기계적으로 차단 (CI `lint:arch`) |
-| 예외 | **infrastructure 계층**(캐시 어댑터 자신, 크로스모듈 위임 어댑터, `prisma-scheduler.reader`, `push-dispatcher.adapter`)의 `CacheService` 직접 사용은 허용 — 어댑터가 인프라 경계이기 때문 |
-| 크로스모듈 무효화 | 타 모듈 소유 키 무효화가 필요하면 자기 포트에 메서드로 노출하고 JSDoc에 크로스모듈임을 명시(예: notification의 `invalidateUserPreference`), 또는 도메인 이벤트 `@OnEvent`로 처리(예: daily-completion) |
-
-### 5.4 TypedConfigService 래퍼
-
-**위치**: `src/shared/infrastructure/config/services/config.service.ts`
-
-NestJS `ConfigService`를 타입 안전하게 래핑:
-
-```typescript
-@Injectable()
-export class TypedConfigService {
-  constructor(private configService: NestConfigService<EnvConfig, true>) {}
-
-  get<K extends keyof EnvConfig>(key: K): EnvConfig[K] {
-    return this.configService.get(key, { infer: true });
-  }
-
-  // 편의 getter
-  get isDevelopment(): boolean { return this.get('NODE_ENV') === 'development'; }
-  get isProduction(): boolean { return this.get('NODE_ENV') === 'production'; }
-  get isTest(): boolean { return this.get('NODE_ENV') === 'test'; }
-
-  // 그룹별 getter
-  get googleOAuth() { return { clientId, clientSecret, callbackUrl, isConfigured }; }
-  get cache() { return { type, defaultTtlMs, maxItems, cleanupIntervalMs }; }
-  get tokenEncryptionKey(): string { return this.get('TOKEN_ENCRYPTION_KEY'); }
-}
-```
-
-> **Zod 스키마 기반 환경변수 검증**: `src/shared/infrastructure/config/schemas/` 하위에 `app.schema.ts`, `security.schema.ts`, `cache.schema.ts` 등에서 `z.object()`로 정의.
-
-### 5.5 PaginationService (오프셋 + 커서)
-
-**위치**: `src/shared/application/pagination/services/pagination.service.ts`
-
-**오프셋 기반:**
-
-```typescript
-// 정규화
-const params = paginationService.normalizePagination({ page: 1, size: 20 });
-// → { page: 1, size: 20, skip: 0, take: 20 }
-
-// 응답 생성
-return paginationService.createPaginatedResponse({
-  items, page: params.page, size: params.size, total,
-});
-// → { items, pagination: { page, size, total, totalPages, hasNext, hasPrevious } }
-```
-
-**커서 기반 (Generic):**
-
-```typescript
-// 정규화 — take = size + 1 (hasNext 판단용)
-const params = paginationService.normalizeCursorPagination<string>({
-  cursor: 'cuid_xxx', size: 20,
-});
-
-// 응답 생성 — items 개수로 hasNext 판단
-return paginationService.createCursorPaginatedResponse<TodoItem, string>({
-  items, size: params.size,
-});
-// → { items, pagination: { nextCursor, hasNext, size } }
-```
-
-> `CursorType = string | number` — CUID, Auto-increment ID 모두 지원.
-
----
-
-## 6. 타임존 처리
-
-### 6.1 규칙
-
-| 항목 | 규칙 |
-|------|------|
-| 저장 | UTC (PostgreSQL TIMESTAMPTZ) |
-| 전송 | ISO 8601 UTC (`2026-02-06T10:30:00.000Z`) |
-| 날짜 경계 판단 | 클라이언트 `X-Timezone` 헤더 기준 |
-| 기본값 | `X-Timezone` 미전송 시 `UTC` |
-
-### 6.2 @Timezone() 데코레이터 + X-Timezone 헤더
-
-```typescript
-import { Timezone } from '@/shared/presentation/decorators';
-import { ApiHeader } from '@nestjs/swagger';
-
-@ApiHeader({
-  name: 'X-Timezone',
-  required: false,
-  description: '사용자 타임존 (IANA, 기본값: UTC)',
-  example: 'Asia/Seoul',
-})
-@Post()
-async create(
-  @Body() dto: CreateTodoDto,
-  @Timezone() timezone: string,  // X-Timezone 헤더 값 추출
-) {
-  return this.service.create(dto, timezone);
-}
-```
-
-**타임존이 필요한 API:**
-
-| 모듈 | 엔드포인트 | 용도 |
-|------|-----------|------|
-| Todo | `POST /todos`, `PATCH /todos/:id`, `PATCH /todos/:id/complete` | 날짜 경계 판단, 스케줄 시간 변환 |
-| Cheer | `POST /cheers`, `GET /cheers/limit` | 일일 제한 리셋 기준 |
-| Nudge | `POST /nudges`, `GET /nudges/limit` | 일일 제한 리셋 기준 |
-
-### 6.3 날짜 유틸리티
-
-**위치**: `src/shared/domain/date/`
-
-```typescript
-import { todayInTimezone, parseLocalDateTime, startOfDayInTimezone, midnightInTimezone } from '@/shared/domain/date';
-
-// 사용자의 "오늘" 날짜를 UTC midnight Date로 반환
-const today = todayInTimezone(timezone);
-
-// 사용자의 로컬 날짜+시간 → UTC 변환
-const scheduledAt = parseLocalDateTime('2026-02-06', '14:00', timezone);
-
-// 특정 시점의 타임존 기준 날짜를 UTC midnight로 반환 (DATE 컬럼 비교용)
-const dayStart = startOfDayInTimezone(date, timezone);
-
-// 타임존 자정의 실제 UTC timestamp (TIMESTAMPTZ 범위 쿼리용)
-const midnight = midnightInTimezone(date, timezone);
-```
-
----
-
-## 7. 도메인 모듈 상세
-
-### 7.1 모듈 의존성 (app.module.ts 등록 순서)
-
-```typescript
-// app.module.ts imports 순서
-imports: [
-  // 1. 설정 (최우선 로드)
-  AppConfigModule,
-
-  // 2. 모니터링
-  SentryModule.forRoot(),
-
-  // 3. 인프라
-  DatabaseModule,
-  EncryptionModule,
-  RedisModule.forRoot(),
-  CacheModule.forRoot(),
-  LockModule.forRoot(),
-  BullModule.forRootAsync({ ... }),
-
-  // 4. 글로벌 모듈
-  EntitlementModule,
-  LoggerModule.forRootAsync(),
-  ExceptionModule,
-  ResponseModule,
-  PaginationModule,
-  ThrottlerModule.forRootAsync({ ... }),
-
-  // 5. 도메인 모듈
-  AdminModule, AdminNotificationModule, AiModule, AiReportModule,
-  AiSuggestionModule, AuthModule, CheerModule, DailyCompletionModule,
-  FollowModule, HealthModule, InquiryModule, NotificationModule,
-  NudgeModule, SchedulerModule, SubscriptionModule, TodoModule,
-  TodoCategoryModule, UserSettingsModule, WeeklyAchievementModule,
-],
-providers: [
-  AppService,
-  { provide: APP_GUARD, useClass: JwtAuthGuard },
-  { provide: APP_GUARD, useClass: ThrottlerGuard },
-  { provide: APP_INTERCEPTOR, useClass: LastActiveInterceptor },
-],
-```
-
-| 모듈 | 설명 | 주요 의존성 |
-|------|------|-----------|
-| **Auth** | JWT 인증, OAuth 4사, 회원 관리, 세션 | EncryptionService, EmailModule |
-| **Todo** | 할 일 CRUD, 완료 처리, 정렬 | NotificationQueueService, FollowService |
-| **TodoCategory** | 카테고리 CRUD, 기본 카테고리 | TodoModule (할 일 이동) |
-| **Follow** | 팔로우/언팔로우, 친구 관계 | NotificationQueueService |
-| **Cheer** | 응원 메시지 전송 | FollowService, NotificationQueueService |
-| **Nudge** | 찌르기 알림 전송 | FollowService, NotificationQueueService |
-| **AI** | 자연어 → Todo 파싱 (Gemini) | CacheService, EntitlementService |
-| **AiReport** | AI 주간/월간 리포트 생성 | AiProvider, BullMQ |
-| **AiSuggestion** | AI 반복 패턴 분석/제안 | AiProvider, BullMQ |
-| **Notification** | 알림 저장/발송, 토큰 관리 | PushProvider (Expo), BullMQ |
-| **Scheduler** | 스케줄러 (리마인더) | BullMQ, NotificationQueueService |
-| **Subscription** | 구독/결제 관리 | EntitlementService |
-| **AdminNotification** | 관리자 알림 (Discord) | BullMQ |
-| **DailyCompletion** | 일일 완료 통계 집계 | - |
-| **Email** | 이메일 발송 | - |
-| **Inquiry** | 문의 접수 | AdminNotifier |
-| **Admin** | 관리자 기능 | AdminGuard |
-| **UserSettings** | 사용자 설정/프로필/스트릭 | AuthModule |
-| **WeeklyAchievement** | 주간 달성 통계 | DailyCompletionModule |
-| **Health** | 헬스체크 | - |
-
-### 7.2 핵심 모듈
-
-**Auth 모듈** (4계층 클린아키. 도메인 규모상 application에 서비스 + use-case 혼재):
-
-```
-src/auth/
-├── auth.module.ts
-├── presentation/
-│   ├── controllers/     # auth·oauth·session·account 컨트롤러
-│   ├── interceptors/    # last-active (글로벌 APP_INTERCEPTOR)
-│   ├── decorators/      # @Public() 등
-│   └── dtos/
-├── application/
-│   ├── facades/         # auth·oauth·session·account 진입점 (컨트롤러의 유일 주입)
-│   ├── workflows/       # credential-auth·oauth·password (실제 오케스트레이션)
-│   ├── services/        # session·verification 서비스
-│   ├── use-cases/       # 쓰기 유스케이스 (폴더당 1개, workflow에 위임)
-│   ├── queries/         # 읽기 유스케이스 (get-current-user·list-* 등)
-│   ├── ports/           # OAuth ID 제공자 포트 등 (Symbol 토큰)
-│   ├── types/ · utils/
-├── domain/
-│   ├── services/ · value-objects/ · constants/
-└── infrastructure/
-    ├── guards/          # jwt-auth(@Public 지원)·jwt-refresh·admin
-    ├── strategies/      # jwt·jwt-refresh (Passport)
-    ├── oauth/           # 4사 provider 어댑터 + 토큰 verifier
-    ├── persistence/     # user·account(암호화)·session·verification·security-log·oauth-state 저장소
-    ├── adapters/        # 크로스모듈 포트 구현
-    ├── queue/ · scheduler/   # account-purge processor/job
-```
-
-**Todo 모듈** (클린아키텍처 참조 구현):
-
-```
+- UoW 콜백은 인자를 받지 않는다. repository는 CLS에서 활성 transaction을 읽는다.
+- load→mutate→write는 경쟁 조건을 줄이기 위해 같은 transaction에 둔다.
+- 낙관적 잠금, conditional update, unique constraint는 DB가 보장한다.
+- 실패 기록처럼 rollback되면 안 되는 쓰기는 기존 의미에 따라 transaction 밖에서 수행한다.
+- 이메일, push, 외부 webhook 등은 커밋 전 실행하지 않는다.
+- 크로스 모듈 후속 작업에만 domain event를 사용한다. 단순한 내부 함수 호출을 이벤트로 바꾸지 않는다.
+
+## 7. Cache와 Redis keyspace
+
+- 캐시는 read cost가 높고 재사용 가능하며 무효화 조건이 명확할 때만 사용한다.
+- 자주 바뀌고 필터 조합이 많은 값은 hit ratio와 invalidation 비용을 먼저 검토한다.
+- application은 의미 기반 cache port만 호출한다. raw Redis key를 알지 않는다.
+- key builder, namespace, TTL, sentinel, pattern invalidation은 해당 컨텍스트의 `infrastructure/cache`가 소유한다.
+- 논리 키는 `aido:v1:<context>:<resource>:<encoded-part>` 형태를 기본으로 한다. 기존 운영 키는 migration 계획 없이 변경하지 않는다.
+- TTL은 이름 있는 상수로 관리하고 단위(`Ms`, `Seconds`, `Minutes`)를 드러낸다.
+- cache miss와 장애 fallback을 구분하고, 캐시 장애가 핵심 쓰기를 rollback시키지 않도록 기존 격리 의미를 유지한다.
+
+참조:
+
+- `todo/infrastructure/cache/todo-cache.keyspace.ts`
+- `weather/infrastructure/cache/weather-cache.keyspace.ts`
+- `notification/infrastructure/cache/notification-cache.keyspace.ts`
+
+## 8. Queue와 background job
+
+- queue name, job name, payload schema, retry/backoff, concurrency는 queue 소유 컨텍스트에 둔다.
+- Redis에서 읽은 payload는 신뢰하지 않는다. 주요 job payload는 Zod로 런타임 검증한다.
+- job 이름은 판별 가능한 literal union으로 유지한다.
+- producer와 processor가 같은 contract를 import한다.
+- 안정적인 idempotency key를 사용하고 retry가 중복 부수효과를 만들지 않게 한다.
+- 로그에는 queue/job 이름, job ID, 시도 횟수, correlation 식별자를 남기되 payload의 개인정보와 token은 기록하지 않는다.
+- queue 이름·payload·enqueue 횟수·retry 의미는 운영 계약이다. 변경 시 migration과 호환 전략이 필요하다.
+
+## 9. Error, logging, security
+
+- Domain invariant 위반은 `DomainException`, application 규칙 위반은 `ApplicationException`으로 표현한다.
+- 공개 오류는 `@aido/errors`의 `ErrorCode`를 사용한다. `HttpException`을 비즈니스 로직에서 직접 생성하지 않는다.
+- `GlobalExceptionFilter`가 상태 코드와 응답 wrapping을 정규화한다.
+- 운영 로그는 구조화하고 비밀번호, token, authorization code, 원문 개인정보를 기록하지 않는다.
+- OAuth token 등 저장이 필요한 비밀은 기존 encryption 경계를 사용한다.
+
+상세: [logging-guide.md](./logging-guide.md)
+
+## 10. 계약과 검증
+
+리팩터링에서 다음은 승인 없이 변경하지 않는다.
+
+- HTTP route/method/header/query/body/response/status
+- Zod/Swagger/`@aido/validators` 공개 export
+- ErrorCode/message/details/wrapping
+- Prisma schema/migration/data
+- queue name/job payload/enqueue 조건
+- Redis key/TTL/invalidation 범위
+- 정렬, pagination, idempotency, side-effect 순서
+
+검증 게이트:
+
+- `check-ddd-architecture.mjs`: 레이어, 명명, barrel, cast
+- `check-immutable-contracts.mjs`: OpenAPI/fingerprint/Prisma 계약
+- unit: Aggregate/VO/Policy와 UseCase 분기
+- integration: 실제 PostgreSQL transaction/concurrency
+- E2E: HTTP와 OpenAPI 계약
+
+## 11. 참조 구조
+
+```text
 src/todo/
-├── todo.module.ts
-├── presentation/
-│   ├── (todo.controller.ts) · dtos/
-├── application/
-│   ├── facades/         # TodoFacade — 컨트롤러의 유일한 주입 지점
-│   ├── use-cases/       # 쓰기 (엔드포인트당 1개)
-│   ├── queries/         # 읽기
-│   ├── ports/           # 저장소·캐시·크로스모듈 포트 (Symbol 토큰)
-│   └── events/          # @OnEvent 도메인 이벤트 구독자
 ├── domain/
-│   ├── entities/        # Todo 애그리게잇 + TodoItem 자식 엔티티
-│   ├── value-objects/   # TodoSchedule 등
-│   ├── services/        # 정책 함수 (completion·reorder·recurring — 순수)
-│   └── events/          # TODO_EVENTS 이벤트명 + 이벤트 타입
-└── infrastructure/
-    ├── adapters/        # 포트 구현 (Prisma 저장소·크로스모듈 위임)
-    └── persistence/     # 행 DAO (TodoRowRepository) + mapper
+│   ├── entities/todo.aggregate.ts
+│   ├── entities/todo-item.entity.ts
+│   ├── value-objects/
+│   ├── services/              # 기존 순수 정책; 신규는 명확한 역할명 사용
+│   └── events/
+├── application/
+│   ├── use-cases/
+│   ├── queries/
+│   ├── ports/
+│   ├── events/
+│   └── types.ts
+├── infrastructure/
+│   ├── adapters/
+│   ├── persistence/
+│   └── cache/
+├── presentation/
+│   ├── dtos/
+│   └── todo.controller.ts
+├── todo.module.ts
+└── index.ts
 ```
 
-### 7.3 소셜 모듈 (Follow, Cheer, Nudge)
-
-**공통 패턴 — 팔로우 관계 확인 후 동작:**
-
-```typescript
-// use-case.execute 내부 — 모든 소셜 기능 공통 패턴 (포트 의존)
-async execute(input: { senderId: string; receiverId: string; ... }): Promise<Result> {
-  // 1. 팔로우 관계 확인 (친구 관계는 포트로 조회)
-  const isFriend = await this.friendPort.isMutualFriend(input.senderId, input.receiverId);
-  if (!isFriend) {
-    throw new ApplicationException(ErrorCode.FOLLOW_XXXX, { receiverId: input.receiverId });
-  }
-
-  // 2. 일일 제한 확인 (EntitlementService)
-  const entitlement = await this.entitlementService.getFeatureLimit(input.senderId, Feature.XXX);
-  this.entitlementService.enforceLimit(entitlement, todayCount);
-
-  // 3. 커밋 후 비동기 큐 enqueue
-  const result = await this.uow.run(async () => this.repository.create({ ... }));
-  this.notificationQueueService.enqueueXxxSent({ ... });
-  return result;
-}
-```
-
-**API 엔드포인트:**
-
-| 모듈 | 엔드포인트 | 설명 |
-|------|-----------|------|
-| Follow | `POST /v1/follows/:userId` | 팔로우 요청 |
-| Follow | `DELETE /v1/follows/:userId` | 언팔로우 |
-| Follow | `GET /v1/follows/followers` | 팔로워 목록 |
-| Follow | `GET /v1/follows/following` | 팔로잉 목록 |
-| Cheer | `POST /v1/cheers` | 응원 전송 (메시지 포함) |
-| Nudge | `POST /v1/nudges` | 찌르기 전송 |
-
-### 7.4 AI 모듈
-
-```
-POST /v1/ai/parse-todo
-     │
-     ▼
-┌─────────────────────────────────────────────────┐
-│  AiService                                       │
-│  - Google Gemini API 호출                         │
-│  - 토큰 최적화 프롬프트 (~200 tokens)              │
-│  - 일일 사용량 제한 (FREE: 5회, PREMIUM: 100회)    │
-└─────────────────────────────────────────────────┘
-     │
-     ▼
-┌─────────────────────────────────────────────────┐
-│  응답: ParsedTodo                                │
-│  - title, startDate, endDate, scheduledTime      │
-│  - isAllDay                                      │
-└─────────────────────────────────────────────────┘
-```
-
-**클라이언트 플로우**: AI 파싱 → 사용자 확인/수정 → `POST /v1/todos`로 생성
-
-**사용량 제한:**
-
-| 플랜 | 일일 제한 |
-|------|----------|
-| FREE | 5회 |
-| PREMIUM | 100회 |
-
-### 7.5 알림/스케줄러 (DB 기반 중복 방지)
-
-**TodoReminderJob** — 크론 작업:
-
-| 항목 | 값 |
-|------|-----|
-| 주기 | 매 10분 (`*/10 * * * *`) |
-| 대상 | 예정 시간 50~60분 전 할 일 |
-| 중복 방지 | DB 기반 (24시간 내 같은 todoId의 REMINDER 알림 확인) |
-
-```typescript
-// todo-reminder.job.ts — DB 기반 중복 방지 패턴
-@Cron('*/10 * * * *')
-async handleTodoReminder() {
-  // 1. 대상 할 일 조회 (50~60분 전)
-  const todosToNotify = await this.database.todo.findMany({ ... });
-
-  // 2. 이미 알림 보낸 할 일 필터링 (24시간 내)
-  const existingNotifications = await this.database.notification.findMany({
-    where: {
-      todoId: { in: todoIds },
-      type: 'TODO_REMINDER',
-      createdAt: { gte: twentyFourHoursAgo },
-    },
-  });
-  const alreadyNotifiedIds = new Set(existingNotifications.map(n => n.todoId));
-
-  // 3. 새로운 대상만 알림 발행
-  const newTodosToNotify = todosToNotify.filter(
-    todo => !alreadyNotifiedIds.has(todo.id)
-  );
-}
-```
-
-> **크론 작업에서 영속적 in-memory 상태(클래스 필드 Set/Map) 사용 금지** — 서버 재시작 시 상태 유실. 반드시 매 실행마다 DB 조회로 중복 판단. (DB 조회 결과를 임시 Set으로 변환하여 필터링하는 것은 허용)
-
-### Durable job / infrastructure key 규칙
-
-- 도메인은 `JOB_RUNTIME` 포트에만 의존하고 pg-boss/BullMQ 타입을 노출하지 않는다.
-- 기본 운영 backend는 PostgreSQL이며 enqueue는 업무 트랜잭션과 같은 DB 트랜잭션에 참여한다.
-- Redis rollback 시에도 같은 포트를 사용한다. 전환 중에는 PostgreSQL에만 쓰고 Redis worker를 drain한 뒤 연결을 제거한다.
-- 런타임 DDL은 금지한다. pg-boss 공식 CLI migration이 성공한 뒤에만 API를 교체한다.
-- 캐시·dedup·lock 논리 키는 `aido:v1:<bounded-context>:<resource>:<encoded-id>` 형식을 사용한다.
-- 키 문자열을 호출부에서 이어 붙이지 않고 공용 `cacheKey`/`cachePattern` 또는 등록된 키 builder를 사용한다. TTL은 key builder와 함께 상수로 관리한다.
-- 키 버전 변경은 cache miss만 유발해야 하며 DB가 항상 source of truth여야 한다.
-
----
-
-## 8. 새 기능 추가 체크리스트
-
-> 전 모듈 클린아키텍처 use-case 표준. 참조 구현: **todo**. 상세 코드 규칙: [api-conventions.md §9](./api-conventions.md#9-클린아키텍처-모듈-규칙).
-
-### 1단계: 스키마/DTO 준비
-
-- [ ] `prisma/schema.prisma`에 모델 추가 + `pnpm db:migrate`
-- [ ] `@aido/validators`에 Request/Response Zod 스키마 + NestJS DTO 추가 ([validators.md](./validators.md)) + `pnpm build`
-- [ ] `@aido/errors`에 필요한 ErrorCode 추가
-
-### 2단계: Domain
-
-- [ ] 애그리게잇 행동 메서드/자식 엔티티/VO/정책 함수/도메인 이벤트 작성
-- [ ] 불변식 위반은 `DomainException`, 생성은 `planCreation`, 판단 규칙은 `domain/services/` 정책 함수(순수)
-
-### 3단계: Application
-
-- [ ] 포트(Symbol 토큰 인터페이스) 확장 — 저장소·캐시·크로스모듈 의존은 전부 포트로
-- [ ] 쓰기는 `use-cases/<kebab>/<kebab>.use-case.ts`, 읽기는 `queries/<kebab>/<kebab>.use-case.ts` — `@Injectable()`, 단일 `execute(input)`
-- [ ] 규칙 위반은 `new ApplicationException(ErrorCode.X, details)`
-- [ ] 트랜잭션은 `UNIT_OF_WORK.run(async () => ...)`, 커밋 후 `DOMAIN_EVENT_PUBLISHER.publishAll(pullDomainEvents())`
-
-### 4단계: Infrastructure
-
-- [ ] 어댑터에 포트 구현 (Prisma 저장소는 행 DAO에 위임 + 도메인/응답 매핑, 벤더 SDK, BullMQ)
-- [ ] 큐/알림 부수효과는 `QueueService.enqueueXxx()` (커밋 후 fire-and-forget)
-
-### 5단계: Facade / Controller / Module
-
-- [ ] Facade에 한 줄 위임 메서드 추가 (공개 시그니처 = 모듈 공개 계약)
-- [ ] 컨트롤러는 Facade만 주입 + Swagger 문서화
-- [ ] 모듈 배럴(`XxxUseCases`/`XxxQueryUseCases` 배열) 등록 확인
-
-### 6단계: 테스트 + 검증
-
-- [ ] use-case/query spec ([unit-test.md](./unit-test.md)) → 통합 → E2E ([e2e-test.md](./e2e-test.md))
-- [ ] `pnpm test` · `pnpm typecheck` · `pnpm lint` 통과
-- [ ] `pnpm lint:boundaries` · `pnpm lint:no-cast` 통과
-- [ ] openapi 스냅샷 diff 0 (리팩터링 시 클라이언트 영향 0)
-
----
-
-**문서 버전**: 4.0.0
-**최종 수정일**: 2026-07-12
+새 구조를 추측하지 말고 이 디렉터리와 [api-conventions.md](./api-conventions.md)의 체크리스트를 함께 따른다.

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,105 +1,66 @@
 # Aido API
 
-> **Version**: 1.2.0 · **Last Updated**: 2026-07-23 · **Owner**: Aido Platform Team
+> Version 2.0.0 · Updated 2026-08-14 · Owner: Aido Platform Team
 
-NestJS 기반 백엔드 API. **실용형 DDD·Clean Architecture 표준**(참조 구현: **todo**) + BullMQ 큐 기반 알림. domain은 순수 TypeScript이며 application은 Nest DI를 사용할 수 있다.
+NestJS API 작업의 세션 진입점이다. 이 파일은 우선순위가 높은 규칙만 담는다. 세부 설계는 링크된 문서를 읽고, 구조가 불명확하면 `src/todo`의 현재 코드를 기준으로 판단한다.
 
----
+## 작업 전 읽기
 
-## 문서 가이드
+| 작업 | 필수 문서 |
+|---|---|
+| API 구조·의존성 | [.claude/architecture.md](.claude/architecture.md) |
+| Controller·UseCase·도메인 코드 | [.claude/api-conventions.md](.claude/api-conventions.md) |
+| Zod DTO·공개 스키마 | [.claude/validators.md](.claude/validators.md) |
+| Prisma·트랜잭션·마이그레이션 | [.claude/prisma.md](.claude/prisma.md) |
+| 테스트 | [.claude/testing-guide.md](.claude/testing-guide.md) |
+| 로깅 | [.claude/logging-guide.md](.claude/logging-guide.md) |
+| 배포 | [DEPLOYMENT.md](DEPLOYMENT.md) |
 
-| 상황 | 읽을 문서 |
-|------|----------|
-| 전체 아키텍처 이해 (에러, BullMQ 큐, 보안, 공통 모듈) | [.claude/architecture.md](.claude/architecture.md) |
-| Controller/Service/Repository 코드 작성 | [.claude/api-conventions.md](.claude/api-conventions.md) |
-| 클린아키텍처 모듈 작성 (use-case 표준 — todo 참조) | [.claude/api-conventions.md §9](.claude/api-conventions.md#9-클린아키텍처-모듈-규칙) → [architecture.md §1.4](.claude/architecture.md) |
-| Zod 스키마/DTO 추가 | [.claude/validators.md](.claude/validators.md) |
-| Prisma 스키마/마이그레이션 | [.claude/prisma.md](.claude/prisma.md) |
-| 테스트 작성 (종합) | [.claude/testing-guide.md](.claude/testing-guide.md) |
-| 단위 테스트 | [.claude/unit-test.md](.claude/unit-test.md) |
-| 통합 테스트 | [.claude/integration-test.md](.claude/integration-test.md) |
-| E2E 테스트 | [.claude/e2e-test.md](.claude/e2e-test.md) |
-| 로깅 패턴 | [.claude/logging-guide.md](.claude/logging-guide.md) |
+## 정본 구조
 
----
-
-## 기술 스택
-
-| 분류 | 기술 |
-|------|------|
-| 프레임워크 | NestJS 11 |
-| ORM | Prisma 7 |
-| 데이터베이스 | PostgreSQL |
-| 검증 | Zod 4.3 + nestjs-zod |
-| 큐 | BullMQ (Redis) |
-| 캐시 | Memory / Redis (Strategy) |
-| 암호화 | AES-256-GCM |
-| 문서화 | Swagger (OpenAPI) |
-| 테스트 | Jest + @suites/unit + Testcontainers |
-
----
-
-## 아키텍처 레이어
-
-```
-[클린아키텍처 use-case 표준 — 전 모듈. 참조 구현: todo. @nestjs/cqrs 미사용]
-Request → Guard → Controller → endpoint UseCase(execute)
-                                      ↓ 포트(인터페이스)       ↓ 도메인 이벤트(커밋 후)
-                              Adapter → Repository → DB    DOMAIN_EVENT_PUBLISHER
-                                                            → EventEmitter2 → @OnEvent 핸들러(부수효과)
-
-[내구성 부수효과 — 커밋 후 enqueue]
-UseCase/Adapter → QueueService.enqueueXxx() → BullMQ → Processor → PushProvider/외부 I/O
+```text
+HTTP → presentation → endpoint UseCase → domain + application port
+                                      infrastructure adapter → DB/Redis/queue/vendor
 ```
 
----
+- `domain`: 순수 TypeScript. Aggregate, Entity, VO, Policy, domain event를 소유한다.
+- `application`: endpoint 흐름과 consumer-owned port를 소유한다. Nest DI와 Nest Logger는 허용한다.
+- `infrastructure`: Prisma, Redis, BullMQ, 외부 SDK, port 구현을 소유한다.
+- `presentation`: HTTP DTO 검증, 원시값 변환, Swagger, 응답 매핑을 소유한다.
+- Controller는 UseCase를 직접 주입한다. 전달 전용 Facade는 만들지 않는다.
+- Port는 DB 내부 호출마다 만들지 않는다. 외부 공급자, 캐시, 큐, 크로스 컨텍스트 capability처럼 교체·격리 가치가 있을 때 만든다.
 
-## 핵심 규칙
+## 절대 규칙
 
-- **예외**: 모듈 코드는 `ApplicationException`/`DomainException`(둘 다 `ErrorCodedException`, `ErrorCode` 보유)을 던진다. `GlobalExceptionFilter`가 이를 정규화해 HTTP 응답을 만든다. `BusinessException`/`BusinessExceptions`는 필터의 canonical 에러 타입 + 공유 에러 카탈로그(Prisma P2002 매핑 등)이며 신규 비즈니스 로직에서 직접 던지지 않는다. `new HttpException()` 금지
-- **트랜잭션**: `UNIT_OF_WORK.run(async () => ...)` — 콜백 무인자, 리포지토리가 CLS(`TransactionHost.tx`)에서 활성 TX를 읽는다
-- **Domain Core**: domain에서 `@nestjs/*`, Prisma, infrastructure, presentation import 금지. application은 `@Injectable`·`@Inject`·Nest `Logger`를 사용할 수 있지만 Prisma·vendor SDK·바깥 계층 타입에는 의존하지 않는다
-- **진입점**: Controller는 endpoint UseCase를 직접 주입한다. Facade는 신규 작성하지 않으며 전환 모듈에서는 제거한다
-- **집합 연산 예외**: batch update, 원자적 claim/counter처럼 다중 행 원자성이 핵심인 작업은 명명된 port 뒤의 SQL로 유지한다
-- **타입 단언 금지**: 클린아키 영역(domain/application/infrastructure)은 `as`/`!` 금지 — `as`는 `pnpm lint:no-cast`, `!`는 Biome `noNonNullAssertion`(biome.json override)로 검사 (CI `lint:arch` 게이트)
-- **임포트 경계**: 클린아키 모듈의 레이어 의존성 방향은 `pnpm lint:boundaries`(dependency-cruiser, `.dependency-cruiser.cjs`)로 검사 (CI `lint:arch` 게이트) — domain은 프레임워크·DB 금지, application은 Prisma 타입·타 모듈 내부 금지, 외부는 배럴만
-- **API 계약 고정**: `openapi-contract.e2e-spec`의 현재 스냅샷 + 스토어 배포 클라이언트 fingerprint가 기존 request/response/status/Zod shape를 고정한다. 새 route/schema 추가만 허용 (상시 계약 게이트 — CI e2e에서 실행)
-- **큐**: 알림/부수효과는 `QueueService.enqueueXxx()` fire-and-forget 패턴 (트랜잭션 커밋 후 enqueue)
-- **캐시**: application은 **모듈 캐시 포트**(Symbol 토큰)에만 의존 — 공유 `CacheService`/`CacheKeys` 직접 주입 금지(`.dependency-cruiser.cjs`가 강제). 상세: [architecture.md §5.3.2](.claude/architecture.md)
-- **암호화**: OAuth 토큰 등 민감 데이터는 `EncryptionService`로 암호화 저장
-- **중복 방지**: 크론 작업은 DB 기반 (in-memory Set/Map 금지)
-- **응답 래핑**: 자동 (`ResponseTransformInterceptor` / `GlobalExceptionFilter`)
-- **타임존**: 서버는 UTC 저장, 클라이언트 `X-Timezone` 헤더로 날짜 경계 판단
+- 공개 HTTP route/method/header/query/body/response/status를 의도 없이 바꾸지 않는다.
+- DTO는 `@aido/validators`, 오류는 `@aido/errors`의 `ErrorCode`를 사용한다.
+- domain에서 `@nestjs/*`, Prisma, application, infrastructure, presentation을 import하지 않는다.
+- application에서 Prisma 타입, vendor SDK, infrastructure, presentation, 타 모듈 내부 경로를 import하지 않는다.
+- 타 모듈 UseCase나 구현체를 직접 호출하지 않는다. 필요한 최소 capability를 공개 경계로 연결한다.
+- 트랜잭션은 `UNIT_OF_WORK.run(async () => ...)`를 사용한다. repository가 CLS의 활성 transaction을 읽는다.
+- 단건 상태 전이는 Aggregate가 판단한다. batch update, atomic claim/counter 등 집합 원자성은 명명된 port 뒤 SQL에 둔다.
+- 커밋 후 필요한 부수효과만 domain event/queue로 보낸다. enqueue 실패 격리 의미를 임의로 바꾸지 않는다.
+- application은 모듈 cache port에 의존한다. 공유 `CacheService`나 전역 `CacheKeys`를 직접 사용하지 않는다.
+- Redis key, TTL, queue name, job payload와 retry 의미는 해당 컨텍스트의 infrastructure에 응집한다.
+- `as`, non-null assertion, deep import, concrete repository 공개를 추가하지 않는다.
 
----
+## 명명
 
-## 빠른 명령어
+- Aggregate: `domain/entities/<name>.aggregate.ts`
+- Entity: `domain/entities/<name>.entity.ts`
+- VO: `domain/value-objects/<name>.vo.ts`
+- UseCase: `application/use-cases/<verb-object>/<verb-object>.use-case.ts`
+- 읽기 UseCase: 기존 규칙에 따라 `application/queries/<verb-object>/<verb-object>.use-case.ts`
+- Port: `application/ports/<capability>.<role>.port.ts`
+- Adapter: `infrastructure/adapters/<purpose>.adapter.ts`
+- 역할명은 `Repository`, `Reader`, `Store`, `Client`, `Sender`, `Recorder`, `Publisher`, `Adapter`, `Policy`, `Resolver`, `Registry`, `JobHandler` 중 실제 책임을 표현한다.
 
-| 명령어 | 설명 |
-|--------|------|
-| `pnpm dev` | 개발 서버 (전체) |
-| `pnpm dev:api` | API만 실행 |
-| `pnpm docker:up` | PostgreSQL 컨테이너 시작 |
-| `pnpm test` | 단위 테스트 |
-| `pnpm test:e2e` | E2E 테스트 |
-| `pnpm typecheck` | 타입 체크 |
-| `pnpm lint` | Biome 린트 |
-| `pnpm db:migrate` | DB 마이그레이션 |
-| `pnpm build` | 전체 빌드 |
+## 완료 조건
 
----
+```bash
+pnpm typecheck
+pnpm lint
+pnpm --filter @aido/api lint:arch
+```
 
-## 새 기능 추가 순서
-
-**클린아키텍처 모듈(전 모듈)에 기능 추가:**
-
-1. **Prisma 스키마** → `prisma/schema.prisma` + `pnpm db:migrate`
-2. **Validators** → `@aido/validators`에 Zod 스키마 + NestJS DTO + `pnpm build`
-3. **Domain** → 애그리게잇 행동 메서드/자식 엔티티/VO/정책 함수/이벤트 (불변식은 DomainException, 생성은 planCreation, 판단 규칙은 domain/services/ 정책)
-4. **Application** → consumer-owned 포트 + `use-cases/<kebab>/<kebab>.use-case.ts` (+spec) — 순수 클래스, 단일 `execute(input)`
-5. **Infrastructure** → 어댑터에 포트 구현 (Prisma 저장소·벤더 SDK·BullMQ 등)
-6. **Controller** → DTO를 application input으로 변환하고 endpoint UseCase 직접 호출 + Swagger 문서화
-7. **Module** → UseCase와 Port→Adapter 바인딩을 명시적으로 등록
-8. **테스트** → use-case spec → e2e (openapi 스냅샷 diff 0 확인) + `lint:no-cast`·`lint:boundaries` 통과
-
-> 상세 체크리스트: [architecture.md - 새 기능 추가 체크리스트](.claude/architecture.md#8-새-기능-추가-체크리스트)
+위 명령은 항상 실행한다. 변경 위험에 따라 API unit/integration/E2E를 추가한다. 공개 계약을 건드리는 작업은 OpenAPI snapshot과 배포 클라이언트 fingerprint의 의도치 않은 diff가 없어야 한다.


### PR DESCRIPTION
## 📋 개요

2026년 8월 기준 Claude와 GPT가 Aido 서버의 현재 아키텍처를 같은 방식으로 해석하도록 API 문서를 재구성합니다.

세션 진입 규칙, 구조적 결정, 코드 작성 규칙을 서로 다른 문서에 분리했습니다. 과거 Facade 구조와 현재 endpoint UseCase 구조가 한 문서에 섞여 있던 문제를 제거하고 실제 `src/todo` 구현을 참조 기준으로 고정합니다.

> 문서 전용 변경입니다. 서버 코드, 모바일, 공개 API, Prisma, Redis, BullMQ 운영 계약은 변경하지 않습니다.

## 🏷️ 변경 유형

- [ ] ✨ `feat` - 새로운 기능 추가
- [ ] 🐛 `fix` - 버그 수정
- [x] 📝 `docs` - 문서 수정
- [ ] ♻️ `refactor` - 코드 리팩토링
- [ ] ⚡ `perf` - 성능 개선
- [ ] ✅ `test` - 테스트 추가/수정
- [ ] 👷 `ci` - CI/CD 설정 및 스크립트 변경
- [ ] 🔨 `chore` - 기타 변경사항

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드 문서
- [ ] `apps/mobile` - Expo 모바일 앱
- [ ] `packages/validators` - Zod 스키마
- [ ] `packages/utils` - 공유 유틸리티
- [ ] `packages/errors` - 에러 정의
- [ ] `tooling/*` - 개발 도구 설정
- [ ] multiple - 여러 영역 동시 변경

## 📝 변경 내용

- API `AGENTS.md`를 66줄의 세션 진입점으로 압축하고 필수 문서 순서와 절대 규칙을 명확히 했습니다.
- `architecture.md`는 레이어, Aggregate, Port, 트랜잭션, 캐시, 큐, 오류와 계약에 관한 결정만 담도록 재작성했습니다.
- `api-conventions.md`는 Controller, UseCase, Domain, Port/Adapter, Repository, Module의 실행 가능한 작성 규칙과 예제를 제공합니다.
- 전달 전용 Facade, 과도한 Port, Aggregate 남용을 금지하고 싱글 DB 모듈러 모놀리스에 맞는 예외를 명시했습니다.
- `TestBed.solitary` 허용 범위, `readonly` 적용 기준, partial update presence 검사 원칙을 명확히 했습니다.
- 루트 `AGENTS.md`의 API 문서 탐색 순서를 새 정본에 맞췄습니다.
- 핵심 세 문서를 2,280줄에서 549줄로 줄여 중복과 상충 규칙을 제거했습니다.

## 🧪 테스트

### 테스트 방법

```bash
pnpm typecheck
pnpm lint
pnpm --filter @aido/api lint:arch
git diff --check
```

### 테스트 결과

- [x] 전체 typecheck 통과
- [x] 전체 lint 통과
- [x] API architecture/immutable contract gate 통과
- [x] 문서 내 참조 코드 경로 확인
- [x] 레거시 Facade 권장 문구 제거 확인
- [x] 코드 변경이 없어 unit/integration/E2E 재실행 불필요

## ✅ 체크리스트

### 작성자 확인

- [x] 현재 Todo 구현과 문서 예제를 대조했습니다
- [x] Claude와 GPT가 순서대로 읽을 수 있는 문서 계층을 유지합니다
- [x] 같은 규칙을 여러 문서에서 다르게 정의하지 않습니다
- [x] 공개 API와 운영 계약 변경이 없습니다
- [x] typecheck, lint, build, architecture gate를 통과했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨을 `type: docs`, `scope: api`로 정리했습니다

### 리뷰어 확인

- [ ] `AGENTS.md`가 세션 진입점으로 충분히 얇습니다
- [ ] architecture와 conventions의 책임이 중복되지 않습니다
- [ ] Port와 Aggregate 적용 기준이 Aido 규모에 적절합니다
- [ ] 캐시·큐·트랜잭션 규칙이 현재 구현과 일치합니다
- [ ] 레거시 구조를 신규 표준으로 오인할 여지가 없습니다

## 🔗 관련 작업

- 서버 아키텍처 리팩터링: Stack #746
- 서버 릴리스: #747
- 문서 Stack: PR #749 단일 계층

## 📸 스크린샷

문서 전용 변경으로 UI 변경이 없습니다.

## 💬 추가 정보

이 PR은 코드 구조를 다시 변경하지 않습니다. 이미 배포된 서버 구조를 AI 에이전트와 개발자가 동일하게 이해하도록 문서의 정보 구조와 표현을 정리한 후속 작업입니다.