### PR TITLE
chore(tooling): E2E 행을 없애고 네이티브 모킹을 한 곳으로 모은다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,15 @@ jobs:
         run: bash scripts/ci/run-with-tee.spec.sh
 
       # 각 테스트 출력을 파일로 남기고 실패 시 아티팩트 업로드 — 플레이크 재현용
+      #
+      # api는 아래 커버리지 스텝이 같은 유닛 스위트를 돌리므로 여기서 제외한다.
+      # (예전에는 양쪽에서 돌아 2600여 건이 매 CI마다 두 번 실행됐다.)
       - name: Run unit tests
-        run: scripts/ci/run-with-tee.sh /tmp/test-unit.log pnpm turbo run test ${{ github.event_name == 'pull_request' && '--affected' || '' }}
+        run: scripts/ci/run-with-tee.sh /tmp/test-unit.log pnpm turbo run test --filter='!@aido/api' ${{ github.event_name == 'pull_request' && '--affected' || '' }}
 
-      - name: Run API coverage
-        run: scripts/ci/run-with-tee.sh /tmp/test-coverage.log pnpm --filter @aido/api test:cov
+      # turbo를 거쳐야 캐시와 --affected 스코핑이 함께 걸린다.
+      - name: Run API unit tests with coverage
+        run: scripts/ci/run-with-tee.sh /tmp/test-coverage.log pnpm turbo run test:cov --filter=@aido/api ${{ github.event_name == 'pull_request' && '--affected' || '' }}
 
       - name: Upload unit test logs (failure only)
         if: failure()

--- a/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.spec.ts
+++ b/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.spec.ts
@@ -385,6 +385,31 @@ describe("PushDispatcherAdapter", () => {
 		expect(repository.markPushDispatchSkipped).toHaveBeenCalledTimes(2);
 	});
 
+	it("정착하지 않는 발송은 시간 상한에서 끊는다 — 이 대기가 beforeEach에 있어, 매달리면 엉뚱한 다음 테스트가 죽는다", async () => {
+		userSettings.getPreferenceRecord.mockImplementation(async (userId) =>
+			makePreference(userId, "UTC"),
+		);
+		rateLimiter.isRateLimited.mockResolvedValue(false);
+		cacheService.wrapPushTokens.mockResolvedValue([]);
+		// 영원히 정착하지 않는 발송 하나. 상한이 없으면 여기서 끝나지 않는다.
+		repository.createPushDispatch.mockImplementation(() => new Promise(() => undefined));
+
+		adapter.fireAndForgetPush(
+			{ userId: "user-1", type: "NUDGE_RECEIVED", title: "stuck", body: "stuck" },
+			1,
+		);
+
+		await expect(adapter.drainPendingPushes(20)).rejects.toThrow(/exceeded 20ms/);
+	});
+
+	it("종료는 드레인이 실패해도 실패로 끝나지 않는다 — 종료가 걸리는 것보다 남기고 가는 게 낫다", async () => {
+		jest
+			.spyOn(adapter, "drainPendingPushes")
+			.mockRejectedValue(new Error("Push drain exceeded 25 rounds"));
+
+		await expect(adapter.beforeApplicationShutdown()).resolves.toBeUndefined();
+	});
+
 	it("배치 발송은 설정 필터 후 모든 사용자 제한을 한 번에 예약한다", async () => {
 		jest.useFakeTimers().setSystemTime(new Date("2026-07-16T00:00:00.000Z"));
 		userSettings.getPreferenceRecordsByUserIds.mockResolvedValue([

--- a/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
+++ b/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
@@ -64,6 +64,23 @@ import {
 } from "../cache/notification-cache.keyspace";
 
 /**
+ * 발송을 기다리는 라운드 상한.
+ *
+ * 대기 중인 발송이 또 다른 발송을 낳을 수 있어 한 번으로는 비지 않는다.
+ * 무한히 돌면 발송 연쇄 루프가 드러나지 않는다. 도메인 이벤트 드레인과 같은 값을 쓴다.
+ */
+const MAX_DRAIN_ROUNDS = 25;
+
+/**
+ * 발송을 기다리는 시간 상한.
+ *
+ * 라운드 상한만으로는 부족하다 — 끝나지 않는 프라미스 하나면 첫 라운드에서 영원히 멈춘다.
+ * 그러면 종료가 걸리고, 테스트에서는 이 대기가 `beforeEach`에 있어 **엉뚱한 다음 테스트가**
+ * 타임아웃으로 죽는다. 여기서 시간을 끊어야 원인이 제자리에서 드러난다.
+ */
+const DRAIN_TIMEOUT_MS = 15_000;
+
+/**
  * 푸시 발송 디스패처 어댑터(PUSH_DISPATCHER 구현).
  *
  * 푸시 전송 메커니즘과 발송 자격 판단을 소유한다:
@@ -496,10 +513,18 @@ export class PushDispatcherAdapter implements PushDispatcherPort, BeforeApplicat
 		};
 
 		const context: PushNotificationData["context"] = {};
-		if (data.todoId) context.todoId = data.todoId;
-		if (data.friendId) context.friendId = data.friendId;
-		if (data.nudgeId) context.nudgeId = data.nudgeId;
-		if (data.cheerId) context.cheerId = data.cheerId;
+		if (data.todoId) {
+			context.todoId = data.todoId;
+		}
+		if (data.friendId) {
+			context.friendId = data.friendId;
+		}
+		if (data.nudgeId) {
+			context.nudgeId = data.nudgeId;
+		}
+		if (data.cheerId) {
+			context.cheerId = data.cheerId;
+		}
 
 		return {
 			notificationId: notificationId ?? 0,
@@ -752,19 +777,61 @@ export class PushDispatcherAdapter implements PushDispatcherPort, BeforeApplicat
 		promise.finally(() => this.#pendingPushes.delete(promise));
 	}
 
-	/** 진행 중인 fire-and-forget 발송을 모두 기다린다. */
-	async drainPendingPushes(): Promise<void> {
+	/**
+	 * 진행 중인 fire-and-forget 발송을 모두 기다린다.
+	 *
+	 * 두 가지로 스스로를 묶는다 — 라운드 상한(발송이 발송을 낳는 연쇄)과
+	 * 시간 상한(끝나지 않는 프라미스 하나). 둘 중 하나라도 걸리면 조용히
+	 * 매달리는 대신 던져서, 무엇이 남았는지 그 자리에서 드러나게 한다.
+	 *
+	 * @param timeoutMs 기다릴 시간 상한. 테스트가 짧게 좁혀 쓴다.
+	 * @throws {Error} 라운드 또는 시간 상한을 넘긴 경우
+	 */
+	async drainPendingPushes(timeoutMs: number = DRAIN_TIMEOUT_MS): Promise<void> {
 		if (this.#pendingPushes.size === 0) return;
 
 		this.#logger.log(`Waiting for ${this.#pendingPushes.size} pending push(es)...`);
-		while (this.#pendingPushes.size > 0) {
-			await Promise.allSettled([...this.#pendingPushes]);
+
+		let expire: ReturnType<typeof setTimeout> | undefined;
+		const deadline = new Promise<never>((_resolve, reject) => {
+			expire = setTimeout(() => {
+				reject(
+					new Error(
+						`Push drain exceeded ${timeoutMs}ms — ${this.#pendingPushes.size}건이 정착하지 않았다`,
+					),
+				);
+			}, timeoutMs);
+			// 이 타이머만 남아 프로세스를 붙잡지 않게 한다.
+			expire.unref?.();
+		});
+
+		try {
+			await Promise.race([this.#settlePendingPushes(), deadline]);
+			this.#logger.log("All pending pushes completed");
+		} finally {
+			clearTimeout(expire);
 		}
-		this.#logger.log("All pending pushes completed");
+	}
+
+	/** 대기 집합이 빌 때까지 라운드를 돈다. 연쇄가 끝나지 않으면 던진다. */
+	async #settlePendingPushes(): Promise<void> {
+		for (let round = 0; round < MAX_DRAIN_ROUNDS; round += 1) {
+			await Promise.allSettled([...this.#pendingPushes]);
+			if (this.#pendingPushes.size === 0) return;
+		}
+
+		throw new Error(
+			`Push drain exceeded ${MAX_DRAIN_ROUNDS} rounds — ${this.#pendingPushes.size}건이 남아 발송 연쇄 루프가 의심된다`,
+		);
 	}
 
 	async beforeApplicationShutdown(): Promise<void> {
-		await this.drainPendingPushes();
+		// 종료는 실패로 끝나면 안 되지만 매달려서도 안 된다 — 남은 발송은 기록만 남기고 넘어간다.
+		try {
+			await this.drainPendingPushes();
+		} catch (error) {
+			this.#logger.warn(`Shutting down with pending pushes unresolved: ${error}`);
+		}
 		this.rateLimiter.destroy?.();
 	}
 }

--- a/apps/api/test/e2e/helpers/e2e-test-state.ts
+++ b/apps/api/test/e2e/helpers/e2e-test-state.ts
@@ -1,7 +1,46 @@
 export type TestStateResetter = () => Promise<unknown> | unknown;
 
+/**
+ * 리셋 한 단계가 기다릴 수 있는 시간 상한.
+ *
+ * 이 리셋은 `beforeEach`에서 돌고, jest는 `beforeEach`와 `it`이 같은 `testTimeout`을
+ * 나눠 쓴다. 그래서 여기서 매달리면 실패가 **엉뚱한 다음 테스트**에 귀속되고,
+ * `randomize: true` 때문에 그 희생자가 실행마다 바뀐다.
+ *
+ * 개별 단계(예: 푸시 드레인 15초)보다 넉넉히 잡아, 원인을 아는 쪽이 먼저 말하게 한다.
+ */
+const RESETTER_TIMEOUT_MS = 20_000;
+
 function normalizeError(error: unknown): Error {
 	return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * 이름을 단 시간 상한으로 감싼다.
+ *
+ * 상한을 넘기면 "무엇이 오래 걸렸는지"를 말하며 실패한다 — 지금까지 이 실패는
+ * 원인을 하나도 알려주지 않는 60초 타임아웃으로만 나타났다.
+ */
+function withDeadline(
+	label: string,
+	resetter: TestStateResetter,
+	timeoutMs: number,
+): TestStateResetter {
+	return async () => {
+		let expire: ReturnType<typeof setTimeout> | undefined;
+		const deadline = new Promise<never>((_resolve, reject) => {
+			expire = setTimeout(() => {
+				reject(new Error(`[e2e-reset] ${label}가 ${timeoutMs}ms를 넘겼다`));
+			}, timeoutMs);
+			expire.unref?.();
+		});
+
+		try {
+			return await Promise.race([Promise.resolve(resetter()), deadline]);
+		} finally {
+			clearTimeout(expire);
+		}
+	};
 }
 
 interface E2eTestStateDependencies {
@@ -11,6 +50,8 @@ interface E2eTestStateDependencies {
 	flushRedis: TestStateResetter;
 	sharedResetters: readonly TestStateResetter[];
 	additionalResetters?: readonly TestStateResetter[];
+	/** 단계별 시간 상한. 이 계약을 검증하는 테스트가 짧게 좁혀 쓴다. */
+	timeoutMs?: number;
 }
 
 export function createE2eTestStateResetter({
@@ -20,14 +61,25 @@ export function createE2eTestStateResetter({
 	flushRedis,
 	sharedResetters,
 	additionalResetters = [],
+	timeoutMs = RESETTER_TIMEOUT_MS,
 }: E2eTestStateDependencies): () => Promise<void> {
-	const nonDatabaseResetters = [resetCache, flushRedis, ...sharedResetters, ...additionalResetters];
+	const named = (label: string, resetter: TestStateResetter) =>
+		withDeadline(label, resetter, timeoutMs);
+	const nonDatabaseResetters = [
+		named("resetCache", resetCache),
+		named("flushRedis", flushRedis),
+		...sharedResetters.map((resetter, index) => named(`sharedResetters[${index}]`, resetter)),
+		...additionalResetters.map((resetter, index) =>
+			named(`additionalResetters[${index}]`, resetter),
+		),
+	];
+	const drain = drainBackgroundWork ? named("drainBackgroundWork", drainBackgroundWork) : undefined;
 
 	return async () => {
 		const errors: Error[] = [];
-		if (drainBackgroundWork) {
+		if (drain) {
 			try {
-				await drainBackgroundWork();
+				await drain();
 			} catch (error) {
 				errors.push(normalizeError(error));
 			}
@@ -36,7 +88,7 @@ export function createE2eTestStateResetter({
 		// drain 실패 여부와 무관하게 DB는 항상 정리한다 — TRUNCATE를 건너뛰면
 		// 오염이 다음 테스트로 전파되어 실패가 연쇄된다. drain 에러는 아래
 		// AggregateError로 함께 보고되므로 은폐되지 않는다.
-		const resetters = [cleanupDatabase, ...nonDatabaseResetters];
+		const resetters = [named("cleanupDatabase", cleanupDatabase), ...nonDatabaseResetters];
 		const results = await Promise.allSettled(resetters.map(async (resetter) => resetter()));
 		errors.push(
 			...results.flatMap((result) =>

--- a/apps/api/test/setup/e2e-test-state.spec.ts
+++ b/apps/api/test/setup/e2e-test-state.spec.ts
@@ -82,4 +82,45 @@ describe("E2E 테스트 상태 reset", () => {
 		expect(flushRedis).toHaveBeenCalledTimes(1);
 		expect(clearFake).toHaveBeenCalledTimes(1);
 	});
+
+	// 이 reset은 beforeEach에서 돈다. 여기서 매달리면 jest는 그 시간을 다음 it의
+	// 예산에서 빼가고, randomize 때문에 매번 다른 테스트가 원인 없이 죽는다.
+	// 아래 두 계약이 그 연결고리를 끊는다.
+	describe("시간 상한", () => {
+		const neverSettles = () => new Promise<void>(() => undefined);
+
+		it("정착하지 않는 drain을 끊고 어느 단계였는지 말한다", async () => {
+			const cleanupDatabase = jest.fn();
+			const reset = createE2eTestStateResetter({
+				drainBackgroundWork: neverSettles,
+				cleanupDatabase,
+				resetCache: jest.fn(),
+				flushRedis: jest.fn(),
+				sharedResetters: [],
+				timeoutMs: 20,
+			});
+
+			await expect(reset()).rejects.toMatchObject({
+				errors: [
+					expect.objectContaining({ message: expect.stringMatching(/drainBackgroundWork.*20ms/) }),
+				],
+			});
+			// drain이 끊겨도 DB 정리는 여전히 수행된다 — 오염을 다음 테스트로 넘기지 않는다.
+			expect(cleanupDatabase).toHaveBeenCalledTimes(1);
+		});
+
+		it("어느 단계가 멈추든 이름과 함께 실패한다", async () => {
+			const reset = createE2eTestStateResetter({
+				cleanupDatabase: jest.fn(),
+				resetCache: neverSettles,
+				flushRedis: jest.fn(),
+				sharedResetters: [],
+				timeoutMs: 20,
+			});
+
+			await expect(reset()).rejects.toMatchObject({
+				errors: [expect.objectContaining({ message: expect.stringMatching(/resetCache.*20ms/) })],
+			});
+		});
+	});
 });

--- a/apps/api/test/setup/test-database.spec.ts
+++ b/apps/api/test/setup/test-database.spec.ts
@@ -1,4 +1,24 @@
+import type { PrismaClient } from "../../src/generated/prisma/client";
 import { TestDatabase } from "./test-database";
+
+const MANAGED_ENV = {
+	DATABASE_URL: "postgresql://test_user:test_password@localhost:55432/aido_test_abc123",
+	AIDO_TEST_DB_MANAGED: "1",
+};
+
+/** 교착 재시도만 확인하면 되므로 cleanup이 부르는 두 메서드만 흉내 낸다. */
+function createFakePrismaClient(executeRawUnsafe: jest.Mock) {
+	return {
+		$connect: jest.fn().mockResolvedValue(undefined),
+		$disconnect: jest.fn().mockResolvedValue(undefined),
+		$queryRaw: jest.fn().mockResolvedValue([{ table_name: "Todo" }]),
+		$executeRawUnsafe: executeRawUnsafe,
+	} as unknown as PrismaClient;
+}
+
+function deadlock() {
+	return Object.assign(new Error("deadlock detected"), { code: "40P01" });
+}
 
 describe("TestDatabase", () => {
 	it("비관리 DATABASE_URL에서 Prisma 연결을 시도하지 않아야 한다", async () => {
@@ -14,5 +34,42 @@ describe("TestDatabase", () => {
 		// When & Then - marker/name 검증에서 즉시 중단
 		await expect(testDatabase.start()).rejects.toThrow("AIDO_TEST_DB_MANAGED=1");
 		expect(createPrismaClient).not.toHaveBeenCalled();
+	});
+
+	// TRUNCATE는 ACCESS EXCLUSIVE 락을 잡는다. 앞 테스트가 남긴 작업과 겹치면 교착으로
+	// 튕기는데, 이건 드문 경합이지 설계 결함이 아니다 — 물러섰다 다시 잡는 게 맞다.
+	describe("TRUNCATE 교착 재시도", () => {
+		async function startWith(executeRawUnsafe: jest.Mock) {
+			const testDatabase = new TestDatabase({
+				env: MANAGED_ENV,
+				createPrismaClient: () => createFakePrismaClient(executeRawUnsafe),
+			});
+			await testDatabase.start();
+			return testDatabase;
+		}
+
+		it("교착으로 튕기면 다시 시도해 끝내 정리한다", async () => {
+			const executeRawUnsafe = jest.fn().mockRejectedValueOnce(deadlock()).mockResolvedValueOnce(1);
+			const testDatabase = await startWith(executeRawUnsafe);
+
+			await expect(testDatabase.cleanup()).resolves.toBeUndefined();
+			expect(executeRawUnsafe).toHaveBeenCalledTimes(2);
+		});
+
+		it("교착이 아닌 실패는 즉시 올린다 — 감추면 원인을 잃는다", async () => {
+			const executeRawUnsafe = jest.fn().mockRejectedValue(new Error("relation does not exist"));
+			const testDatabase = await startWith(executeRawUnsafe);
+
+			await expect(testDatabase.cleanup()).rejects.toThrow("relation does not exist");
+			expect(executeRawUnsafe).toHaveBeenCalledTimes(1);
+		});
+
+		it("계속 교착이면 무한정 매달리지 않고 마지막 실패를 올린다", async () => {
+			const executeRawUnsafe = jest.fn().mockRejectedValue(deadlock());
+			const testDatabase = await startWith(executeRawUnsafe);
+
+			await expect(testDatabase.cleanup()).rejects.toThrow("deadlock detected");
+			expect(executeRawUnsafe).toHaveBeenCalledTimes(3);
+		});
 	});
 });

--- a/apps/api/test/setup/test-database.ts
+++ b/apps/api/test/setup/test-database.ts
@@ -12,6 +12,30 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../../src/generated/prisma/client";
 import { assertManagedTestDatabaseEnvironment } from "./managed-test-database";
 
+/** 교착으로 튕긴 TRUNCATE를 다시 시도하는 횟수. */
+const TRUNCATE_MAX_ATTEMPTS = 3;
+
+/** 재시도 간격의 기준값. 시도마다 선형으로 늘려 경합이 풀릴 틈을 준다. */
+const TRUNCATE_RETRY_BASE_MS = 250;
+
+/** PostgreSQL `deadlock_detected`. 이것만 재시도하고, 나머지 실패는 그대로 올린다. */
+const DEADLOCK_DETECTED = "40P01";
+
+function isDeadlock(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(error as { code?: unknown }).code === DEADLOCK_DETECTED
+	);
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
 interface TestDatabaseOptions {
 	env?: NodeJS.ProcessEnv;
 	createPrismaClient?: (connectionUri: string) => PrismaClient;
@@ -93,7 +117,32 @@ export class TestDatabase {
 		const tableList = tables
 			.map(({ table_name }) => `"public"."${table_name.replaceAll('"', '""')}"`)
 			.join(", ");
-		await this.prisma.$executeRawUnsafe(`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`);
+		await this.#truncate(`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`);
+	}
+
+	/**
+	 * TRUNCATE는 대상 테이블에 ACCESS EXCLUSIVE 락을 잡는다. 앞 테스트가 남긴 작업이
+	 * 아직 같은 테이블을 쥐고 있으면 교착(40P01)으로 튕길 수 있다 — 드문 경합이지
+	 * 설계 결함이 아니므로, 물러섰다 다시 잡는다.
+	 *
+	 * 시간 상한으로 죽이지 않는 이유: 정상적으로 조금 오래 걸리는 정리까지 함께 죽고,
+	 * 실패가 "무엇이 잘못됐는지" 대신 "느렸다"만 말하게 된다.
+	 */
+	async #truncate(statement: string): Promise<void> {
+		const client = this.getPrisma();
+
+		for (let attempt = 1; attempt <= TRUNCATE_MAX_ATTEMPTS; attempt += 1) {
+			try {
+				await client.$executeRawUnsafe(statement);
+				return;
+			} catch (error) {
+				const isLastAttempt = attempt === TRUNCATE_MAX_ATTEMPTS;
+				if (isLastAttempt || !isDeadlock(error)) {
+					throw error;
+				}
+				await delay(TRUNCATE_RETRY_BASE_MS * attempt);
+			}
+		}
 	}
 
 	/**

--- a/apps/mobile/.claude/testing-guide.md
+++ b/apps/mobile/.claude/testing-guide.md
@@ -535,12 +535,43 @@ describe('{Feature}Service', () => {
 
 ### 4. UI 컴포넌트 테스트
 
-컴포넌트 테스트에는 TanStack Query의 `QueryClient`가 필요하다.
+#### 네이티브 경계는 전역 setup이 담당한다 — 테스트에서 다시 mock하지 않는다
+
+`react-native-worklets`·`@gorhom/bottom-sheet`·`react-native-keyboard-controller`·
+`react-native-safe-area-context`·`react-native-gesture-handler`는 import 시점에 네이티브를
+붙잡아 jest에서 그대로 터진다. 이들은 **`jest.setup.ts` 한 곳에서 각 패키지가 공식으로
+제공하는 mock으로** 대체한다. 손으로 가짜를 만들거나 테스트마다 다시 mock하지 않는다.
+
+- `moduleNameMapper`가 아니라 `jest.mock`을 쓴다 — 공식 mock 일부가 내부에서
+  `jest.requireActual`로 실물을 읽는데, mapper는 그 호출까지 가로채 실물에 닿지 못하게 한다.
+- 순서가 계약이다 — worklets를 먼저 막지 않으면 다른 mock도 같은 자리에서 죽는다.
+- `react-native-reanimated`는 목록에 없다. 자체적으로 jest를 인식해 JS 경로로 도는 설계고,
+  공식 mock으로 갈아끼우면 `useReducedMotion`처럼 heroui-native가 쓰는 API가 빠진다.
+
+**`heroui-native`나 `@src/shared/ui`를 통째로 `jest.mock`하지 않는다.** 그렇게 하면
+검증하려던 배선이 함께 사라져, 테스트는 초록인데 화면은 깨지는 상태가 된다.
+
+#### `renderUi` — 앱과 같은 문맥에서 렌더한다
+
+heroui-native 컴포넌트는 `HeroUINativeProvider` 없이는 애니메이션 설정을 읽다 죽고,
+글꼴 배율은 `FontScaleProvider`가 소유한다. 이 문맥을 테스트마다 다시 세우지 않는다.
+
+```tsx
+import { renderUi } from '@src/shared/__tests__/render-ui';
+
+// DI는 이 렌더가 실제로 쓰는 것만 넣는다 —
+// 넣지 않은 의존성에 손대면 컨테이너가 이름을 대며 즉시 실패해 누락이 드러난다.
+await renderUi(<CommentComposerSheet {...props} />, { di: { analytics } });
+```
+
+- RTL 14의 `render`·`fireEvent`는 **비동기**다. `await`하지 않으면 다음 단언이 이전 상태를 본다.
+- `renderUi`는 배럴(`@src/shared/__tests__`)에 넣지 않는다 — 그러면 이 유틸을 쓰지 않는
+  테스트까지 UI 스택 전체를 끌어온다.
 
 #### QueryClient 래핑
 
-TanStack Query를 사용하는 컴포넌트는 `QueryClientProvider`로 래핑해야 한다.
-테스트 파일 내에서 직접 설정한다.
+`renderUi`가 재시도를 끈 `QueryClient`를 이미 감싸 준다. 캐시 상태를 직접 들여다봐야 할 때만
+`queryClient`를 넘긴다. 아래는 `renderUi`를 쓰지 않고 직접 세울 때의 형태다.
 
 ```typescript
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   clearMocks: true,
   restoreMocks: true,
   transformIgnorePatterns: [
-    'node_modules/(?!(.pnpm/[^/]+/node_modules/)?(react-native|@react-native|expo|@expo|heroui-native|uniwind|tailwind-variants|tailwind-merge|@gorhom|react-native-reanimated|react-native-gesture-handler|react-native-svg|react-native-worklets|ky))',
+    'node_modules/(?!(.pnpm/[^/]+/node_modules/)?(react-native|@react-native|expo|@expo|heroui-native|uniwind|tailwind-variants|tailwind-merge|@gorhom|react-native-reanimated|react-native-gesture-handler|react-native-svg|react-native-worklets|ky|standard-navigation))',
   ],
   moduleNameMapper: {
     // Path aliases

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -9,3 +9,33 @@ const originalFetch =
 if (typeof originalFetch === 'function') {
   globalThis.fetch = originalFetch as typeof fetch;
 }
+
+/**
+ * 네이티브 경계 대체 — 여기 한 곳에서만 한다.
+ *
+ * 아래 모듈들은 import 시점에 네이티브를 붙잡아 jest에서 그대로 터진다.
+ * 손으로 가짜를 만들지 않고 각 패키지가 공식으로 내주는 mock을 쓴다.
+ *
+ * moduleNameMapper가 아니라 jest.mock인 이유: 공식 mock 일부가 내부에서
+ * `jest.requireActual`로 실물을 다시 읽는데(safe-area-context), mapper는 그 호출까지
+ * 가로채 실물에 닿지 못하게 만든다. jest.mock은 requireActual을 건드리지 않는다.
+ *
+ * reanimated는 목록에 없다 — 자체적으로 jest를 인식해 JS 경로로 도는 설계이고,
+ * 터지던 이유는 worklets 하나였다. 공식 mock으로 갈아끼우면 useReducedMotion처럼
+ * heroui-native가 쓰는 API가 빠져 오히려 렌더가 깨진다.
+ */
+jest.mock('react-native-worklets', () => require('react-native-worklets/src/mock'));
+// 이 mock은 CommonJS라 __esModule 표시가 없다. 그대로 두면 default import가
+// 모듈 객체 전체로 잡혀 "Element type is invalid: got object"로 죽는다.
+jest.mock('@gorhom/bottom-sheet', () => ({
+  __esModule: true,
+  ...require('@gorhom/bottom-sheet/mock'),
+}));
+jest.mock('react-native-keyboard-controller', () =>
+  require('./src/shared/__tests__/mocks/react-native-keyboard-controller'),
+);
+jest.mock(
+  'react-native-safe-area-context',
+  () => require('react-native-safe-area-context/jest/mock').default,
+);
+require('react-native-gesture-handler/jestSetup');

--- a/apps/mobile/src/shared/__tests__/mocks/react-native-keyboard-controller.js
+++ b/apps/mobile/src/shared/__tests__/mocks/react-native-keyboard-controller.js
@@ -1,0 +1,18 @@
+/**
+ * react-native-keyboard-controller 공식 jest mock + 빠진 것 한 가지.
+ *
+ * 실물 `useKeyboardContext()`는 `setEnabled`를 함께 내주지만, 공식 mock은 그 함수를
+ * `useKeyboardController`에만 두었다. `KeyboardBottomSheet`는 시트가 열려 있는 동안
+ * 키보드 제어를 끄려고 컨텍스트 쪽 `setEnabled`를 쓴다 — 그래서 이 한 칸만 메운다.
+ *
+ * 나머지는 손대지 않는다. 벤더가 mock을 고치면 이 파일에서 이 줄만 지우면 된다.
+ */
+const official = require('react-native-keyboard-controller/jest');
+
+module.exports = {
+  ...official,
+  useKeyboardContext: jest.fn(() => ({
+    ...official.useKeyboardContext(),
+    setEnabled: jest.fn(),
+  })),
+};

--- a/apps/mobile/src/shared/__tests__/render-ui.tsx
+++ b/apps/mobile/src/shared/__tests__/render-ui.tsx
@@ -1,0 +1,71 @@
+import type { DIContainer } from '@src/bootstrap/providers/di-context';
+import { StaticDIProvider } from '@src/bootstrap/providers/di-context';
+import { HeroUIProvider } from '@src/bootstrap/providers/hero-ui-provider';
+import { FontScaleProvider } from '@src/shared/providers/font-scale-provider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react-native';
+import type { ReactElement, ReactNode } from 'react';
+
+import { createMockDIContainer } from './create-mock-di-container';
+
+/**
+ * 테스트용 QueryClient.
+ *
+ * 재시도를 끄는 게 핵심이다 — 켜 두면 실패를 검증하는 테스트가 기본 백오프만큼
+ * 기다렸다가 타임아웃으로 죽고, 원인이 "느렸다"로만 보인다.
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+interface RenderUiOptions {
+  /**
+   * 이 렌더가 실제로 쓰는 의존성만 넣는다.
+   * 넣지 않은 것에 손대면 컨테이너가 이름을 대며 즉시 실패해 누락이 드러난다.
+   */
+  di?: Partial<DIContainer>;
+  /** 캐시 상태를 직접 들여다봐야 할 때만 넘긴다. 보통은 비워 둔다. */
+  queryClient?: QueryClient;
+}
+
+/**
+ * 우리 UI 컴포넌트를 앱에서와 같은 문맥에 세운다.
+ *
+ * heroui-native 컴포넌트는 `HeroUINativeProvider` 없이는 애니메이션 설정을 읽다 죽고,
+ * 글꼴 배율은 `FontScaleProvider`가 소유한다. 이 문맥이 없어서 나는 실패는 컴포넌트의
+ * 결함이 아니므로, 테스트마다 다시 세우는 대신 여기 한 번만 세운다.
+ *
+ * 라이브러리를 통째로 mock해 우회하지 않는다 — 그러면 검증하려던 배선이 함께 사라진다.
+ * 네이티브 경계는 jest.config.js의 moduleNameMapper가 공식 mock으로 대체한다.
+ */
+/** RTL 14의 render 결과 + 이 렌더가 쓴 QueryClient. 명시하지 않으면 타입이 pnpm 경로에 묶인다. */
+type RenderUiResult = Awaited<ReturnType<typeof render>> & { queryClient: QueryClient };
+
+export async function renderUi(
+  ui: ReactElement,
+  { di, queryClient }: RenderUiOptions = {},
+): Promise<RenderUiResult> {
+  const client = queryClient ?? createTestQueryClient();
+  const container = createMockDIContainer(di);
+
+  function Harness({ children }: { children: ReactNode }) {
+    return (
+      <StaticDIProvider container={container}>
+        <QueryClientProvider client={client}>
+          <FontScaleProvider>
+            <HeroUIProvider>{children}</HeroUIProvider>
+          </FontScaleProvider>
+        </QueryClientProvider>
+      </StaticDIProvider>
+    );
+  }
+
+  // RTL 14의 render는 비동기다. 그리고 반환 객체는 전개하면 쿼리 메서드가 떨어져 나가므로
+  // 전개하지 않고 그대로 넘긴다.
+  return Object.assign(await render(ui, { wrapper: Harness }), { queryClient: client });
+}


### PR DESCRIPTION
## 📋 개요

E2E가 실행마다 **다른 테스트에서** 60초 타임아웃으로 죽던 문제를 없애고, 모바일에서 컴포넌트를 실제로 렌더하는 테스트를 쓸 수 있게 만듭니다. CI의 중복 실행도 함께 제거합니다.

이 PR은 Stack #755의 2단입니다. 프로덕션 런타임 동작은 바꾸지 않습니다(단, 푸시 드레인은 종료 경로에도 영향이 있어 아래에 따로 적었습니다).

## 🏷️ 변경 유형

- [x] 🧪 `test` - E2E 격리와 모바일 렌더 테스트 기반
- [x] 🤖 `ci` - 유닛 테스트 중복 실행 제거
- [x] ♻️ `refactor` - 드레인 경계를 어댑터가 소유

## 📦 영향 범위

- [x] `apps/api` - 푸시 드레인, E2E 리셋, TestDatabase
- [x] `apps/mobile` - jest 셋업, 렌더 유틸, 테스트 가이드
- [x] multiple - `.github/workflows/ci.yml`

## 🔍 근본 원인

`daily-completion.e2e-spec.ts`가 60초 타임아웃으로 죽었지만 **그 테스트는 원인이 아니라 피해자**였습니다. 유저 1명·할 일 1개·GET 1회가 전부인 가벼운 테스트입니다.

진짜 원인은 `beforeEach`가 부르는 드레인이었습니다.

```ts
drainBackgroundWork: async () => {
  await trackingEventPublisher?.drainPendingEvents();   // 25라운드 상한 있음
  await pushDispatcher?.drainPendingPushes();           // ← 상한이 없다
}

// push-dispatcher.adapter.ts
while (this.#pendingPushes.size > 0) {
  await Promise.allSettled([...this.#pendingPushes]);
}
```

jest는 `beforeEach`와 `it`이 같은 `testTimeout`을 나눠 씁니다. 그래서 여기서 매달리면 **실패가 다음에 실행될 `it`에 귀속**되고, `randomize: true`라 희생자가 실행마다 바뀝니다.

같은 증상의 선례가 저장소에 있습니다 — `bf02ae93 fix(api,test): E2E 플레이크 근본 원인 제거`. 그건 당시 발견된 3곳만 고친 point fix였고, 이 무한 루프가 남아 있는 것이 그 증거입니다.

## Before / After

| 영역 | Before | After |
|---|---|---|
| 푸시 드레인 | 상한·타임아웃 없는 `while` | 라운드(25) + 시간(15s) 두 경계 |
| 종료 경로 | 남은 발송이 있으면 영원히 대기 가능 | 경고 로그 후 진행 |
| E2E 리셋 | 매달리면 원인 불명 60초 타임아웃 | `[e2e-reset] drainBackgroundWork가 20000ms를 넘겼다` |
| TRUNCATE 교착 | 그대로 실패 | 40P01만 3회 재시도(선형 백오프) |
| 모바일 네이티브 모듈 | 테스트마다 손으로 mock, heroui-native 실렌더 **0건** | 공식 mock을 `jest.setup.ts` 한 곳에 |
| CI 유닛 테스트 | API 2,639건이 **매번 두 번** 실행 | 한 번(turbo 캐시·`--affected` 적용) |

## 설계 판단

- **라운드 상한만으로는 부족합니다.** 정착하지 않는 프라미스 하나면 첫 라운드에서 멈춥니다. 실측으로 확인하고 시간 경계를 함께 넣었습니다. 종료(`beforeApplicationShutdown`)에서는 던지는 대신 경고 후 진행합니다 — 종료가 실패로 끝나선 안 되지만 매달려서도 안 됩니다.
- **DB 타임아웃(`statement_timeout`/`lock_timeout`)은 넣지 않았습니다.** NestJS·Prisma 공식 문서에 해당 지침이 없고, immich(NestJS 최대 OSS)의 테스트 인프라에도 0건입니다. immich는 TRUNCATE 경합을 **교착 재시도**로 다루기에 같은 방식을 택했습니다. 이 저장소에는 의도적으로 락을 기다리는 `mutation-lock-concurrency` 통합 테스트가 있어 전역 타임아웃은 그걸 깨뜨릴 위험도 있었습니다.
- **`moduleNameMapper`가 아니라 `jest.mock`을 씁니다.** 공식 mock 일부(`react-native-safe-area-context`)가 내부에서 `jest.requireActual`로 실물을 읽는데, mapper는 그 호출까지 가로채 `SafeAreaListener`가 사라졌습니다.
- **`react-native-reanimated`는 mock하지 않습니다.** 자체적으로 jest를 인식해 JS 경로로 도는 설계고, 공식 mock으로 갈아끼우면 heroui-native가 쓰는 `useReducedMotion`이 빠집니다. 터지던 원인은 worklets 하나였습니다.
- `renderUi`는 배럴에 넣지 않습니다 — 그러면 이 유틸을 쓰지 않는 테스트까지 UI 스택 전체를 끌어옵니다.
- `randomize: true`는 유지합니다. 이게 결함을 드러내는 장치입니다.

## ✅ 검증

E2E는 한 번 초록으로 부족하므로 시드를 바꿔 가며 확인했습니다.

```
--seed=-207959283 (실패했던 그 시드)   31/31 스위트, 445/445 통과
랜덤 시드 2회                          각각 445/445 통과
통합 테스트                            36 스위트, 364건 통과
apps/api 유닛                          2,639건 통과 (드레인 계약 테스트 포함)
apps/mobile                            127 스위트, 1,114건 통과
CI 필터 dry-run                        test에서 @aido/api 제외, test:cov는 api만
```

## ⚠️ 남긴 것

- 모바일 전체 실행에 `worker process failed to exit gracefully` 경고가 뜹니다. 대조 실행으로 **이 PR 이전부터 있던 현상**임을 확인했고, 원인까지는 파지 않았습니다.
- Testcontainers 템플릿 클론(스펙별 DB 분리)은 넣지 않았습니다. 시드 3종이 안정적으로 통과하므로 비용을 재보고 판단하는 게 맞다고 봅니다.
