### PR TITLE
feat(api): 무한 깊이 댓글 트리와 연쇄 작성을 추가한다

### DIFF
--- a/apps/api/.claude/architecture.md
+++ b/apps/api/.claude/architecture.md
@@ -140,8 +140,16 @@ commit
 참조:
 
 - `todo/infrastructure/cache/todo-cache.keyspace.ts`
+- `todo-comment/infrastructure/cache/todo-comment-cache.keyspace.ts`
 - `weather/infrastructure/cache/weather-cache.keyspace.ts`
 - `notification/infrastructure/cache/notification-cache.keyspace.ts`
+
+### 댓글 캐시 결정
+
+- 댓글은 필터 조합 전체를 캐시하지 않는다. 기본 크기의 첫 페이지만 캐시한다.
+- `POPULAR`은 10초, `LATEST`는 30초로 제한해 쓰기 빈도가 높은 화면에서 오래된 목록이 장기 노출되지 않게 한다.
+- 사용자별 좋아요 여부는 공유 캐시에 넣지 않고 한 번의 `IN` 조회로 결합한다.
+- 댓글 쓰기 후에는 알려진 두 키를 직접 병렬 삭제한다. 제한된 키에 `SCAN` 또는 pattern invalidation을 사용하지 않는다.
 
 ## 8. Queue와 background job
 
@@ -212,3 +220,28 @@ src/todo/
 ```
 
 새 구조를 추측하지 말고 이 디렉터리와 [api-conventions.md](./api-conventions.md)의 체크리스트를 함께 따른다.
+
+## 12. Todo 댓글 참조 흐름
+
+```text
+GET /v1/todos/:todoId/details
+  → 접근 가능한 Todo 조회
+  → 비소유자 조회를 (todoId, viewerId) unique key로 멱등 기록
+  → 같은 transaction에서 최신 viewCount 반환
+
+GET /v1/todos/:todoId/comments
+  → opaque cursor 해석
+  → root + reply preview 관계 조회
+  → page 전체 comment ID의 viewer like를 단일 IN 조회
+
+comment/reply/like mutation
+  → Aggregate 권한·삭제 상태 검증
+  → counter와 상태를 transaction에서 반영
+commit
+  → 두 정렬 캐시 병렬 무효화 + 기존 NotificationSender 호출
+```
+
+- 별도 조회수 기록 endpoint는 두지 않는다. 상세 GET 재시도·prefetch는 DB unique constraint로 중복 집계되지 않는다.
+- 상위 댓글 삭제는 soft delete다. 본문과 작성자 표시는 제거하되 답글은 유지한다.
+- cursor는 클라이언트가 정렬 컬럼을 조립하지 못하도록 버전·정렬을 포함한 opaque 값으로 제공한다.
+- 댓글 알림은 구버전 앱이 이미 아는 `TODO_SHARED` 타입을 유지하고, 최신 앱만 Zod로 검증한 comment context를 해석한다.

--- a/apps/api/prisma/migrations/20260814000000_add_todo_comments/migration.sql
+++ b/apps/api/prisma/migrations/20260814000000_add_todo_comments/migration.sql
@@ -1,0 +1,60 @@
+-- AlterTable
+ALTER TABLE "Todo"
+ADD COLUMN "viewCount" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "commentCount" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "TodoComment" (
+    "id" TEXT NOT NULL,
+    "todoId" INTEGER NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "rootCommentId" TEXT,
+    "replyToCommentId" TEXT,
+    "clientRequestId" UUID NOT NULL,
+    "content" VARCHAR(500),
+    "likeCount" INTEGER NOT NULL DEFAULT 0,
+    "replyCount" INTEGER NOT NULL DEFAULT 0,
+    "deletedAt" TIMESTAMP(3),
+    "editedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "TodoComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TodoCommentLike" (
+    "commentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "notifiedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "TodoCommentLike_pkey" PRIMARY KEY ("commentId", "userId")
+);
+
+-- CreateTable
+CREATE TABLE "TodoView" (
+    "todoId" INTEGER NOT NULL,
+    "viewerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "TodoView_pkey" PRIMARY KEY ("todoId", "viewerId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TodoComment_authorId_clientRequestId_key" ON "TodoComment"("authorId", "clientRequestId");
+CREATE INDEX "TodoComment_todoId_rootCommentId_createdAt_id_idx" ON "TodoComment"("todoId", "rootCommentId", "createdAt", "id");
+CREATE INDEX "TodoComment_todoId_rootCommentId_likeCount_replyCount_createdAt_id_idx" ON "TodoComment"("todoId", "rootCommentId", "likeCount", "replyCount", "createdAt", "id");
+CREATE INDEX "TodoComment_rootCommentId_createdAt_id_idx" ON "TodoComment"("rootCommentId", "createdAt", "id");
+CREATE INDEX "TodoComment_replyToCommentId_idx" ON "TodoComment"("replyToCommentId");
+CREATE INDEX "TodoCommentLike_userId_isActive_idx" ON "TodoCommentLike"("userId", "isActive");
+CREATE INDEX "TodoView_viewerId_createdAt_idx" ON "TodoView"("viewerId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "TodoComment" ADD CONSTRAINT "TodoComment_todoId_fkey" FOREIGN KEY ("todoId") REFERENCES "Todo"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TodoComment" ADD CONSTRAINT "TodoComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TodoComment" ADD CONSTRAINT "TodoComment_rootCommentId_fkey" FOREIGN KEY ("rootCommentId") REFERENCES "TodoComment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TodoComment" ADD CONSTRAINT "TodoComment_replyToCommentId_fkey" FOREIGN KEY ("replyToCommentId") REFERENCES "TodoComment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "TodoCommentLike" ADD CONSTRAINT "TodoCommentLike_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "TodoComment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TodoCommentLike" ADD CONSTRAINT "TodoCommentLike_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TodoView" ADD CONSTRAINT "TodoView_todoId_fkey" FOREIGN KEY ("todoId") REFERENCES "Todo"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TodoView" ADD CONSTRAINT "TodoView_viewerId_fkey" FOREIGN KEY ("viewerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260816000000_todo_comment_tree/migration.sql
+++ b/apps/api/prisma/migrations/20260816000000_todo_comment_tree/migration.sql
@@ -1,0 +1,40 @@
+-- 댓글을 2단 고정에서 임의 깊이 트리로 전환합니다.
+-- 직계 부모(parentId) + 뿌리(rootId) + 조상 경로(path)를 두어 어떤 깊이에서도 답글을 받을 수 있게 합니다.
+
+-- 1) 새 컬럼 추가
+ALTER TABLE "TodoComment"
+ADD COLUMN "parentId" TEXT,
+ADD COLUMN "rootId" TEXT,
+ADD COLUMN "path" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN "depth" INTEGER NOT NULL DEFAULT 0;
+
+-- 2) 기존 2단 데이터 백필
+--    답글의 직계 부모는 replyToCommentId(없으면 루트), 뿌리는 rootCommentId.
+--    기존 구조상 깊이는 최대 1이므로 경로도 뿌리 하나로 채워집니다.
+UPDATE "TodoComment"
+SET "parentId" = COALESCE("replyToCommentId", "rootCommentId"),
+    "rootId" = "rootCommentId",
+    "path" = ARRAY["rootCommentId"],
+    "depth" = 1
+WHERE "rootCommentId" IS NOT NULL;
+
+-- 3) 옛 인덱스·제약·컬럼 제거
+DROP INDEX IF EXISTS "TodoComment_todoId_rootCommentId_createdAt_id_idx";
+DROP INDEX IF EXISTS "TodoComment_todoId_rootCommentId_likeCount_replyCount_createdAt_id_idx";
+DROP INDEX IF EXISTS "TodoComment_rootCommentId_createdAt_id_idx";
+DROP INDEX IF EXISTS "TodoComment_replyToCommentId_idx";
+
+ALTER TABLE "TodoComment" DROP CONSTRAINT IF EXISTS "TodoComment_rootCommentId_fkey";
+ALTER TABLE "TodoComment" DROP CONSTRAINT IF EXISTS "TodoComment_replyToCommentId_fkey";
+
+ALTER TABLE "TodoComment"
+DROP COLUMN "rootCommentId",
+DROP COLUMN "replyToCommentId";
+
+-- 4) 새 인덱스·제약
+CREATE INDEX "TodoComment_todoId_parentId_createdAt_id_idx" ON "TodoComment"("todoId", "parentId", "createdAt", "id");
+-- 이름은 Prisma가 63자로 잘라 붙이는 형태를 그대로 씁니다 (migrate diff가 깨끗하도록)
+CREATE INDEX "TodoComment_todoId_parentId_likeCount_replyCount_createdAt__idx" ON "TodoComment"("todoId", "parentId", "likeCount", "replyCount", "createdAt", "id");
+CREATE INDEX "TodoComment_todoId_rootId_idx" ON "TodoComment"("todoId", "rootId");
+
+ALTER TABLE "TodoComment" ADD CONSTRAINT "TodoComment_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "TodoComment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -82,6 +82,9 @@ model User {
   retentionAssignments RetentionExperimentAssignment[]
   weeklyAchievements   WeeklyAchievement[]
   subscriptions        Subscription[]
+  authoredTodoComments TodoComment[]                   @relation("todo_comment_author")
+  todoCommentLikes     TodoCommentLike[]
+  todoViews            TodoView[]
 
   // 관계: AI
   aiReports            AiReport[]
@@ -499,10 +502,16 @@ model Todo {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // 소셜 상호작용 카운터 (원본 행과 같은 트랜잭션에서 갱신)
+  viewCount    Int @default(0)
+  commentCount Int @default(0)
+
   // 관계
   user   User       @relation(fields: [userId], references: [id], onDelete: Cascade)
   nudges Nudge[]
   items  TodoItem[]
+  comments TodoComment[]
+  views    TodoView[]
 
   @@index([userId, startDate, endDate])
   @@index([userId, completed, startDate])
@@ -510,6 +519,78 @@ model Todo {
   @@index([userId, sortOrder])
   @@index([completed, scheduledTime]) // 리마인더 대상 조회
   @@index([recurrenceGroupId])
+}
+
+/// Todo 댓글. parentId가 null이면 최상위 댓글, 값이 있으면 그 댓글의 답글입니다.
+/// 깊이 상한은 두지 않습니다 — 화면이 들여쓰기를 한 겹으로 접습니다.
+model TodoComment {
+  id       String @id @default(cuid())
+  todoId   Int
+  authorId String
+
+  /// 직계 부모. null이면 최상위 댓글
+  parentId String?
+  /// 대화의 뿌리. 최상위 댓글이면 null
+  rootId   String?
+  /// 뿌리→부모 순서의 조상 id. 조상 사슬을 한 번의 쿼리로 가져오려고 둡니다
+  path     String[] @default([])
+  /// path의 길이 (최상위는 0)
+  depth    Int      @default(0)
+
+  clientRequestId String  @db.Uuid
+  content         String? @db.VarChar(500)
+
+  likeCount Int @default(0)
+  /// 직계 자식 수 (자손 총합이 아닙니다)
+  replyCount Int @default(0)
+
+  deletedAt DateTime?
+  editedAt  DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  todo     Todo @relation(fields: [todoId], references: [id], onDelete: Cascade)
+  author   User @relation("todo_comment_author", fields: [authorId], references: [id], onDelete: Cascade)
+  parent   TodoComment?  @relation("todo_comment_children", fields: [parentId], references: [id], onDelete: Cascade)
+  children TodoComment[] @relation("todo_comment_children")
+  likes    TodoCommentLike[]
+
+  @@unique([authorId, clientRequestId])
+  /// 최신순 — 최상위 목록(parentId IS NULL)과 임의 댓글의 답글 목록이 같은 인덱스를 씁니다
+  @@index([todoId, parentId, createdAt, id])
+  /// 인기순 — 좋아요 → 답글 수 → 시간
+  @@index([todoId, parentId, likeCount, replyCount, createdAt, id])
+  /// 스레드 단위 집계·정리
+  @@index([todoId, rootId])
+}
+
+/// 좋아요 취소 후 재등록해도 최초 알림을 반복하지 않도록 행을 보존합니다.
+model TodoCommentLike {
+  commentId String
+  userId    String
+  isActive  Boolean  @default(true)
+  notifiedAt DateTime?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  comment TodoComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  user    User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([commentId, userId])
+  @@index([userId, isActive])
+}
+
+/// 로그인 사용자별 lifetime unique Todo 조회 기록입니다.
+model TodoView {
+  todoId    Int
+  viewerId String
+  createdAt DateTime @default(now())
+
+  todo   Todo @relation(fields: [todoId], references: [id], onDelete: Cascade)
+  viewer User @relation(fields: [viewerId], references: [id], onDelete: Cascade)
+
+  @@id([todoId, viewerId])
+  @@index([viewerId, createdAt])
 }
 
 /// 투두 하위 항목 (체크리스트)

--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -2,11 +2,10 @@ import { Module } from "@nestjs/common";
 
 import { NotificationModule } from "@/notification/notification.module";
 
+import { ADMIN_PROVIDERS } from "./application/admin.providers";
 import { ADMIN_BROADCAST_NOTIFIER } from "./application/ports/admin-broadcast-notifier.port";
 import { ADMIN_GROWTH_METRICS } from "./application/ports/admin-growth-metrics.port";
 import { ADMIN_USER_DIRECTORY } from "./application/ports/admin-user-directory.port";
-import { AdminQueries } from "./application/queries";
-import { AdminUseCases } from "./application/use-cases";
 import { NotificationAdminBroadcastNotifierAdapter } from "./infrastructure/adapters/notification-admin-broadcast-notifier.adapter";
 import { PrismaAdminGrowthMetricsAdapter } from "./infrastructure/adapters/prisma-admin-growth-metrics.adapter";
 import { PrismaAdminUserDirectoryAdapter } from "./infrastructure/adapters/prisma-admin-user-directory.adapter";
@@ -35,8 +34,7 @@ import { AdminController } from "./presentation/admin.controller";
 			provide: ADMIN_GROWTH_METRICS,
 			useClass: PrismaAdminGrowthMetricsAdapter,
 		},
-		...AdminUseCases,
-		...AdminQueries,
+		...ADMIN_PROVIDERS,
 	],
 })
 export class AdminModule {}

--- a/apps/api/src/admin/application/admin.providers.ts
+++ b/apps/api/src/admin/application/admin.providers.ts
@@ -1,0 +1,9 @@
+import { GetGrowthSummaryQuery } from "./queries/get-growth-summary/get-growth-summary.query";
+import { BroadcastNotificationUseCase } from "./use-cases/broadcast-notification/broadcast-notification.use-case";
+import { SendTargetedNotificationUseCase } from "./use-cases/send-targeted-notification/send-targeted-notification.use-case";
+
+export const ADMIN_PROVIDERS = [
+	BroadcastNotificationUseCase,
+	SendTargetedNotificationUseCase,
+	GetGrowthSummaryQuery,
+] as const;

--- a/apps/api/src/admin/application/queries/index.ts
+++ b/apps/api/src/admin/application/queries/index.ts
@@ -1,6 +1,1 @@
-import { GetGrowthSummaryQuery } from "./get-growth-summary/get-growth-summary.query";
-
-/** 모듈 등록용 query 목록 */
-export const AdminQueries = [GetGrowthSummaryQuery];
-
-export { GetGrowthSummaryQuery };
+export * from "./get-growth-summary/get-growth-summary.query";

--- a/apps/api/src/admin/application/use-cases/index.ts
+++ b/apps/api/src/admin/application/use-cases/index.ts
@@ -1,5 +1,2 @@
-import { BroadcastNotificationUseCase } from "./broadcast-notification/broadcast-notification.use-case";
-import { SendTargetedNotificationUseCase } from "./send-targeted-notification/send-targeted-notification.use-case";
-
-/** 모듈 등록용 use-case 목록 */
-export const AdminUseCases = [BroadcastNotificationUseCase, SendTargetedNotificationUseCase];
+export * from "./broadcast-notification/broadcast-notification.use-case";
+export * from "./send-targeted-notification/send-targeted-notification.use-case";

--- a/apps/api/src/ai/ai.module.ts
+++ b/apps/api/src/ai/ai.module.ts
@@ -1,12 +1,11 @@
 import { Module } from "@nestjs/common";
 
 import { TodoCategoryModule } from "../todo-category/todo-category.module";
+import { AI_PROVIDERS } from "./application/ai.providers";
 import { AI_PROVIDER } from "./application/ports/ai-provider.port";
 import { AI_USAGE_REPOSITORY } from "./application/ports/ai-usage.repository.port";
 import { USER_CATEGORY_READER } from "./application/ports/user-category-reader.port";
-import { AiQueryUseCases } from "./application/queries";
 import { AiUsageMeter } from "./application/services/ai-usage-meter.service";
-import { AiUseCases } from "./application/use-cases";
 import { AI_PROVIDER_GEMINI, AiRouterAdapter } from "./infrastructure/adapters/ai-router.adapter";
 import { GeminiAiAdapter } from "./infrastructure/adapters/gemini-ai.adapter";
 import { PrismaAiUsageRepository } from "./infrastructure/adapters/prisma-ai-usage.repository";
@@ -48,8 +47,7 @@ import { AiController } from "./presentation/ai.controller";
 		{ provide: AI_PROVIDER, useClass: AiRouterAdapter },
 		{ provide: AI_USAGE_REPOSITORY, useClass: PrismaAiUsageRepository },
 		{ provide: USER_CATEGORY_READER, useClass: TodoCategoryReaderAdapter },
-		...AiUseCases,
-		...AiQueryUseCases,
+		...AI_PROVIDERS,
 	],
 	exports: [AI_PROVIDER],
 })

--- a/apps/api/src/ai/application/ai.providers.ts
+++ b/apps/api/src/ai/application/ai.providers.ts
@@ -1,0 +1,5 @@
+import { GetAiUsageUseCase } from "./queries/get-ai-usage/get-ai-usage.use-case";
+import { ParseMemoUseCase } from "./use-cases/parse-memo/parse-memo.use-case";
+import { ParseTodoUseCase } from "./use-cases/parse-todo/parse-todo.use-case";
+
+export const AI_PROVIDERS = [ParseTodoUseCase, ParseMemoUseCase, GetAiUsageUseCase] as const;

--- a/apps/api/src/ai/application/queries/index.ts
+++ b/apps/api/src/ai/application/queries/index.ts
@@ -1,4 +1,1 @@
-import { GetAiUsageUseCase } from "./get-ai-usage/get-ai-usage.use-case";
-
-/** AI 쿼리 use-case (모듈 등록용 배럴). */
-export const AiQueryUseCases = [GetAiUsageUseCase];
+export * from "./get-ai-usage/get-ai-usage.use-case";

--- a/apps/api/src/ai/application/use-cases/index.ts
+++ b/apps/api/src/ai/application/use-cases/index.ts
@@ -1,5 +1,2 @@
-import { ParseMemoUseCase } from "./parse-memo/parse-memo.use-case";
-import { ParseTodoUseCase } from "./parse-todo/parse-todo.use-case";
-
-/** AI 커맨드 use-case (모듈 등록용 배럴). */
-export const AiUseCases = [ParseTodoUseCase, ParseMemoUseCase];
+export * from "./parse-memo/parse-memo.use-case";
+export * from "./parse-todo/parse-todo.use-case";

--- a/apps/api/src/app-config/app-config.module.ts
+++ b/apps/api/src/app-config/app-config.module.ts
@@ -1,14 +1,14 @@
 import { Module } from "@nestjs/common";
 
+import { APP_CONFIG_PROVIDERS } from "./application/app-config.providers";
 import { FEATURE_DISCOVERY_CONFIG } from "./application/ports/feature-discovery-config.port";
-import { AppConfigQueryUseCases } from "./application/queries";
 import { FeatureDiscoveryConfigAdapter } from "./infrastructure/adapters/feature-discovery-config.adapter";
 import { AppConfigController } from "./presentation/app-config.controller";
 
 @Module({
 	controllers: [AppConfigController],
 	providers: [
-		...AppConfigQueryUseCases,
+		...APP_CONFIG_PROVIDERS,
 		FeatureDiscoveryConfigAdapter,
 		{
 			provide: FEATURE_DISCOVERY_CONFIG,

--- a/apps/api/src/app-config/application/app-config.providers.ts
+++ b/apps/api/src/app-config/application/app-config.providers.ts
@@ -1,0 +1,3 @@
+import { GetFeatureDiscoveryUseCase } from "./queries/get-feature-discovery/get-feature-discovery.use-case";
+
+export const APP_CONFIG_PROVIDERS = [GetFeatureDiscoveryUseCase] as const;

--- a/apps/api/src/app-config/application/queries/index.ts
+++ b/apps/api/src/app-config/application/queries/index.ts
@@ -1,3 +1,1 @@
-import { GetFeatureDiscoveryUseCase } from "./get-feature-discovery/get-feature-discovery.use-case";
-
-export const AppConfigQueryUseCases = [GetFeatureDiscoveryUseCase];
+export * from "./get-feature-discovery/get-feature-discovery.use-case";

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -42,6 +42,7 @@ import { THROTTLER_STORAGE, ThrottleModule } from "@/shared/infrastructure/throt
 import { SubscriptionModule } from "@/subscription";
 import { TodoModule } from "@/todo";
 import { TodoCategoryModule } from "@/todo-category";
+import { TodoCommentModule } from "@/todo-comment";
 import { TimezoneSelfHealInterceptor, UserSettingsModule } from "@/user-settings";
 import { WeatherModule } from "@/weather/weather.module";
 import { WeeklyAchievementModule } from "@/weekly-achievement";
@@ -122,6 +123,7 @@ import { AppService } from "./app.service";
 		SchedulerModule,
 		SubscriptionModule,
 		TodoModule,
+		TodoCommentModule,
 		TodoCategoryModule,
 		UserSettingsModule,
 		WeatherModule,

--- a/apps/api/src/daily-completion/application/daily-completion.providers.ts
+++ b/apps/api/src/daily-completion/application/daily-completion.providers.ts
@@ -1,0 +1,7 @@
+import { GetDailyCompletionsUseCase } from "./queries/get-daily-completions/get-daily-completions.use-case";
+import { GetFriendDailyCompletionsUseCase } from "./queries/get-friend-daily-completions/get-friend-daily-completions.use-case";
+
+export const DAILY_COMPLETION_PROVIDERS = [
+	GetDailyCompletionsUseCase,
+	GetFriendDailyCompletionsUseCase,
+] as const;

--- a/apps/api/src/daily-completion/application/queries/index.ts
+++ b/apps/api/src/daily-completion/application/queries/index.ts
@@ -1,8 +1,2 @@
-import { GetDailyCompletionsUseCase } from "./get-daily-completions/get-daily-completions.use-case";
-import { GetFriendDailyCompletionsUseCase } from "./get-friend-daily-completions/get-friend-daily-completions.use-case";
-
-/** 모듈 등록용 쿼리 use-case 목록 */
-export const DailyCompletionQueryUseCases = [
-	GetDailyCompletionsUseCase,
-	GetFriendDailyCompletionsUseCase,
-];
+export * from "./get-daily-completions/get-daily-completions.use-case";
+export * from "./get-friend-daily-completions/get-friend-daily-completions.use-case";

--- a/apps/api/src/daily-completion/daily-completion.module.ts
+++ b/apps/api/src/daily-completion/daily-completion.module.ts
@@ -2,11 +2,11 @@ import { Module } from "@nestjs/common";
 
 import { FollowModule } from "@/follow";
 
+import { DAILY_COMPLETION_PROVIDERS } from "./application/daily-completion.providers";
 import { DailyCompletionCacheInvalidator } from "./application/events/daily-completion-cache.invalidator";
 import { DAILY_COMPLETION_CACHE } from "./application/ports/daily-completion-cache.port";
 import { FRIEND_PORT } from "./application/ports/friend.port";
 import { TODO_COMPLETION_REPOSITORY } from "./application/ports/todo-completion.repository.port";
-import { DailyCompletionQueryUseCases } from "./application/queries";
 import { DailyCompletionCacheAdapter } from "./infrastructure/adapters/daily-completion-cache.adapter";
 import { FriendAdapter } from "./infrastructure/adapters/friend.adapter";
 import { PrismaTodoCompletionRepository } from "./infrastructure/adapters/prisma-todo-completion.repository";
@@ -33,7 +33,7 @@ import { DailyCompletionController } from "./presentation/daily-completion.contr
 		},
 		{ provide: FRIEND_PORT, useClass: FriendAdapter },
 		DailyCompletionCacheInvalidator,
-		...DailyCompletionQueryUseCases,
+		...DAILY_COMPLETION_PROVIDERS,
 	],
 })
 export class DailyCompletionModule {}

--- a/apps/api/src/inquiry/application/inquiry.providers.ts
+++ b/apps/api/src/inquiry/application/inquiry.providers.ts
@@ -1,0 +1,3 @@
+import { CreateInquiryUseCase } from "./use-cases/create-inquiry/create-inquiry.use-case";
+
+export const INQUIRY_PROVIDERS = [CreateInquiryUseCase] as const;

--- a/apps/api/src/inquiry/application/use-cases/index.ts
+++ b/apps/api/src/inquiry/application/use-cases/index.ts
@@ -1,4 +1,1 @@
-import { CreateInquiryUseCase } from "./create-inquiry/create-inquiry.use-case";
-
-/** 모듈 등록용 use-case 목록 */
-export const InquiryUseCases = [CreateInquiryUseCase];
+export * from "./create-inquiry/create-inquiry.use-case";

--- a/apps/api/src/inquiry/inquiry.module.ts
+++ b/apps/api/src/inquiry/inquiry.module.ts
@@ -2,8 +2,8 @@ import { Module } from "@nestjs/common";
 
 import { EmailModule } from "@/email/email.module";
 
+import { INQUIRY_PROVIDERS } from "./application/inquiry.providers";
 import { INQUIRY_MAILER } from "./application/ports/inquiry-mailer.port";
-import { InquiryUseCases } from "./application/use-cases";
 import { EmailInquiryMailerAdapter } from "./infrastructure/adapters/email-inquiry-mailer.adapter";
 import { InquiryController } from "./presentation/inquiry.controller";
 
@@ -16,6 +16,9 @@ import { InquiryController } from "./presentation/inquiry.controller";
 @Module({
 	imports: [EmailModule],
 	controllers: [InquiryController],
-	providers: [{ provide: INQUIRY_MAILER, useClass: EmailInquiryMailerAdapter }, ...InquiryUseCases],
+	providers: [
+		{ provide: INQUIRY_MAILER, useClass: EmailInquiryMailerAdapter },
+		...INQUIRY_PROVIDERS,
+	],
 })
 export class InquiryModule {}

--- a/apps/api/src/memo/application/memo.providers.ts
+++ b/apps/api/src/memo/application/memo.providers.ts
@@ -1,0 +1,23 @@
+import { GetMemoResourceLimitUseCase } from "./queries/get-memo-resource-limit/get-memo-resource-limit.use-case";
+import { GetMemoUseCase } from "./queries/get-memo/get-memo.use-case";
+import { GetMemosUseCase } from "./queries/get-memos/get-memos.use-case";
+import { ConvertMemoToTodoUseCase } from "./use-cases/convert-memo-to-todo/convert-memo-to-todo.use-case";
+import { ConvertMemoToTodosUseCase } from "./use-cases/convert-memo-to-todos/convert-memo-to-todos.use-case";
+import { CreateMemoUseCase } from "./use-cases/create-memo/create-memo.use-case";
+import { DeleteMemoUseCase } from "./use-cases/delete-memo/delete-memo.use-case";
+import { ReorderMemoUseCase } from "./use-cases/reorder-memo/reorder-memo.use-case";
+import { ToggleMemoPinUseCase } from "./use-cases/toggle-memo-pin/toggle-memo-pin.use-case";
+import { UpdateMemoUseCase } from "./use-cases/update-memo/update-memo.use-case";
+
+export const MEMO_PROVIDERS = [
+	CreateMemoUseCase,
+	UpdateMemoUseCase,
+	ToggleMemoPinUseCase,
+	ReorderMemoUseCase,
+	DeleteMemoUseCase,
+	ConvertMemoToTodoUseCase,
+	ConvertMemoToTodosUseCase,
+	GetMemoUseCase,
+	GetMemosUseCase,
+	GetMemoResourceLimitUseCase,
+] as const;

--- a/apps/api/src/memo/application/queries/index.ts
+++ b/apps/api/src/memo/application/queries/index.ts
@@ -1,8 +1,3 @@
-import { GetMemoResourceLimitUseCase } from "./get-memo-resource-limit/get-memo-resource-limit.use-case";
-import { GetMemoUseCase } from "./get-memo/get-memo.use-case";
-import { GetMemosUseCase } from "./get-memos/get-memos.use-case";
-
-export { GetMemoResourceLimitUseCase, GetMemosUseCase, GetMemoUseCase };
-
-/** 메모 쿼리 use-case (모듈 등록용 배럴). */
-export const MemoQueryUseCases = [GetMemoUseCase, GetMemosUseCase, GetMemoResourceLimitUseCase];
+export * from "./get-memo-resource-limit/get-memo-resource-limit.use-case";
+export * from "./get-memo/get-memo.use-case";
+export * from "./get-memos/get-memos.use-case";

--- a/apps/api/src/memo/application/use-cases/convert-memo-to-todo/convert-memo-to-todo.use-case.spec.ts
+++ b/apps/api/src/memo/application/use-cases/convert-memo-to-todo/convert-memo-to-todo.use-case.spec.ts
@@ -43,6 +43,7 @@ const todoView = (id: number): Todo => ({
 	category: { id: 5, name: "기본", color: "#FFB3B3", sortOrder: 0 },
 	items: [],
 	itemStats: { total: 0, completed: 0 },
+	commentCount: 0,
 	createdAt: "2026-04-06T00:00:00.000Z",
 	updatedAt: "2026-04-06T00:00:00.000Z",
 });

--- a/apps/api/src/memo/application/use-cases/convert-memo-to-todos/convert-memo-to-todos.use-case.spec.ts
+++ b/apps/api/src/memo/application/use-cases/convert-memo-to-todos/convert-memo-to-todos.use-case.spec.ts
@@ -49,6 +49,7 @@ const todoView = (id: number): Todo => ({
 	category: { id: 5, name: "기본", color: "#FFB3B3", sortOrder: 0 },
 	items: [],
 	itemStats: { total: 0, completed: 0 },
+	commentCount: 0,
 	createdAt: "2026-04-06T00:00:00.000Z",
 	updatedAt: "2026-04-06T00:00:00.000Z",
 });

--- a/apps/api/src/memo/application/use-cases/index.ts
+++ b/apps/api/src/memo/application/use-cases/index.ts
@@ -1,28 +1,7 @@
-import { ConvertMemoToTodoUseCase } from "./convert-memo-to-todo/convert-memo-to-todo.use-case";
-import { ConvertMemoToTodosUseCase } from "./convert-memo-to-todos/convert-memo-to-todos.use-case";
-import { CreateMemoUseCase } from "./create-memo/create-memo.use-case";
-import { DeleteMemoUseCase } from "./delete-memo/delete-memo.use-case";
-import { ReorderMemoUseCase } from "./reorder-memo/reorder-memo.use-case";
-import { ToggleMemoPinUseCase } from "./toggle-memo-pin/toggle-memo-pin.use-case";
-import { UpdateMemoUseCase } from "./update-memo/update-memo.use-case";
-
-export {
-	ConvertMemoToTodosUseCase,
-	ConvertMemoToTodoUseCase,
-	CreateMemoUseCase,
-	DeleteMemoUseCase,
-	ReorderMemoUseCase,
-	ToggleMemoPinUseCase,
-	UpdateMemoUseCase,
-};
-
-/** 메모 커맨드 use-case (모듈 등록용 배럴). */
-export const MemoUseCases = [
-	CreateMemoUseCase,
-	UpdateMemoUseCase,
-	ToggleMemoPinUseCase,
-	ReorderMemoUseCase,
-	DeleteMemoUseCase,
-	ConvertMemoToTodoUseCase,
-	ConvertMemoToTodosUseCase,
-];
+export * from "./convert-memo-to-todo/convert-memo-to-todo.use-case";
+export * from "./convert-memo-to-todos/convert-memo-to-todos.use-case";
+export * from "./create-memo/create-memo.use-case";
+export * from "./delete-memo/delete-memo.use-case";
+export * from "./reorder-memo/reorder-memo.use-case";
+export * from "./toggle-memo-pin/toggle-memo-pin.use-case";
+export * from "./update-memo/update-memo.use-case";

--- a/apps/api/src/memo/memo.module.ts
+++ b/apps/api/src/memo/memo.module.ts
@@ -12,10 +12,9 @@
 import { Module } from "@nestjs/common";
 
 import { TodoModule } from "../todo/todo.module";
+import { MEMO_PROVIDERS } from "./application/memo.providers";
 import { MEMO_REPOSITORY } from "./application/ports/memo.repository.port";
 import { TODO_CREATOR } from "./application/ports/todo-creator.port";
-import { MemoQueryUseCases } from "./application/queries";
-import { MemoUseCases } from "./application/use-cases";
 import { TodoCreatorAdapter } from "./infrastructure/adapters/todo-creator.adapter";
 import { PrismaMemoRepository } from "./infrastructure/persistence/prisma-memo.repository";
 import { MemoController } from "./presentation/memo.controller";
@@ -26,8 +25,7 @@ import { MemoController } from "./presentation/memo.controller";
 	providers: [
 		{ provide: MEMO_REPOSITORY, useClass: PrismaMemoRepository },
 		{ provide: TODO_CREATOR, useClass: TodoCreatorAdapter },
-		...MemoUseCases,
-		...MemoQueryUseCases,
+		...MEMO_PROVIDERS,
 	],
 })
 export class MemoModule {}

--- a/apps/api/src/notification/domain/services/templates/locales/en.ts
+++ b/apps/api/src/notification/domain/services/templates/locales/en.ts
@@ -1,6 +1,8 @@
 import type { NotificationType } from "../../../types/notification-type";
 import type { NotificationTemplate, WeatherFallbackTemplates } from "../template.types";
 
+export const SOCIAL_SENDER_FALLBACK = "A friend";
+
 // English templates — same keys/variants as ko.ts (parity is unit-tested).
 // No josa placeholders ({name:이/가}) — plain {name} substitution only.
 
@@ -616,6 +618,36 @@ export const SOCIAL_TEMPLATES = {
 				body: "One nudge might bring them back?",
 			},
 		],
+	} satisfies NotificationTemplate,
+	TODO_COMMENT: {
+		title: "New comment",
+		body: "{senderName} commented on a todo.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_CHAIN: {
+		title: "New comment",
+		body: "{senderName} left {count} comments on a todo.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_REPLY: {
+		title: "New reply",
+		body: "{senderName} replied to your comment.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_REPLY_CHAIN: {
+		title: "New reply",
+		body: "{senderName} left {count} replies to your comment.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_LIKE: {
+		title: "Comment liked",
+		body: "{senderName} liked your comment.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
 	} satisfies NotificationTemplate,
 } as const;
 

--- a/apps/api/src/notification/domain/services/templates/locales/ko.ts
+++ b/apps/api/src/notification/domain/services/templates/locales/ko.ts
@@ -1,6 +1,8 @@
 import type { NotificationType } from "../../../types/notification-type";
 import type { NotificationTemplate, WeatherFallbackTemplates } from "../template.types";
 
+export const SOCIAL_SENDER_FALLBACK = "친구";
+
 export const SCHEDULER_TEMPLATES = {
 	TODO_REMINDER: {
 		title: "⏰ {todoTitle}, 1시간 뒤 시작!",
@@ -574,6 +576,36 @@ export const SOCIAL_TEMPLATES = {
 				body: "가볍게 안부를 보내볼까?",
 			},
 		],
+	} satisfies NotificationTemplate,
+	TODO_COMMENT: {
+		title: "새 댓글",
+		body: "{senderName:이/가} 할 일에 댓글을 남겼어요.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_CHAIN: {
+		title: "새 댓글",
+		body: "{senderName:이/가} 할 일에 댓글 {count}개를 남겼어요.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_REPLY: {
+		title: "새 답글",
+		body: "{senderName:이/가} 댓글에 답글을 남겼어요.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_REPLY_CHAIN: {
+		title: "새 답글",
+		body: "{senderName:이/가} 댓글에 답글 {count}개를 남겼어요.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
+	} satisfies NotificationTemplate,
+	TODO_COMMENT_LIKE: {
+		title: "댓글 좋아요",
+		body: "{senderName:이/가} 댓글을 좋아해요.",
+		type: "TODO_SHARED",
+		defaultRoute: "/todo/{todoId}",
 	} satisfies NotificationTemplate,
 } as const;
 

--- a/apps/api/src/notification/domain/services/templates/notification-templates.ts
+++ b/apps/api/src/notification/domain/services/templates/notification-templates.ts
@@ -198,6 +198,37 @@ function fillMessage(
  * locale 미전달 호출은 기존과 완전히 동일하게 동작한다 (하위 호환).
  */
 export class NotificationMessageBuilder {
+	static todoCommentActivity(
+		kind: "COMMENT" | "REPLY" | "LIKE",
+		senderName: string | null,
+		locale: SupportedLocale = DEFAULT_LOCALE,
+		count = 1,
+	): { title: string; body: string } {
+		const templates = LOCALE_TEMPLATES[locale].SOCIAL_TEMPLATES;
+		// 한 번에 여러 개를 이어 썼으면 알림 한 건에 개수를 담아 알린다.
+		const isChain = count > 1;
+		let template: NotificationTemplate;
+
+		switch (kind) {
+			case "COMMENT":
+				template = isChain ? templates.TODO_COMMENT_CHAIN : templates.TODO_COMMENT;
+				break;
+			case "REPLY":
+				template = isChain ? templates.TODO_COMMENT_REPLY_CHAIN : templates.TODO_COMMENT_REPLY;
+				break;
+			case "LIKE":
+				template = templates.TODO_COMMENT_LIKE;
+				break;
+		}
+		const displayName = senderName?.trim() || LOCALE_TEMPLATES[locale].SOCIAL_SENDER_FALLBACK;
+		const values = { senderName: displayName, count: String(count) };
+
+		return {
+			title: fillTemplate(template.title, values),
+			body: fillTemplate(template.body, values),
+		};
+	}
+
 	/**
 	 * 팔로우 요청 알림 메시지 생성
 	 */

--- a/apps/api/src/todo-comment/application/assert-todo-comment-access.ts
+++ b/apps/api/src/todo-comment/application/assert-todo-comment-access.ts
@@ -1,0 +1,17 @@
+import { ErrorCode } from "@aido/errors";
+
+import { ApplicationException } from "@/shared/domain";
+
+import type { TodoCommentRepositoryPort } from "./ports/todo-comment.repository.port";
+
+export async function assertTodoCommentAccess(
+	repository: TodoCommentRepositoryPort,
+	todoId: number,
+	viewerId: string,
+): Promise<void> {
+	const canAccess = await repository.canAccessTodo(todoId, viewerId);
+
+	if (!canAccess) {
+		throw new ApplicationException(ErrorCode.TODO_0801, { todoId });
+	}
+}

--- a/apps/api/src/todo-comment/application/ports/todo-comment-cache.port.ts
+++ b/apps/api/src/todo-comment/application/ports/todo-comment-cache.port.ts
@@ -1,0 +1,18 @@
+import type { TodoCommentSort } from "@aido/validators";
+
+import type { PaginatedTodoCommentRecords } from "../types";
+
+export const TODO_COMMENT_CACHE = Symbol("TODO_COMMENT_CACHE");
+
+export interface TodoCommentCachePort {
+	getTopLevelFirstPage(
+		todoId: number,
+		sort: TodoCommentSort,
+	): Promise<PaginatedTodoCommentRecords | undefined>;
+	setTopLevelFirstPage(
+		todoId: number,
+		sort: TodoCommentSort,
+		page: PaginatedTodoCommentRecords,
+	): Promise<void>;
+	invalidateTopLevelFirstPages(todoId: number): Promise<void>;
+}

--- a/apps/api/src/todo-comment/application/ports/todo-comment-notification.port.ts
+++ b/apps/api/src/todo-comment/application/ports/todo-comment-notification.port.ts
@@ -1,0 +1,23 @@
+export const TODO_COMMENT_NOTIFICATION = Symbol("TODO_COMMENT_NOTIFICATION");
+
+interface TodoCommentNotificationInput {
+	recipientId: string;
+	senderId: string;
+	senderName: string | null;
+	todoId: number;
+	commentId: string;
+	/** 이 댓글이 속한 대화의 뿌리 */
+	threadRootId: string;
+}
+
+export interface TodoCommentWrittenInput extends TodoCommentNotificationInput {
+	/** 댓글인지 답글인지 — 받는 사람이 할 일 주인인지 부모 댓글 작성자인지와 짝을 이룬다. */
+	isReply: boolean;
+	/** 한 번에 이어 쓴 글 수. 여러 개여도 알림은 한 건이고, 개수는 문구가 말한다. */
+	count: number;
+}
+
+export interface TodoCommentNotificationPort {
+	notifyCommentsWritten(input: TodoCommentWrittenInput): Promise<void>;
+	notifyCommentLiked(input: TodoCommentNotificationInput): Promise<void>;
+}

--- a/apps/api/src/todo-comment/application/ports/todo-comment.repository.port.ts
+++ b/apps/api/src/todo-comment/application/ports/todo-comment.repository.port.ts
@@ -1,0 +1,43 @@
+import type { TodoComment } from "../../domain/entities/todo-comment.aggregate";
+import type {
+	CreateTodoCommentChainInput,
+	ListTodoCommentsParams,
+	TodoCommentChainCreationResult,
+	TodoCommentLikeTransition,
+	PaginatedTodoCommentRecords,
+	TodoCommentRecord,
+	TodoDetailsRecord,
+} from "../types";
+
+export const TODO_COMMENT_REPOSITORY = Symbol("TODO_COMMENT_REPOSITORY");
+
+export interface TodoCommentRepositoryPort {
+	findAccessibleTodoDetails(todoId: number, viewerId: string): Promise<TodoDetailsRecord | null>;
+	canAccessTodo(todoId: number, viewerId: string): Promise<boolean>;
+	findComment(todoId: number, commentId: string): Promise<TodoComment | null>;
+	findCommentRecord(todoId: number, commentId: string): Promise<TodoCommentRecord | null>;
+	/** parentId가 null이면 최상위 댓글 목록, 값이 있으면 그 댓글의 직계 답글 목록이다. */
+	listComments(params: ListTodoCommentsParams): Promise<PaginatedTodoCommentRecords>;
+	/** 뿌리 → 부모 순서의 조상. path가 비면 빈 배열을 돌려준다. */
+	findAncestors(todoId: number, path: readonly string[]): Promise<TodoCommentRecord[]>;
+	findLikedCommentIds(commentIds: readonly string[], viewerId: string): Promise<Set<string>>;
+	findUserDisplayName(userId: string): Promise<string | null>;
+	/** 사슬을 한 번에 심는다 — 글마다 왕복하지 않도록 저장소가 통째로 맡는다. */
+	createCommentChain(input: CreateTodoCommentChainInput): Promise<TodoCommentChainCreationResult>;
+	updateComment(comment: TodoComment): Promise<void>;
+	deleteComment(comment: TodoComment): Promise<void>;
+	/** 사슬 길이만큼 한 번에 올린다. */
+	increaseTodoCommentCount(todoId: number, amount: number): Promise<void>;
+	decrementTodoCommentCount(todoId: number): Promise<void>;
+	incrementReplyCount(parentId: string): Promise<void>;
+	/**
+	 * 삭제된 댓글이 목록에서 사라진 만큼 조상의 답글 수를 줄인다.
+	 * 답글이 남은 댓글은 묘비로 자리를 지키므로 사라짐이 거기서 멈춘다.
+	 */
+	dropDeletedFromAncestors(commentId: string, path: readonly string[]): Promise<void>;
+	setLike(todoId: number, commentId: string, userId: string): Promise<TodoCommentLikeTransition>;
+	/** 좋아요 알림을 보낸 사실을 남긴다 — 껐다 켜도 다시 알리지 않기 위한 도장이다. */
+	markLikeNotified(commentId: string, userId: string): Promise<void>;
+	removeLike(todoId: number, commentId: string, userId: string): Promise<TodoCommentLikeTransition>;
+	recordView(todoId: number, viewerId: string): Promise<{ recorded: boolean; viewCount: number }>;
+}

--- a/apps/api/src/todo-comment/application/queries/get-todo-comment-thread/get-todo-comment-thread.use-case.ts
+++ b/apps/api/src/todo-comment/application/queries/get-todo-comment-thread/get-todo-comment-thread.use-case.ts
@@ -1,0 +1,57 @@
+import { ErrorCode } from "@aido/errors";
+import type { TodoCommentThreadResponse } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { ApplicationException } from "@/shared/domain";
+
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+import {
+	collectCommentIds,
+	toTodoCommentPreviewResponse,
+	toTodoCommentResponse,
+} from "../../types";
+
+export interface GetTodoCommentThreadInput {
+	todoId: number;
+	commentId: string;
+	viewerId: string;
+}
+
+/**
+ * 스레드 화면의 머리말 — 조상 사슬(뿌리 → 부모)과 지금 보는 댓글.
+ * 정렬과 무관한 값만 담아 정렬을 바꿔도 다시 만들지 않는다.
+ */
+@Injectable()
+export class GetTodoCommentThreadUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+	) {}
+
+	async execute(input: GetTodoCommentThreadInput): Promise<TodoCommentThreadResponse> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.viewerId);
+		const comment = await this.repository.findCommentRecord(input.todoId, input.commentId);
+
+		if (comment === null) {
+			throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.commentId });
+		}
+
+		// 조상은 path 덕분에 깊이와 무관하게 한 번에 읽힌다.
+		const ancestors = await this.repository.findAncestors(input.todoId, comment.path);
+		const likedCommentIds = await this.repository.findLikedCommentIds(
+			collectCommentIds([comment, ...ancestors]),
+			input.viewerId,
+		);
+
+		return {
+			ancestors: ancestors.map((ancestor) =>
+				toTodoCommentPreviewResponse(ancestor, input.viewerId, likedCommentIds),
+			),
+			comment: toTodoCommentResponse(comment, input.viewerId, likedCommentIds),
+		};
+	}
+}

--- a/apps/api/src/todo-comment/application/queries/get-todo-details/get-todo-details.use-case.ts
+++ b/apps/api/src/todo-comment/application/queries/get-todo-details/get-todo-details.use-case.ts
@@ -1,0 +1,57 @@
+import { ErrorCode } from "@aido/errors";
+import type { TodoDetailsResponse } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import { ApplicationException } from "@/shared/domain";
+
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+
+export interface GetTodoDetailsInput {
+	todoId: number;
+	viewerId: string;
+}
+
+@Injectable()
+export class GetTodoDetailsUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly todoCommentRepository: TodoCommentRepositoryPort,
+		@Inject(UNIT_OF_WORK)
+		private readonly unitOfWork: UnitOfWorkPort,
+	) {}
+
+	async execute(input: GetTodoDetailsInput): Promise<TodoDetailsResponse> {
+		return this.unitOfWork.run(async () => {
+			const todoDetails = await this.todoCommentRepository.findAccessibleTodoDetails(
+				input.todoId,
+				input.viewerId,
+			);
+
+			if (todoDetails === null) {
+				throw new ApplicationException(ErrorCode.TODO_0801, { todoId: input.todoId });
+			}
+
+			const viewCount = todoDetails.isOwner
+				? todoDetails.viewCount
+				: (await this.todoCommentRepository.recordView(input.todoId, input.viewerId)).viewCount;
+
+			return {
+				todo: todoDetails.todo,
+				owner: todoDetails.owner,
+				permissions: {
+					canEdit: todoDetails.isOwner,
+					canComment: true,
+					canNudge: !todoDetails.isOwner,
+				},
+				metrics: {
+					viewCount,
+					commentCount: todoDetails.commentCount,
+				},
+			};
+		});
+	}
+}

--- a/apps/api/src/todo-comment/application/queries/index.ts
+++ b/apps/api/src/todo-comment/application/queries/index.ts
@@ -1,0 +1,4 @@
+export * from "./get-todo-comment-thread/get-todo-comment-thread.use-case";
+export * from "./get-todo-details/get-todo-details.use-case";
+export * from "./list-todo-comment-replies/list-todo-comment-replies.use-case";
+export * from "./list-todo-comments/list-todo-comments.use-case";

--- a/apps/api/src/todo-comment/application/queries/list-todo-comment-replies/list-todo-comment-replies.use-case.ts
+++ b/apps/api/src/todo-comment/application/queries/list-todo-comment-replies/list-todo-comment-replies.use-case.ts
@@ -1,0 +1,54 @@
+import { ErrorCode } from "@aido/errors";
+import type { PaginatedTodoComments, TodoCommentSort } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { ApplicationException } from "@/shared/domain";
+
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+import { decodeTodoCommentCursor } from "../../todo-comment-cursor";
+import { collectCommentIds, toPaginatedTodoComments } from "../../types";
+
+export interface ListTodoCommentRepliesInput {
+	todoId: number;
+	commentId: string;
+	viewerId: string;
+	sort: TodoCommentSort;
+	size: number;
+	cursor?: string;
+}
+
+/** 어떤 깊이의 댓글이든 그 댓글의 직계 답글 목록. 최상위 목록과 같은 모양·같은 커서를 쓴다. */
+@Injectable()
+export class ListTodoCommentRepliesUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+	) {}
+
+	async execute(input: ListTodoCommentRepliesInput): Promise<PaginatedTodoComments> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.viewerId);
+		const parent = await this.repository.findCommentRecord(input.todoId, input.commentId);
+
+		if (parent === null) {
+			throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.commentId });
+		}
+
+		const page = await this.repository.listComments({
+			todoId: input.todoId,
+			parentId: input.commentId,
+			sort: input.sort,
+			size: input.size,
+			cursor: decodeTodoCommentCursor(input.cursor, input.sort),
+		});
+		const likedCommentIds = await this.repository.findLikedCommentIds(
+			collectCommentIds(page.items),
+			input.viewerId,
+		);
+
+		return toPaginatedTodoComments(page, input.viewerId, likedCommentIds);
+	}
+}

--- a/apps/api/src/todo-comment/application/queries/list-todo-comments/list-todo-comments.use-case.ts
+++ b/apps/api/src/todo-comment/application/queries/list-todo-comments/list-todo-comments.use-case.ts
@@ -1,0 +1,65 @@
+import {
+	TODO_COMMENT_LIMITS,
+	type PaginatedTodoComments,
+	type TodoCommentSort,
+} from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import { TODO_COMMENT_CACHE, type TodoCommentCachePort } from "../../ports/todo-comment-cache.port";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+import { decodeTodoCommentCursor } from "../../todo-comment-cursor";
+import { collectCommentIds, toPaginatedTodoComments } from "../../types";
+
+export interface ListTodoCommentsInput {
+	todoId: number;
+	viewerId: string;
+	sort: TodoCommentSort;
+	size: number;
+	cursor?: string;
+}
+
+/** 할 일에 바로 달린 최상위 댓글 목록. 각 댓글은 답글 미리보기를 한 겹 함께 싣는다. */
+@Injectable()
+export class ListTodoCommentsUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+		@Inject(TODO_COMMENT_CACHE)
+		private readonly cache: TodoCommentCachePort,
+	) {}
+
+	async execute(input: ListTodoCommentsInput): Promise<PaginatedTodoComments> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.viewerId);
+
+		const isCacheable =
+			input.cursor === undefined && input.size === TODO_COMMENT_LIMITS.DEFAULT_PAGE_SIZE;
+		const cachedPage = isCacheable
+			? await this.cache.getTopLevelFirstPage(input.todoId, input.sort)
+			: undefined;
+		const page =
+			cachedPage ??
+			(await this.repository.listComments({
+				todoId: input.todoId,
+				parentId: null,
+				sort: input.sort,
+				size: input.size,
+				cursor: decodeTodoCommentCursor(input.cursor, input.sort),
+			}));
+
+		if (isCacheable && cachedPage === undefined) {
+			await this.cache.setTopLevelFirstPage(input.todoId, input.sort, page);
+		}
+
+		// 좋아요 여부는 캐시에 담지 않고 미리보기까지 한 번의 조회로 붙인다.
+		const likedCommentIds = await this.repository.findLikedCommentIds(
+			collectCommentIds(page.items),
+			input.viewerId,
+		);
+
+		return toPaginatedTodoComments(page, input.viewerId, likedCommentIds);
+	}
+}

--- a/apps/api/src/todo-comment/application/todo-comment-cursor.spec.ts
+++ b/apps/api/src/todo-comment/application/todo-comment-cursor.spec.ts
@@ -1,0 +1,64 @@
+import { TODO_COMMENT_SORT } from "@aido/validators";
+
+import { decodeTodoCommentCursor, encodeTodoCommentCursor } from "./todo-comment-cursor";
+import type { TodoCommentRecord } from "./types";
+
+const record: TodoCommentRecord = {
+	id: "cm1todoacomment00000000001",
+	todoId: 1,
+	parentId: null,
+	rootId: null,
+	path: [],
+	depth: 0,
+	parentAuthorName: null,
+	authorId: "cm1author0000000000000001",
+	authorName: "작성자",
+	authorProfileImage: null,
+	todoOwnerId: "cm1author0000000000000001",
+	content: "댓글",
+	likeCount: 3,
+	replyCount: 2,
+	deletedAt: null,
+	editedAt: null,
+	createdAt: "2026-08-14T00:00:00.000Z",
+	children: [],
+};
+
+describe("Todo 댓글 cursor", () => {
+	it.each([TODO_COMMENT_SORT.LATEST, TODO_COMMENT_SORT.POPULAR])(
+		"%s cursor를 손실 없이 복원한다",
+		(sort) => {
+			const cursor = encodeTodoCommentCursor(record, sort);
+
+			expect(decodeTodoCommentCursor(cursor, sort)).toMatchObject({
+				sort,
+				id: record.id,
+			});
+		},
+	);
+
+	it("정렬 종류가 다른 cursor를 거부한다", () => {
+		const cursor = encodeTodoCommentCursor(record, TODO_COMMENT_SORT.LATEST);
+
+		expect(() => decodeTodoCommentCursor(cursor, TODO_COMMENT_SORT.POPULAR)).toThrow();
+	});
+
+	it("어느 깊이의 답글이든 최상위와 같은 cursor 계약을 쓴다", () => {
+		const reply: TodoCommentRecord = {
+			...record,
+			id: "cm1todoacomment00000000002",
+			parentId: record.id,
+			rootId: record.id,
+			path: [record.id],
+			depth: 1,
+		};
+		const cursor = encodeTodoCommentCursor(reply, TODO_COMMENT_SORT.POPULAR);
+
+		expect(decodeTodoCommentCursor(cursor, TODO_COMMENT_SORT.POPULAR)).toMatchObject({
+			sort: TODO_COMMENT_SORT.POPULAR,
+			id: reply.id,
+			likeCount: reply.likeCount,
+			replyCount: reply.replyCount,
+		});
+	});
+});

--- a/apps/api/src/todo-comment/application/todo-comment-cursor.ts
+++ b/apps/api/src/todo-comment/application/todo-comment-cursor.ts
@@ -1,0 +1,73 @@
+import { ErrorCode } from "@aido/errors";
+import { TODO_COMMENT_SORT, z, type TodoCommentSort } from "@aido/validators";
+
+import { ApplicationException } from "@/shared/domain";
+
+import type { TodoCommentCursor, TodoCommentRecord } from "./types";
+
+const latestCursorSchema = z.object({
+	v: z.literal(1),
+	sort: z.literal(TODO_COMMENT_SORT.LATEST),
+	createdAt: z.iso.datetime(),
+	id: z.cuid(),
+});
+
+const popularCursorSchema = z.object({
+	v: z.literal(1),
+	sort: z.literal(TODO_COMMENT_SORT.POPULAR),
+	likeCount: z.number().int().nonnegative(),
+	replyCount: z.number().int().nonnegative(),
+	createdAt: z.iso.datetime(),
+	id: z.cuid(),
+});
+
+const cursorSchema = z.discriminatedUnion("sort", [latestCursorSchema, popularCursorSchema]);
+
+function encode(value: unknown): string {
+	return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function decode(cursor: string): unknown {
+	try {
+		return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+	} catch {
+		throw new ApplicationException(ErrorCode.SYS_0002, { cursor: "invalid" });
+	}
+}
+
+export function decodeTodoCommentCursor(
+	cursor: string | undefined,
+	sort: TodoCommentSort,
+): TodoCommentCursor | undefined {
+	if (cursor === undefined) {
+		return undefined;
+	}
+
+	const parsedCursor = cursorSchema.safeParse(decode(cursor));
+
+	if (!parsedCursor.success || parsedCursor.data.sort !== sort) {
+		throw new ApplicationException(ErrorCode.SYS_0002, { cursor: "invalid" });
+	}
+
+	return parsedCursor.data;
+}
+
+export function encodeTodoCommentCursor(record: TodoCommentRecord, sort: TodoCommentSort): string {
+	if (sort === TODO_COMMENT_SORT.LATEST) {
+		return encode({
+			v: 1,
+			sort,
+			createdAt: record.createdAt,
+			id: record.id,
+		});
+	}
+
+	return encode({
+		v: 1,
+		sort,
+		likeCount: record.likeCount,
+		replyCount: record.replyCount,
+		createdAt: record.createdAt,
+		id: record.id,
+	});
+}

--- a/apps/api/src/todo-comment/application/types.ts
+++ b/apps/api/src/todo-comment/application/types.ts
@@ -1,0 +1,195 @@
+import { TODO_COMMENT_LIMITS } from "@aido/validators";
+import type {
+	PaginatedTodoComments,
+	Todo,
+	TodoComment,
+	TodoCommentPreview,
+	TodoCommentSort,
+	TodoDetailsResponse,
+} from "@aido/validators";
+
+import type { ThreadPlacement } from "../domain/value-objects/thread-placement.vo";
+
+/**
+ * 댓글 한 건의 읽기 모델.
+ * 최상위 댓글과 답글은 같은 모양이고 parentId가 있느냐로만 갈린다.
+ */
+export interface TodoCommentRecord {
+	id: string;
+	todoId: number;
+	/** 직계 부모. null이면 최상위 댓글 */
+	parentId: string | null;
+	/** 대화의 뿌리. 최상위 댓글이면 null */
+	rootId: string | null;
+	/** 뿌리 → 부모 순서의 조상 id */
+	path: string[];
+	depth: number;
+	/** @멘션에 쓸 부모 작성자 이름 */
+	parentAuthorName: string | null;
+	authorId: string;
+	authorName: string | null;
+	authorProfileImage: string | null;
+	todoOwnerId: string;
+	content: string | null;
+	likeCount: number;
+	/** 직계 자식 수 */
+	replyCount: number;
+	deletedAt: string | null;
+	editedAt: string | null;
+	createdAt: string;
+	/** 함께 실어 보낼 직계 자식 (목록은 한 겹만 채운다) */
+	children: TodoCommentRecord[];
+}
+
+export interface PaginatedTodoCommentRecords {
+	items: TodoCommentRecord[];
+	nextCursor: string | null;
+	hasNext: boolean;
+	size: number;
+}
+
+export interface TodoDetailsRecord {
+	todo: Todo;
+	owner: TodoDetailsResponse["owner"];
+	viewCount: number;
+	commentCount: number;
+	isOwner: boolean;
+}
+
+export type LatestTodoCommentCursor = {
+	v: 1;
+	sort: "LATEST";
+	createdAt: string;
+	id: string;
+};
+
+export type PopularTodoCommentCursor = {
+	v: 1;
+	sort: "POPULAR";
+	likeCount: number;
+	replyCount: number;
+	createdAt: string;
+	id: string;
+};
+
+export type TodoCommentCursor = LatestTodoCommentCursor | PopularTodoCommentCursor;
+
+/** parentId가 null이면 최상위 댓글 목록, 값이 있으면 그 댓글의 직계 답글 목록이다. */
+export interface ListTodoCommentsParams {
+	todoId: number;
+	parentId: string | null;
+	sort: TodoCommentSort;
+	size: number;
+	cursor?: TodoCommentCursor;
+}
+
+export interface CreateTodoCommentChainInput {
+	todoId: number;
+	authorId: string;
+	/** 사슬이 매달릴 자리. 첫 글이 여기 놓이고 나머지는 앞 글 아래로 이어진다. */
+	placement: ThreadPlacement;
+	items: { clientRequestId: string; content: string }[];
+}
+
+export interface TodoCommentChainCreationResult {
+	comments: TodoCommentRecord[];
+	/** 이번 요청으로 새로 생긴 글 수. 재시도로 전부 이미 있으면 0이다. */
+	createdCount: number;
+}
+
+export interface TodoCommentLikeTransition {
+	commentId: string;
+	commentAuthorId: string;
+	changed: boolean;
+	isLiked: boolean;
+	likeCount: number;
+	wasEverNotified: boolean;
+}
+
+/**
+ * 댓글 한 건. 어느 깊이에 있든 같은 모양이다.
+ * 자기 답글은 개수로만 알리고, 답글 미리보기는 이 댓글을 감싸는 목록 노드가 채운다.
+ */
+export function toTodoCommentPreviewResponse(
+	record: TodoCommentRecord,
+	viewerId: string,
+	likedCommentIds: ReadonlySet<string>,
+): TodoCommentPreview {
+	const isDeleted = record.deletedAt !== null;
+	const canEdit = !isDeleted && record.authorId === viewerId;
+
+	return {
+		id: record.id,
+		todoId: record.todoId,
+		parentId: record.parentId,
+		rootId: record.rootId,
+		depth: record.depth,
+		author: isDeleted
+			? null
+			: {
+					id: record.authorId,
+					name: record.authorName,
+					profileImage: record.authorProfileImage,
+					isTodoOwner: record.authorId === record.todoOwnerId,
+				},
+		content: isDeleted ? null : record.content,
+		isDeleted,
+		isEdited: record.editedAt !== null,
+		likeCount: isDeleted ? 0 : record.likeCount,
+		replyCount: record.replyCount,
+		hasReplies: record.replyCount > 0,
+		// 미리보기를 싣지 못하는 자리라 답글이 있으면 전부 다음 화면에 있다.
+		hasMoreReplies: record.replyCount > 0,
+		replyTo:
+			record.parentId === null
+				? null
+				: { commentId: record.parentId, authorName: record.parentAuthorName },
+		viewer: {
+			isLiked: !isDeleted && likedCommentIds.has(record.id),
+			canEdit,
+			canDelete: canEdit,
+			canReply: !isDeleted,
+		},
+		createdAt: record.createdAt,
+		editedAt: record.editedAt,
+	};
+}
+
+/** 목록에 실리는 댓글. 직계 자식을 한 겹만 미리 보여주고 나머지는 다음 화면으로 넘긴다. */
+export function toTodoCommentResponse(
+	record: TodoCommentRecord,
+	viewerId: string,
+	likedCommentIds: ReadonlySet<string>,
+): TodoComment {
+	const replyPreview = record.children
+		.slice(0, TODO_COMMENT_LIMITS.REPLY_PREVIEW_SIZE)
+		.map((child) => toTodoCommentPreviewResponse(child, viewerId, likedCommentIds));
+
+	return {
+		...toTodoCommentPreviewResponse(record, viewerId, likedCommentIds),
+		// 실제로 실어 보낸 미리보기만큼은 더 볼 것이 아니다.
+		hasMoreReplies: record.replyCount > replyPreview.length,
+		replyPreview,
+	};
+}
+
+/** 한 페이지를 그대로 응답 모양으로 옮긴다 — 최상위 목록과 답글 목록이 같은 함수를 쓴다. */
+export function toPaginatedTodoComments(
+	page: PaginatedTodoCommentRecords,
+	viewerId: string,
+	likedCommentIds: ReadonlySet<string>,
+): PaginatedTodoComments {
+	return {
+		items: page.items.map((record) => toTodoCommentResponse(record, viewerId, likedCommentIds)),
+		pagination: {
+			nextCursor: page.nextCursor,
+			hasNext: page.hasNext,
+			size: page.size,
+		},
+	};
+}
+
+/** 응답에 실릴 모든 댓글 id — 좋아요 여부를 한 번의 IN으로 묶기 위해 모은다. */
+export function collectCommentIds(records: readonly TodoCommentRecord[]): string[] {
+	return records.flatMap((record) => [record.id, ...collectCommentIds(record.children)]);
+}

--- a/apps/api/src/todo-comment/application/use-cases/delete-todo-comment/delete-todo-comment.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/delete-todo-comment/delete-todo-comment.use-case.ts
@@ -1,0 +1,61 @@
+import { ErrorCode } from "@aido/errors";
+import type { DeleteTodoCommentResponse } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import { ApplicationException } from "@/shared/domain";
+import { now } from "@/shared/domain/date/utils/core";
+
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import { TODO_COMMENT_CACHE, type TodoCommentCachePort } from "../../ports/todo-comment-cache.port";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+
+export interface DeleteTodoCommentInput {
+	todoId: number;
+	commentId: string;
+	userId: string;
+}
+
+@Injectable()
+export class DeleteTodoCommentUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+		@Inject(TODO_COMMENT_CACHE)
+		private readonly cache: TodoCommentCachePort,
+		@Inject(UNIT_OF_WORK)
+		private readonly unitOfWork: UnitOfWorkPort,
+	) {}
+
+	async execute(input: DeleteTodoCommentInput): Promise<DeleteTodoCommentResponse> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.userId);
+		const wasDeleted = await this.unitOfWork.run(async () => {
+			const comment = await this.repository.findComment(input.todoId, input.commentId);
+
+			if (comment === null) {
+				throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.commentId });
+			}
+
+			if (comment.isDeleted) {
+				comment.delete(input.userId, now());
+				return false;
+			}
+
+			comment.delete(input.userId, now());
+			await this.repository.deleteComment(comment);
+			await this.repository.decrementTodoCommentCount(input.todoId);
+			await this.repository.dropDeletedFromAncestors(input.commentId, comment.placement.path);
+
+			return true;
+		});
+
+		if (wasDeleted) {
+			await this.cache.invalidateTopLevelFirstPages(input.todoId);
+		}
+
+		return { commentId: input.commentId, isDeleted: true };
+	}
+}

--- a/apps/api/src/todo-comment/application/use-cases/index.ts
+++ b/apps/api/src/todo-comment/application/use-cases/index.ts
@@ -1,0 +1,5 @@
+export * from "./delete-todo-comment/delete-todo-comment.use-case";
+export * from "./like-todo-comment/like-todo-comment.use-case";
+export * from "./unlike-todo-comment/unlike-todo-comment.use-case";
+export * from "./write-todo-comment-chain/write-todo-comment-chain.use-case";
+export * from "./update-todo-comment/update-todo-comment.use-case";

--- a/apps/api/src/todo-comment/application/use-cases/like-todo-comment/like-todo-comment.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/like-todo-comment/like-todo-comment.use-case.ts
@@ -1,0 +1,79 @@
+import { ErrorCode } from "@aido/errors";
+import type { TodoCommentLikeResponse } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import { ApplicationException } from "@/shared/domain";
+
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import { TODO_COMMENT_CACHE, type TodoCommentCachePort } from "../../ports/todo-comment-cache.port";
+import {
+	TODO_COMMENT_NOTIFICATION,
+	type TodoCommentNotificationPort,
+} from "../../ports/todo-comment-notification.port";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+
+export interface LikeTodoCommentInput {
+	todoId: number;
+	commentId: string;
+	userId: string;
+}
+
+@Injectable()
+export class LikeTodoCommentUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+		@Inject(TODO_COMMENT_CACHE)
+		private readonly cache: TodoCommentCachePort,
+		@Inject(TODO_COMMENT_NOTIFICATION)
+		private readonly notification: TodoCommentNotificationPort,
+		@Inject(UNIT_OF_WORK)
+		private readonly unitOfWork: UnitOfWorkPort,
+	) {}
+
+	async execute(input: LikeTodoCommentInput): Promise<TodoCommentLikeResponse> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.userId);
+		const likeOutcome = await this.unitOfWork.run(async () => {
+			const [comment, senderName] = await Promise.all([
+				this.repository.findComment(input.todoId, input.commentId),
+				this.repository.findUserDisplayName(input.userId),
+			]);
+
+			if (comment === null) {
+				throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.commentId });
+			}
+
+			comment.assertCanReceiveInteraction();
+			const transition = await this.repository.setLike(input.todoId, input.commentId, input.userId);
+			return { transition, senderName, threadRootId: comment.threadRootId.getValue() };
+		});
+
+		// 이미 한 번 알린 좋아요는 껐다 켜도 다시 알리지 않는다.
+		if (likeOutcome.transition.changed && !likeOutcome.transition.wasEverNotified) {
+			await this.repository.markLikeNotified(input.commentId, input.userId);
+			await Promise.all([
+				this.cache.invalidateTopLevelFirstPages(input.todoId),
+				this.notification.notifyCommentLiked({
+					recipientId: likeOutcome.transition.commentAuthorId,
+					senderId: input.userId,
+					senderName: likeOutcome.senderName,
+					todoId: input.todoId,
+					commentId: input.commentId,
+					threadRootId: likeOutcome.threadRootId,
+				}),
+			]);
+		} else if (likeOutcome.transition.changed) {
+			await this.cache.invalidateTopLevelFirstPages(input.todoId);
+		}
+
+		return {
+			commentId: input.commentId,
+			isLiked: true,
+			likeCount: likeOutcome.transition.likeCount,
+		};
+	}
+}

--- a/apps/api/src/todo-comment/application/use-cases/unlike-todo-comment/unlike-todo-comment.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/unlike-todo-comment/unlike-todo-comment.use-case.ts
@@ -1,0 +1,55 @@
+import { ErrorCode } from "@aido/errors";
+import type { TodoCommentLikeResponse } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import { ApplicationException } from "@/shared/domain";
+
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import { TODO_COMMENT_CACHE, type TodoCommentCachePort } from "../../ports/todo-comment-cache.port";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+
+export interface UnlikeTodoCommentInput {
+	todoId: number;
+	commentId: string;
+	userId: string;
+}
+
+@Injectable()
+export class UnlikeTodoCommentUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+		@Inject(TODO_COMMENT_CACHE)
+		private readonly cache: TodoCommentCachePort,
+		@Inject(UNIT_OF_WORK)
+		private readonly unitOfWork: UnitOfWorkPort,
+	) {}
+
+	async execute(input: UnlikeTodoCommentInput): Promise<TodoCommentLikeResponse> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.userId);
+		const transition = await this.unitOfWork.run(async () => {
+			const comment = await this.repository.findComment(input.todoId, input.commentId);
+
+			if (comment === null) {
+				throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.commentId });
+			}
+
+			comment.assertCanReceiveInteraction();
+			return this.repository.removeLike(input.todoId, input.commentId, input.userId);
+		});
+
+		if (transition.changed) {
+			await this.cache.invalidateTopLevelFirstPages(input.todoId);
+		}
+
+		return {
+			commentId: input.commentId,
+			isLiked: false,
+			likeCount: transition.likeCount,
+		};
+	}
+}

--- a/apps/api/src/todo-comment/application/use-cases/update-todo-comment/update-todo-comment.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/update-todo-comment/update-todo-comment.use-case.ts
@@ -1,0 +1,60 @@
+import { ErrorCode } from "@aido/errors";
+import type { TodoCommentMutationResponse } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import { ApplicationException } from "@/shared/domain";
+import { now } from "@/shared/domain/date/utils/core";
+
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import { TODO_COMMENT_CACHE, type TodoCommentCachePort } from "../../ports/todo-comment-cache.port";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+import { toTodoCommentResponse } from "../../types";
+
+export interface UpdateTodoCommentInput {
+	todoId: number;
+	commentId: string;
+	userId: string;
+	content: string;
+}
+
+@Injectable()
+export class UpdateTodoCommentUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+		@Inject(TODO_COMMENT_CACHE)
+		private readonly cache: TodoCommentCachePort,
+		@Inject(UNIT_OF_WORK)
+		private readonly unitOfWork: UnitOfWorkPort,
+	) {}
+
+	async execute(input: UpdateTodoCommentInput): Promise<TodoCommentMutationResponse> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.userId);
+		await this.unitOfWork.run(async () => {
+			const comment = await this.repository.findComment(input.todoId, input.commentId);
+
+			if (comment === null) {
+				throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.commentId });
+			}
+
+			comment.edit(input.userId, input.content, now());
+			await this.repository.updateComment(comment);
+		});
+
+		await this.cache.invalidateTopLevelFirstPages(input.todoId);
+		const updatedComment = await this.repository.findCommentRecord(input.todoId, input.commentId);
+
+		if (updatedComment === null) {
+			throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.commentId });
+		}
+
+		const likedIds = await this.repository.findLikedCommentIds([input.commentId], input.userId);
+
+		// 최상위든 답글이든 같은 모양이라 분기가 없다.
+		return { comment: toTodoCommentResponse(updatedComment, input.userId, likedIds) };
+	}
+}

--- a/apps/api/src/todo-comment/application/use-cases/write-todo-comment-chain/write-todo-comment-chain.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/write-todo-comment-chain/write-todo-comment-chain.use-case.ts
@@ -1,0 +1,113 @@
+import { ErrorCode } from "@aido/errors";
+import type { TodoCommentChainResponse } from "@aido/validators";
+import { Inject, Injectable } from "@nestjs/common";
+
+import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
+import { ApplicationException } from "@/shared/domain";
+
+import { ThreadPlacement } from "../../../domain/value-objects/thread-placement.vo";
+import { TodoCommentContent } from "../../../domain/value-objects/todo-comment-content.vo";
+import { assertTodoCommentAccess } from "../../assert-todo-comment-access";
+import { TODO_COMMENT_CACHE, type TodoCommentCachePort } from "../../ports/todo-comment-cache.port";
+import {
+	TODO_COMMENT_NOTIFICATION,
+	type TodoCommentNotificationPort,
+} from "../../ports/todo-comment-notification.port";
+import {
+	TODO_COMMENT_REPOSITORY,
+	type TodoCommentRepositoryPort,
+} from "../../ports/todo-comment.repository.port";
+import { toTodoCommentResponse } from "../../types";
+
+export interface WriteTodoCommentChainInput {
+	todoId: number;
+	authorId: string;
+	/** 사슬이 매달릴 댓글. 없으면 할 일에 바로 달린다. */
+	parentId: string | null;
+	items: { clientRequestId: string; content: string }[];
+}
+
+/**
+ * 한 번에 이어 쓴 글 묶음을 사슬로 심는다.
+ *
+ * 첫 글만 대상의 직계 자식이고 나머지는 바로 앞 글의 답글이 된다 —
+ * 그래서 부모의 답글 수는 사슬 길이와 무관하게 하나만 오른다.
+ * 최상위 댓글이든 답글이든 부모 유무만 다르고 흐름이 같아 한 use-case가 맡는다.
+ */
+@Injectable()
+export class WriteTodoCommentChainUseCase {
+	constructor(
+		@Inject(TODO_COMMENT_REPOSITORY)
+		private readonly repository: TodoCommentRepositoryPort,
+		@Inject(TODO_COMMENT_CACHE)
+		private readonly cache: TodoCommentCachePort,
+		@Inject(TODO_COMMENT_NOTIFICATION)
+		private readonly notification: TodoCommentNotificationPort,
+		@Inject(UNIT_OF_WORK)
+		private readonly unitOfWork: UnitOfWorkPort,
+	) {}
+
+	async execute(input: WriteTodoCommentChainInput): Promise<TodoCommentChainResponse> {
+		await assertTodoCommentAccess(this.repository, input.todoId, input.authorId);
+		const contents = input.items.map((item) => TodoCommentContent.create(item.content).getValue());
+
+		const outcome = await this.unitOfWork.run(async () => {
+			const parent =
+				input.parentId === null
+					? null
+					: await this.repository.findComment(input.todoId, input.parentId);
+
+			if (input.parentId !== null && parent === null) {
+				throw new ApplicationException(ErrorCode.TODO_0831, { commentId: input.parentId });
+			}
+
+			const chain = await this.repository.createCommentChain({
+				todoId: input.todoId,
+				authorId: input.authorId,
+				placement: parent === null ? ThreadPlacement.topLevel() : parent.placeReply(),
+				items: input.items.map((item, index) => ({
+					clientRequestId: item.clientRequestId,
+					content: contents[index] ?? "",
+				})),
+			});
+
+			if (chain.createdCount > 0) {
+				await this.repository.increaseTodoCommentCount(input.todoId, chain.createdCount);
+
+				// 직계 자식은 사슬의 첫 글 하나뿐이라, 부모의 답글 수는 길이와 무관하게 하나만 오른다.
+				if (parent !== null) {
+					await this.repository.incrementReplyCount(parent.id.getValue());
+				}
+			}
+
+			return {
+				written: chain.comments,
+				addedCount: chain.createdCount,
+				recipientId: parent === null ? chain.comments[0]?.todoOwnerId : parent.authorId,
+				threadRootId: parent === null ? chain.comments[0]?.id : parent.threadRootId.getValue(),
+			};
+		});
+
+		if (outcome.addedCount > 0 && outcome.recipientId !== undefined) {
+			await Promise.all([
+				this.cache.invalidateTopLevelFirstPages(input.todoId),
+				this.notification.notifyCommentsWritten({
+					recipientId: outcome.recipientId,
+					senderId: input.authorId,
+					senderName: outcome.written[0]?.authorName ?? null,
+					todoId: input.todoId,
+					commentId: outcome.written[0]?.id ?? "",
+					threadRootId: outcome.threadRootId ?? "",
+					isReply: input.parentId !== null,
+					count: outcome.addedCount,
+				}),
+			]);
+		}
+
+		return {
+			comments: outcome.written.map((record) =>
+				toTodoCommentResponse(record, input.authorId, new Set()),
+			),
+		};
+	}
+}

--- a/apps/api/src/todo-comment/domain/entities/todo-comment.aggregate.spec.ts
+++ b/apps/api/src/todo-comment/domain/entities/todo-comment.aggregate.spec.ts
@@ -1,0 +1,97 @@
+import { ErrorCode } from "@aido/errors";
+
+import { DomainException } from "@/shared/domain";
+
+import { TodoComment } from "./todo-comment.aggregate";
+
+function createComment(overrides: Partial<Parameters<typeof TodoComment.reconstitute>[0]> = {}) {
+	const createdAt = new Date("2026-08-14T00:00:00.000Z");
+	return TodoComment.reconstitute({
+		id: "cm1todoacomment00000000001",
+		todoId: 1,
+		authorId: "cm1author0000000000000001",
+		parentId: null,
+		rootId: null,
+		path: [],
+		content: "함께 해요",
+		deletedAt: null,
+		editedAt: null,
+		createdAt,
+		updatedAt: createdAt,
+		...overrides,
+	});
+}
+
+describe("TodoComment Aggregate", () => {
+	it("작성자가 댓글을 수정한다", () => {
+		const comment = createComment();
+		const editedAt = new Date("2026-08-14T01:00:00.000Z");
+
+		comment.edit("cm1author0000000000000001", "  수정된 댓글  ", editedAt);
+
+		expect(comment.content).toBe("수정된 댓글");
+		expect(comment.editedAt).toEqual(editedAt);
+	});
+
+	it("다른 사용자의 수정을 거부한다", () => {
+		const comment = createComment();
+
+		try {
+			comment.edit("cm1another000000000000001", "수정", new Date());
+			throw new Error("예외가 발생해야 합니다.");
+		} catch (error) {
+			expect(error).toBeInstanceOf(DomainException);
+			expect(error).toMatchObject({ errorCode: ErrorCode.TODO_0832 });
+		}
+	});
+
+	it("삭제 시 원문을 제거하고 같은 요청을 멱등 처리한다", () => {
+		const comment = createComment();
+		const deletedAt = new Date("2026-08-14T02:00:00.000Z");
+
+		comment.delete("cm1author0000000000000001", deletedAt);
+		comment.delete("cm1author0000000000000001", new Date("2026-08-14T03:00:00.000Z"));
+
+		expect(comment.content).toBeNull();
+		expect(comment.deletedAt).toEqual(deletedAt);
+	});
+
+	it("삭제된 댓글의 상호작용을 거부한다", () => {
+		const comment = createComment({
+			content: null,
+			deletedAt: new Date("2026-08-14T02:00:00.000Z"),
+		});
+
+		expect(() => comment.assertCanReceiveInteraction()).toThrow(DomainException);
+	});
+
+	it("최상위 댓글은 자기 자신이 대화의 뿌리다", () => {
+		const comment = createComment();
+
+		expect(comment.threadRootId.getValue()).toBe("cm1todoacomment00000000001");
+	});
+
+	it("답글의 자리는 부모를 이어받고 뿌리는 그대로 둔다", () => {
+		const reply = createComment({
+			id: "cm1todoacomment00000000002",
+			parentId: "cm1todoacomment00000000001",
+			rootId: "cm1todoacomment00000000001",
+			path: ["cm1todoacomment00000000001"],
+		});
+
+		const grandChildPlacement = reply.placeReply();
+
+		expect(grandChildPlacement.parentId?.getValue()).toBe("cm1todoacomment00000000002");
+		expect(grandChildPlacement.rootId?.getValue()).toBe("cm1todoacomment00000000001");
+		expect(grandChildPlacement.depth).toBe(2);
+	});
+
+	it("삭제된 댓글은 답글을 받지 못한다", () => {
+		const comment = createComment({
+			content: null,
+			deletedAt: new Date("2026-08-14T02:00:00.000Z"),
+		});
+
+		expect(() => comment.placeReply()).toThrow(DomainException);
+	});
+});

--- a/apps/api/src/todo-comment/domain/entities/todo-comment.aggregate.ts
+++ b/apps/api/src/todo-comment/domain/entities/todo-comment.aggregate.ts
@@ -1,0 +1,139 @@
+import { ErrorCode } from "@aido/errors";
+
+import { AggregateRoot, DomainException } from "@/shared/domain";
+
+import { ThreadPlacement } from "../value-objects/thread-placement.vo";
+import { TodoCommentContent } from "../value-objects/todo-comment-content.vo";
+import { TodoCommentId } from "../value-objects/todo-comment-id.vo";
+
+interface TodoCommentProps {
+	id: TodoCommentId;
+	todoId: number;
+	authorId: string;
+	/** 스레드에서 이 댓글이 놓인 자리 */
+	placement: ThreadPlacement;
+	content: TodoCommentContent | null;
+	deletedAt: Date | null;
+	editedAt: Date | null;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+export class TodoComment extends AggregateRoot<TodoCommentProps> {
+	static reconstitute(props: {
+		id: string;
+		todoId: number;
+		authorId: string;
+		parentId: string | null;
+		rootId: string | null;
+		path: readonly string[];
+		content: string | null;
+		deletedAt: Date | null;
+		editedAt: Date | null;
+		createdAt: Date;
+		updatedAt: Date;
+	}): TodoComment {
+		return new TodoComment({
+			id: TodoCommentId.create(props.id),
+			todoId: props.todoId,
+			authorId: props.authorId,
+			placement: ThreadPlacement.reconstitute({
+				parentId: props.parentId,
+				rootId: props.rootId,
+				path: props.path,
+			}),
+			content: props.content ? TodoCommentContent.create(props.content) : null,
+			deletedAt: props.deletedAt ? new Date(props.deletedAt) : null,
+			editedAt: props.editedAt ? new Date(props.editedAt) : null,
+			createdAt: new Date(props.createdAt),
+			updatedAt: new Date(props.updatedAt),
+		});
+	}
+
+	get id(): TodoCommentId {
+		return this.props.id;
+	}
+
+	get todoId(): number {
+		return this.props.todoId;
+	}
+
+	get authorId(): string {
+		return this.props.authorId;
+	}
+
+	get placement(): ThreadPlacement {
+		return this.props.placement;
+	}
+
+	/** 이 댓글이 속한 대화의 뿌리. 최상위 댓글이면 자기 자신이다. */
+	get threadRootId(): TodoCommentId {
+		return this.props.placement.rootId ?? this.props.id;
+	}
+
+	/**
+	 * 이 댓글에 달릴 답글의 자리.
+	 * 삭제된 댓글은 답글을 받지 못하므로, 자리를 내주기 전에 상태부터 확인한다.
+	 */
+	placeReply(): ThreadPlacement {
+		this.assertCanReceiveInteraction();
+
+		return this.props.placement.under(this.props.id);
+	}
+
+	get isDeleted(): boolean {
+		return this.props.deletedAt !== null;
+	}
+
+	get content(): string | null {
+		return this.props.content?.getValue() ?? null;
+	}
+
+	get deletedAt(): Date | null {
+		return this.props.deletedAt ? new Date(this.props.deletedAt) : null;
+	}
+
+	get editedAt(): Date | null {
+		return this.props.editedAt ? new Date(this.props.editedAt) : null;
+	}
+
+	edit(userId: string, content: string, editedAt: Date): void {
+		this.assertAuthor(userId);
+		this.assertActive();
+		this.props.content = TodoCommentContent.create(content);
+		this.props.editedAt = new Date(editedAt);
+		this.props.updatedAt = new Date(editedAt);
+	}
+
+	delete(userId: string, deletedAt: Date): void {
+		this.assertAuthor(userId);
+
+		if (this.isDeleted) {
+			return;
+		}
+
+		this.props.content = null;
+		this.props.deletedAt = new Date(deletedAt);
+		this.props.updatedAt = new Date(deletedAt);
+	}
+
+	assertCanReceiveInteraction(): void {
+		this.assertActive();
+	}
+
+	private assertAuthor(userId: string): void {
+		if (this.props.authorId !== userId) {
+			throw new DomainException(ErrorCode.TODO_0832, {
+				commentId: this.props.id.getValue(),
+			});
+		}
+	}
+
+	private assertActive(): void {
+		if (this.isDeleted) {
+			throw new DomainException(ErrorCode.TODO_0833, {
+				commentId: this.props.id.getValue(),
+			});
+		}
+	}
+}

--- a/apps/api/src/todo-comment/domain/value-objects/thread-placement.vo.spec.ts
+++ b/apps/api/src/todo-comment/domain/value-objects/thread-placement.vo.spec.ts
@@ -1,0 +1,62 @@
+import { DomainException } from "@/shared/domain";
+
+import { ThreadPlacement } from "./thread-placement.vo";
+import { TodoCommentId } from "./todo-comment-id.vo";
+
+const ROOT_ID = "cm1todoacomment00000000001";
+const REPLY_ID = "cm1todoacomment00000000002";
+
+describe("ThreadPlacement", () => {
+	it("최상위 자리는 부모도 뿌리도 조상도 없다", () => {
+		const placement = ThreadPlacement.topLevel();
+
+		expect(placement.parentId).toBeNull();
+		expect(placement.rootId).toBeNull();
+		expect(placement.path).toEqual([]);
+		expect(placement.depth).toBe(0);
+		expect(placement.isTopLevel).toBe(true);
+	});
+
+	it("최상위 댓글 아래의 답글은 그 댓글을 부모이자 뿌리로 삼는다", () => {
+		const placement = ThreadPlacement.topLevel().under(TodoCommentId.create(ROOT_ID));
+
+		expect(placement.parentId?.getValue()).toBe(ROOT_ID);
+		expect(placement.rootId?.getValue()).toBe(ROOT_ID);
+		expect(placement.path).toEqual([ROOT_ID]);
+		expect(placement.depth).toBe(1);
+	});
+
+	it("답글의 답글은 뿌리를 이어받고 조상만 쌓인다", () => {
+		const placement = ThreadPlacement.topLevel()
+			.under(TodoCommentId.create(ROOT_ID))
+			.under(TodoCommentId.create(REPLY_ID));
+
+		expect(placement.parentId?.getValue()).toBe(REPLY_ID);
+		expect(placement.rootId?.getValue()).toBe(ROOT_ID);
+		expect(placement.path).toEqual([ROOT_ID, REPLY_ID]);
+		expect(placement.depth).toBe(2);
+	});
+
+	it("조상은 뿌리 → 부모 순서로 복원된다", () => {
+		const placement = ThreadPlacement.reconstitute({
+			parentId: REPLY_ID,
+			rootId: ROOT_ID,
+			path: [ROOT_ID, REPLY_ID],
+		});
+
+		expect(placement.path).toEqual([ROOT_ID, REPLY_ID]);
+		expect(placement.isTopLevel).toBe(false);
+	});
+
+	it("부모 없이 조상만 있는 자리는 복원하지 못한다", () => {
+		expect(() =>
+			ThreadPlacement.reconstitute({ parentId: null, rootId: ROOT_ID, path: [ROOT_ID] }),
+		).toThrow(DomainException);
+	});
+
+	it("경로의 끝이 부모가 아니면 복원하지 못한다", () => {
+		expect(() =>
+			ThreadPlacement.reconstitute({ parentId: REPLY_ID, rootId: ROOT_ID, path: [ROOT_ID] }),
+		).toThrow(DomainException);
+	});
+});

--- a/apps/api/src/todo-comment/domain/value-objects/thread-placement.vo.ts
+++ b/apps/api/src/todo-comment/domain/value-objects/thread-placement.vo.ts
@@ -1,0 +1,89 @@
+import { ErrorCode } from "@aido/errors";
+
+import { DomainException, ValueObject } from "@/shared/domain";
+
+import { TodoCommentId } from "./todo-comment-id.vo";
+
+interface ThreadPlacementProps {
+	/** 직계 부모. 최상위 댓글이면 null */
+	parentId: TodoCommentId | null;
+	/** 대화의 뿌리. 최상위 댓글이면 null */
+	rootId: TodoCommentId | null;
+	/** 뿌리 → 부모 순서의 조상 id */
+	path: readonly string[];
+}
+
+/**
+ * 스레드에서 댓글이 놓인 자리.
+ *
+ * 최상위 댓글은 부모도 뿌리도 조상도 없고, 답글은 셋 다 가진다.
+ * 이 짝이 어긋나면 대화가 어디에 속하는지 알 수 없으므로 생성 시점에 막는다.
+ */
+export class ThreadPlacement extends ValueObject<ThreadPlacementProps> {
+	/** 할 일에 바로 달린 댓글의 자리. */
+	static topLevel(): ThreadPlacement {
+		return new ThreadPlacement({ parentId: null, rootId: null, path: [] });
+	}
+
+	/** 영속된 자리를 복원한다 — 저장된 값은 이미 유효하므로 짝만 확인한다. */
+	static reconstitute(props: {
+		parentId: string | null;
+		rootId: string | null;
+		path: readonly string[];
+	}): ThreadPlacement {
+		if (props.parentId === null) {
+			if (props.rootId !== null || props.path.length > 0) {
+				throw new DomainException(ErrorCode.SYS_0002, {
+					reason: "topLevelPlacementMustNotHaveAncestors",
+				});
+			}
+
+			return ThreadPlacement.topLevel();
+		}
+
+		if (props.rootId === null || props.path.at(-1) !== props.parentId) {
+			throw new DomainException(ErrorCode.SYS_0002, {
+				reason: "replyPlacementMustEndWithParent",
+			});
+		}
+
+		return new ThreadPlacement({
+			parentId: TodoCommentId.create(props.parentId),
+			rootId: TodoCommentId.create(props.rootId),
+			path: [...props.path],
+		});
+	}
+
+	/**
+	 * 이 자리에 놓인 댓글 아래로 들어갈 답글의 자리.
+	 * 답글의 뿌리는 내 뿌리이고, 내가 뿌리가 없으면(=내가 최상위면) 내가 뿌리가 된다.
+	 */
+	under(parentId: TodoCommentId): ThreadPlacement {
+		return new ThreadPlacement({
+			parentId,
+			rootId: this.value.rootId ?? parentId,
+			path: [...this.value.path, parentId.getValue()],
+		});
+	}
+
+	get parentId(): TodoCommentId | null {
+		return this.value.parentId;
+	}
+
+	get rootId(): TodoCommentId | null {
+		return this.value.rootId;
+	}
+
+	get path(): readonly string[] {
+		return this.value.path;
+	}
+
+	/** 뿌리에서 이 댓글까지의 깊이. 최상위는 0이다. */
+	get depth(): number {
+		return this.value.path.length;
+	}
+
+	get isTopLevel(): boolean {
+		return this.value.parentId === null;
+	}
+}

--- a/apps/api/src/todo-comment/domain/value-objects/todo-comment-content.vo.spec.ts
+++ b/apps/api/src/todo-comment/domain/value-objects/todo-comment-content.vo.spec.ts
@@ -1,0 +1,19 @@
+import { DomainException } from "@/shared/domain";
+
+import { TodoCommentContent } from "./todo-comment-content.vo";
+
+describe("TodoCommentContent", () => {
+	it("앞뒤 공백을 제거한 댓글 내용을 보관한다", () => {
+		const content = TodoCommentContent.create("  같이 해요  ");
+
+		expect(content.getValue()).toBe("같이 해요");
+	});
+
+	it.each(["", "   "])("빈 댓글을 거부한다: %p", (value) => {
+		expect(() => TodoCommentContent.create(value)).toThrow(DomainException);
+	});
+
+	it("500자를 초과한 댓글을 거부한다", () => {
+		expect(() => TodoCommentContent.create("가".repeat(501))).toThrow(DomainException);
+	});
+});

--- a/apps/api/src/todo-comment/domain/value-objects/todo-comment-content.vo.ts
+++ b/apps/api/src/todo-comment/domain/value-objects/todo-comment-content.vo.ts
@@ -1,0 +1,22 @@
+import { ErrorCode } from "@aido/errors";
+import { TODO_COMMENT_LIMITS } from "@aido/validators";
+
+import { DomainException, ValueObject } from "@/shared/domain";
+
+export class TodoCommentContent extends ValueObject<string> {
+	static create(value: string): TodoCommentContent {
+		const normalizedContent = value.trim();
+
+		if (
+			normalizedContent.length === 0 ||
+			normalizedContent.length > TODO_COMMENT_LIMITS.CONTENT_MAX_LENGTH
+		) {
+			throw new DomainException(ErrorCode.SYS_0002, {
+				contentLength: normalizedContent.length,
+				maxLength: TODO_COMMENT_LIMITS.CONTENT_MAX_LENGTH,
+			});
+		}
+
+		return new TodoCommentContent(normalizedContent);
+	}
+}

--- a/apps/api/src/todo-comment/domain/value-objects/todo-comment-id.vo.ts
+++ b/apps/api/src/todo-comment/domain/value-objects/todo-comment-id.vo.ts
@@ -1,0 +1,7 @@
+import { EntityId } from "@/shared/domain";
+
+export class TodoCommentId extends EntityId<string> {
+	static create(value: string): TodoCommentId {
+		return new TodoCommentId(value);
+	}
+}

--- a/apps/api/src/todo-comment/index.ts
+++ b/apps/api/src/todo-comment/index.ts
@@ -1,0 +1,1 @@
+export * from "./todo-comment.module";

--- a/apps/api/src/todo-comment/infrastructure/adapters/todo-comment-notification.adapter.ts
+++ b/apps/api/src/todo-comment/infrastructure/adapters/todo-comment-notification.adapter.ts
@@ -1,0 +1,67 @@
+import { NOTIFICATION_ACTION_TYPE } from "@aido/validators";
+import { Injectable } from "@nestjs/common";
+
+import { NotificationMessageBuilder, NotificationSender } from "@/notification";
+
+import type {
+	TodoCommentNotificationPort,
+	TodoCommentWrittenInput,
+} from "../../application/ports/todo-comment-notification.port";
+
+type TodoCommentNotificationKind = "COMMENT" | "REPLY" | "LIKE";
+
+interface LikedInput {
+	recipientId: string;
+	senderId: string;
+	senderName: string | null;
+	todoId: number;
+	commentId: string;
+	threadRootId: string;
+}
+
+@Injectable()
+export class TodoCommentNotificationAdapter implements TodoCommentNotificationPort {
+	constructor(private readonly notificationSender: NotificationSender) {}
+
+	notifyCommentsWritten(input: TodoCommentWrittenInput): Promise<void> {
+		return this.#send(input, input.isReply ? "REPLY" : "COMMENT", input.count);
+	}
+
+	notifyCommentLiked(input: LikedInput): Promise<void> {
+		return this.#send(input, "LIKE", 1);
+	}
+
+	/**
+	 * 알림 타입은 TODO_SHARED 그대로 둔다 — 새 타입을 늘리면 구버전 앱의 목록 파싱이 통째로 깨진다.
+	 * 무엇에 달렸는지는 문구와 activityKind가 말한다.
+	 */
+	async #send(input: LikedInput, kind: TodoCommentNotificationKind, count: number): Promise<void> {
+		if (input.recipientId === input.senderId) {
+			return;
+		}
+
+		const locale = await this.notificationSender.getUserLocale(input.recipientId);
+		const copy = NotificationMessageBuilder.todoCommentActivity(
+			kind,
+			input.senderName,
+			locale,
+			count,
+		);
+		await this.notificationSender.createAndSend({
+			userId: input.recipientId,
+			type: "TODO_SHARED",
+			title: copy.title,
+			body: copy.body,
+			todoId: input.todoId,
+			action: {
+				type: NOTIFICATION_ACTION_TYPE.DEEP_LINK,
+				url: `/todo/${input.todoId}/comment/${input.commentId}`,
+			},
+			metadata: {
+				commentId: input.commentId,
+				threadRootId: input.threadRootId,
+				activityKind: kind,
+			},
+		});
+	}
+}

--- a/apps/api/src/todo-comment/infrastructure/cache/todo-comment-cache.adapter.ts
+++ b/apps/api/src/todo-comment/infrastructure/cache/todo-comment-cache.adapter.ts
@@ -1,0 +1,87 @@
+import { TODO_COMMENT_SORT, z, type TodoCommentSort } from "@aido/validators";
+import { Injectable } from "@nestjs/common";
+
+import { CacheService } from "@/shared/infrastructure/cache/cache.service";
+
+import type { TodoCommentCachePort } from "../../application/ports/todo-comment-cache.port";
+import type { PaginatedTodoCommentRecords } from "../../application/types";
+import { TODO_COMMENT_CACHE_TTL_MS, TodoCommentCacheKey } from "./todo-comment-cache.keyspace";
+
+const commentRecordSchema: z.ZodType<PaginatedTodoCommentRecords["items"][number]> = z.lazy(() =>
+	z.object({
+		id: z.cuid(),
+		todoId: z.number().int().positive(),
+		parentId: z.cuid().nullable(),
+		rootId: z.cuid().nullable(),
+		path: z.array(z.cuid()),
+		depth: z.number().int().nonnegative(),
+		parentAuthorName: z.string().nullable(),
+		authorId: z.cuid(),
+		authorName: z.string().nullable(),
+		authorProfileImage: z.string().nullable(),
+		todoOwnerId: z.cuid(),
+		content: z.string().nullable(),
+		likeCount: z.number().int().nonnegative(),
+		replyCount: z.number().int().nonnegative(),
+		deletedAt: z.iso.datetime().nullable(),
+		editedAt: z.iso.datetime().nullable(),
+		createdAt: z.iso.datetime(),
+		children: z.array(commentRecordSchema),
+	}),
+);
+
+const pageSchema = z.object({
+	items: z.array(commentRecordSchema),
+	nextCursor: z.string().nullable(),
+	hasNext: z.boolean(),
+	size: z.number().int().positive(),
+});
+
+@Injectable()
+export class TodoCommentCacheAdapter implements TodoCommentCachePort {
+	constructor(private readonly cacheService: CacheService) {}
+
+	async getTopLevelFirstPage(
+		todoId: number,
+		sort: TodoCommentSort,
+	): Promise<PaginatedTodoCommentRecords | undefined> {
+		const key = TodoCommentCacheKey.topLevelFirstPage(todoId, sort);
+		const cached = await this.cacheService.get<unknown>(key);
+
+		if (cached === undefined) {
+			return undefined;
+		}
+
+		const parsed = pageSchema.safeParse(cached);
+
+		if (!parsed.success) {
+			await this.cacheService.del(key);
+			return undefined;
+		}
+
+		return parsed.data;
+	}
+
+	async setTopLevelFirstPage(
+		todoId: number,
+		sort: TodoCommentSort,
+		page: PaginatedTodoCommentRecords,
+	): Promise<void> {
+		const ttl =
+			sort === TODO_COMMENT_SORT.POPULAR
+				? TODO_COMMENT_CACHE_TTL_MS.POPULAR_FIRST_PAGE
+				: TODO_COMMENT_CACHE_TTL_MS.LATEST_FIRST_PAGE;
+		await this.cacheService.set(TodoCommentCacheKey.topLevelFirstPage(todoId, sort), page, ttl);
+	}
+
+	async invalidateTopLevelFirstPages(todoId: number): Promise<void> {
+		await Promise.all([
+			this.cacheService.del(
+				TodoCommentCacheKey.topLevelFirstPage(todoId, TODO_COMMENT_SORT.POPULAR),
+			),
+			this.cacheService.del(
+				TodoCommentCacheKey.topLevelFirstPage(todoId, TODO_COMMENT_SORT.LATEST),
+			),
+		]);
+	}
+}

--- a/apps/api/src/todo-comment/infrastructure/cache/todo-comment-cache.keyspace.spec.ts
+++ b/apps/api/src/todo-comment/infrastructure/cache/todo-comment-cache.keyspace.spec.ts
@@ -1,0 +1,11 @@
+import { TODO_COMMENT_SORT } from "@aido/validators";
+
+import { TodoCommentCacheKey } from "./todo-comment-cache.keyspace";
+
+describe("TodoCommentCacheKey", () => {
+	it("버전과 정렬을 포함한 최상위 첫 페이지 키를 만든다", () => {
+		expect(TodoCommentCacheKey.topLevelFirstPage(42, TODO_COMMENT_SORT.POPULAR)).toBe(
+			"aido:v1:todo-comments:top-level-first-page-v2:42:popular:20",
+		);
+	});
+});

--- a/apps/api/src/todo-comment/infrastructure/cache/todo-comment-cache.keyspace.ts
+++ b/apps/api/src/todo-comment/infrastructure/cache/todo-comment-cache.keyspace.ts
@@ -1,0 +1,20 @@
+import { TODO_COMMENT_LIMITS, type TodoCommentSort } from "@aido/validators";
+
+import { cacheKey } from "@/shared/infrastructure/cache/keyspace/cache-key";
+
+export const TODO_COMMENT_CACHE_TTL_MS = {
+	POPULAR_FIRST_PAGE: 10_000,
+	LATEST_FIRST_PAGE: 30_000,
+} as const;
+
+export const TodoCommentCacheKey = {
+	topLevelFirstPage(todoId: number, sort: TodoCommentSort) {
+		return cacheKey(
+			"todo-comments",
+			"top-level-first-page-v2",
+			String(todoId),
+			sort.toLowerCase(),
+			String(TODO_COMMENT_LIMITS.DEFAULT_PAGE_SIZE),
+		);
+	},
+} as const;

--- a/apps/api/src/todo-comment/infrastructure/persistence/prisma-todo-comment.repository.ts
+++ b/apps/api/src/todo-comment/infrastructure/persistence/prisma-todo-comment.repository.ts
@@ -1,0 +1,571 @@
+import { TODO_COMMENT_LIMITS, TODO_COMMENT_SORT, type TodoCommentSort } from "@aido/validators";
+import { TransactionHost } from "@nestjs-cls/transactional";
+import type { TransactionalAdapterPrisma } from "@nestjs-cls/transactional-adapter-prisma";
+import { Injectable } from "@nestjs/common";
+
+import type { Prisma } from "@/generated/prisma/client";
+import { FollowStatus, TodoVisibility } from "@/generated/prisma/enums";
+import { toISOString, toISOStringOrNull } from "@/shared/domain/date/utils/format";
+import type { DatabaseService } from "@/shared/infrastructure/database/database.service";
+
+import type { TodoCommentRepositoryPort } from "../../application/ports/todo-comment.repository.port";
+import { encodeTodoCommentCursor } from "../../application/todo-comment-cursor";
+import type {
+	CreateTodoCommentChainInput,
+	ListTodoCommentsParams,
+	TodoCommentChainCreationResult,
+	TodoCommentLikeTransition,
+	PaginatedTodoCommentRecords,
+	TodoCommentRecord,
+	TodoDetailsRecord,
+} from "../../application/types";
+import { TodoComment } from "../../domain/entities/todo-comment.aggregate";
+import { TodoCommentId } from "../../domain/value-objects/todo-comment-id.vo";
+import { TODO_DETAILS_INCLUDE, toTodoResponse } from "./todo-details.mapper";
+
+const COMMENT_INCLUDE = {
+	author: { include: { profile: true } },
+	parent: { include: { author: { include: { profile: true } } } },
+	todo: { select: { userId: true } },
+} satisfies Prisma.TodoCommentInclude;
+
+type CommentRow = Prisma.TodoCommentGetPayload<{ include: typeof COMMENT_INCLUDE }>;
+type CommentWithChildrenRow = CommentRow & { children?: CommentRow[] };
+
+/**
+ * 삭제됐어도 답글이 남았으면 묘비로 남긴다 — 대화가 끊기지 않게.
+ * replyCount는 "보이는 직계 자식 수"라서 깊이가 얼마든 이 한 줄로 판정된다.
+ */
+const VISIBLE_COMMENT = {
+	OR: [{ deletedAt: null }, { replyCount: { gt: 0 } }],
+} satisfies Prisma.TodoCommentWhereInput;
+
+function orderBySort(sort: TodoCommentSort): Prisma.TodoCommentOrderByWithRelationInput[] {
+	return sort === TODO_COMMENT_SORT.LATEST
+		? [{ createdAt: "desc" }, { id: "desc" }]
+		: [{ likeCount: "desc" }, { replyCount: "desc" }, { createdAt: "desc" }, { id: "desc" }];
+}
+
+function toRecord(row: CommentWithChildrenRow): TodoCommentRecord {
+	return {
+		id: row.id,
+		todoId: row.todoId,
+		parentId: row.parentId,
+		rootId: row.rootId,
+		path: row.path,
+		depth: row.depth,
+		parentAuthorName: row.parent?.author.profile?.name ?? null,
+		authorId: row.authorId,
+		authorName: row.author.profile?.name ?? null,
+		authorProfileImage: row.author.profile?.profileImage ?? null,
+		todoOwnerId: row.todo.userId,
+		content: row.content,
+		likeCount: row.likeCount,
+		replyCount: row.replyCount,
+		deletedAt: toISOStringOrNull(row.deletedAt),
+		editedAt: toISOStringOrNull(row.editedAt),
+		createdAt: toISOString(row.createdAt),
+		children: (row.children ?? []).map(toRecord),
+	};
+}
+
+function toAggregate(row: Prisma.TodoCommentGetPayload<object>): TodoComment {
+	return TodoComment.reconstitute({
+		id: row.id,
+		todoId: row.todoId,
+		authorId: row.authorId,
+		parentId: row.parentId,
+		rootId: row.rootId,
+		path: row.path,
+		content: row.content,
+		deletedAt: row.deletedAt,
+		editedAt: row.editedAt,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	});
+}
+
+@Injectable()
+export class PrismaTodoCommentRepository implements TodoCommentRepositoryPort {
+	constructor(
+		private readonly txHost: TransactionHost<TransactionalAdapterPrisma<DatabaseService>>,
+	) {}
+
+	private get client() {
+		return this.txHost.tx;
+	}
+
+	private async isAcceptedFriend(firstUserId: string, secondUserId: string): Promise<boolean> {
+		const friendship = await this.client.follow.findFirst({
+			where: {
+				status: FollowStatus.ACCEPTED,
+				OR: [
+					{ followerId: firstUserId, followingId: secondUserId },
+					{ followerId: secondUserId, followingId: firstUserId },
+				],
+			},
+			select: { id: true },
+		});
+
+		return friendship !== null;
+	}
+
+	async canAccessTodo(todoId: number, viewerId: string): Promise<boolean> {
+		const todo = await this.client.todo.findUnique({
+			where: { id: todoId },
+			select: { userId: true, visibility: true },
+		});
+
+		if (todo === null) {
+			return false;
+		}
+
+		if (todo.userId === viewerId) {
+			return true;
+		}
+
+		if (todo.visibility !== TodoVisibility.PUBLIC) {
+			return false;
+		}
+
+		return this.isAcceptedFriend(todo.userId, viewerId);
+	}
+
+	async findAccessibleTodoDetails(
+		todoId: number,
+		viewerId: string,
+	): Promise<TodoDetailsRecord | null> {
+		const row = await this.client.todo.findUnique({
+			where: { id: todoId },
+			include: TODO_DETAILS_INCLUDE,
+		});
+
+		if (row === null) {
+			return null;
+		}
+
+		const isOwner = row.userId === viewerId;
+		const canAccess =
+			isOwner ||
+			(row.visibility === TodoVisibility.PUBLIC &&
+				(await this.isAcceptedFriend(row.userId, viewerId)));
+
+		if (!canAccess) {
+			return null;
+		}
+
+		return {
+			todo: toTodoResponse(row),
+			owner: {
+				id: row.user.id,
+				name: row.user.profile?.name ?? null,
+				profileImage: row.user.profile?.profileImage ?? null,
+			},
+			viewCount: row.viewCount,
+			commentCount: row.commentCount,
+			isOwner,
+		};
+	}
+
+	async findComment(todoId: number, commentId: string): Promise<TodoComment | null> {
+		const row = await this.client.todoComment.findFirst({
+			where: { id: commentId, todoId },
+		});
+
+		return row ? toAggregate(row) : null;
+	}
+
+	async findCommentRecord(todoId: number, commentId: string): Promise<TodoCommentRecord | null> {
+		const row = await this.client.todoComment.findFirst({
+			where: { id: commentId, todoId },
+			include: COMMENT_INCLUDE,
+		});
+
+		return row ? toRecord(row) : null;
+	}
+
+	/**
+	 * parentId가 null이면 최상위 댓글 목록, 값이 있으면 그 댓글의 직계 답글 목록이다.
+	 * 자식 미리보기는 한 겹만 채운다 — 관계는 부모 수와 무관하게 1회 조회되고 take는 부모별로 적용된다.
+	 */
+	async listComments(params: ListTodoCommentsParams): Promise<PaginatedTodoCommentRecords> {
+		const cursorWhere = this.buildCursorWhere(params);
+		const rows = await this.client.todoComment.findMany({
+			where: {
+				todoId: params.todoId,
+				parentId: params.parentId,
+				AND: [VISIBLE_COMMENT, ...(cursorWhere ? [cursorWhere] : [])],
+			},
+			orderBy: orderBySort(params.sort),
+			take: params.size + 1,
+			include: {
+				...COMMENT_INCLUDE,
+				children: {
+					where: VISIBLE_COMMENT,
+					orderBy: orderBySort(params.sort),
+					take: TODO_COMMENT_LIMITS.REPLY_PREVIEW_SIZE,
+					include: COMMENT_INCLUDE,
+				},
+			},
+		});
+
+		const hasNext = rows.length > params.size;
+		const pageRows = hasNext ? rows.slice(0, params.size) : rows;
+		const items = pageRows.map(toRecord);
+		const lastItem = items.at(-1);
+
+		return {
+			items,
+			nextCursor: hasNext && lastItem ? encodeTodoCommentCursor(lastItem, params.sort) : null,
+			hasNext,
+			size: params.size,
+		};
+	}
+
+	/** 뿌리 → 부모 순서의 조상. path 덕분에 깊이와 무관하게 한 번의 조회로 끝난다. */
+	async findAncestors(todoId: number, path: readonly string[]): Promise<TodoCommentRecord[]> {
+		if (path.length === 0) {
+			return [];
+		}
+
+		const rows = await this.client.todoComment.findMany({
+			where: { todoId, id: { in: [...path] } },
+			include: COMMENT_INCLUDE,
+		});
+		const rowById = new Map(rows.map((row) => [row.id, row]));
+
+		return path.flatMap((ancestorId) => {
+			const row = rowById.get(ancestorId);
+
+			return row ? [toRecord(row)] : [];
+		});
+	}
+
+	private buildCursorWhere(params: ListTodoCommentsParams): Prisma.TodoCommentWhereInput | null {
+		const cursor = params.cursor;
+
+		if (cursor === undefined) {
+			return null;
+		}
+
+		const createdAt = new Date(cursor.createdAt);
+
+		if (cursor.sort === TODO_COMMENT_SORT.LATEST) {
+			return {
+				OR: [{ createdAt: { lt: createdAt } }, { createdAt, id: { lt: cursor.id } }],
+			};
+		}
+
+		if (cursor.sort !== TODO_COMMENT_SORT.POPULAR) {
+			return null;
+		}
+
+		return {
+			OR: [
+				{ likeCount: { lt: cursor.likeCount } },
+				{ likeCount: cursor.likeCount, replyCount: { lt: cursor.replyCount } },
+				{
+					likeCount: cursor.likeCount,
+					replyCount: cursor.replyCount,
+					createdAt: { lt: createdAt },
+				},
+				{
+					likeCount: cursor.likeCount,
+					replyCount: cursor.replyCount,
+					createdAt,
+					id: { lt: cursor.id },
+				},
+			],
+		};
+	}
+
+	async findLikedCommentIds(commentIds: readonly string[], viewerId: string): Promise<Set<string>> {
+		if (commentIds.length === 0) {
+			return new Set();
+		}
+
+		const likes = await this.client.todoCommentLike.findMany({
+			where: { commentId: { in: [...commentIds] }, userId: viewerId, isActive: true },
+			select: { commentId: true },
+		});
+
+		return new Set(likes.map((like) => like.commentId));
+	}
+
+	async findUserDisplayName(userId: string): Promise<string | null> {
+		const profile = await this.client.userProfile.findUnique({
+			where: { userId },
+			select: { name: true },
+		});
+
+		return profile?.name ?? null;
+	}
+
+	/**
+	 * 사슬을 한 번에 심는다.
+	 *
+	 * 글마다 왕복하면 길이에 비례해 쿼리가 늘어난다. 재시도로 이미 다 있는 경우를 한 번의 조회로 걸러내고,
+	 * 새로 만들 때만 글 수만큼 create를 돈다 — 각 글의 부모가 바로 앞 글이라 순서를 건너뛸 수 없기 때문이다.
+	 * 카운터는 마지막에 한 번씩만 올린다.
+	 */
+	async createCommentChain(
+		input: CreateTodoCommentChainInput,
+	): Promise<TodoCommentChainCreationResult> {
+		const clientRequestIds = input.items.map((item) => item.clientRequestId);
+		const existing = await this.client.todoComment.findMany({
+			where: { authorId: input.authorId, clientRequestId: { in: clientRequestIds } },
+			include: COMMENT_INCLUDE,
+		});
+
+		if (existing.length === input.items.length) {
+			const byRequestId = new Map(existing.map((row) => [row.clientRequestId, row]));
+
+			return {
+				comments: clientRequestIds.flatMap((id) => {
+					const row = byRequestId.get(id);
+
+					return row ? [toRecord(row)] : [];
+				}),
+				createdCount: 0,
+			};
+		}
+
+		let placement = input.placement;
+		const comments: TodoCommentRecord[] = [];
+		const lastIndex = input.items.length - 1;
+
+		for (const [index, item] of input.items.entries()) {
+			const row = await this.client.todoComment.create({
+				data: {
+					todoId: input.todoId,
+					authorId: input.authorId,
+					clientRequestId: item.clientRequestId,
+					content: item.content,
+					parentId: placement.parentId?.getValue() ?? null,
+					rootId: placement.rootId?.getValue() ?? null,
+					path: [...placement.path],
+					depth: placement.depth,
+					// 마지막을 뺀 모든 글은 바로 다음 글을 직계 자식으로 갖는다.
+					// 심는 순간 이미 아는 수라서, 뒤따라 세는 쿼리를 만들지 않는다.
+					replyCount: index < lastIndex ? 1 : 0,
+				},
+				include: COMMENT_INCLUDE,
+			});
+
+			comments.push(toRecord(row));
+			placement = placement.under(TodoCommentId.create(row.id));
+		}
+
+		return { comments, createdCount: comments.length };
+	}
+
+	async updateComment(comment: TodoComment): Promise<void> {
+		await this.client.todoComment.update({
+			where: { id: comment.id.getValue() },
+			data: { content: comment.content, editedAt: comment.editedAt },
+		});
+	}
+
+	async deleteComment(comment: TodoComment): Promise<void> {
+		await this.client.todoComment.update({
+			where: { id: comment.id.getValue() },
+			data: { content: null, deletedAt: comment.deletedAt, likeCount: 0 },
+		});
+		await this.client.todoCommentLike.updateMany({
+			where: { commentId: comment.id.getValue(), isActive: true },
+			data: { isActive: false },
+		});
+	}
+
+	async increaseTodoCommentCount(todoId: number, amount: number): Promise<void> {
+		await this.client.todo.update({
+			where: { id: todoId },
+			data: { commentCount: { increment: amount } },
+		});
+	}
+
+	async decrementTodoCommentCount(todoId: number): Promise<void> {
+		await this.client.todo.updateMany({
+			where: { id: todoId, commentCount: { gt: 0 } },
+			data: { commentCount: { decrement: 1 } },
+		});
+	}
+
+	/** 답글 수는 직계 부모에만 쌓인다. */
+	async incrementReplyCount(parentId: string): Promise<void> {
+		await this.client.todoComment.update({
+			where: { id: parentId },
+			data: { replyCount: { increment: 1 } },
+		});
+	}
+
+	/**
+	 * 삭제된 댓글이 목록에서 사라진 만큼 조상의 답글 수를 줄인다.
+	 * 묘비로 남는 조상을 만나면 거기서 멈춘다 — 그 위로는 보이는 자식 수가 그대로다.
+	 */
+	async dropDeletedFromAncestors(commentId: string, path: readonly string[]): Promise<void> {
+		const chain = [commentId, ...[...path].reverse()];
+
+		for (const [index, id] of chain.entries()) {
+			const node = await this.client.todoComment.findUniqueOrThrow({
+				where: { id },
+				select: { deletedAt: true, replyCount: true },
+			});
+
+			if (node.deletedAt === null || node.replyCount > 0) {
+				return;
+			}
+
+			const parentId = chain[index + 1];
+
+			if (parentId === undefined) {
+				return;
+			}
+
+			await this.client.todoComment.updateMany({
+				where: { id: parentId, replyCount: { gt: 0 } },
+				data: { replyCount: { decrement: 1 } },
+			});
+		}
+	}
+
+	async setLike(
+		todoId: number,
+		commentId: string,
+		userId: string,
+	): Promise<TodoCommentLikeTransition> {
+		const [comment, existingLike] = await Promise.all([
+			this.client.todoComment.findFirstOrThrow({
+				where: { id: commentId, todoId },
+				select: { authorId: true, likeCount: true },
+			}),
+			this.client.todoCommentLike.findUnique({
+				where: { commentId_userId: { commentId, userId } },
+			}),
+		]);
+
+		if (existingLike?.isActive) {
+			return {
+				commentId,
+				commentAuthorId: comment.authorId,
+				changed: false,
+				isLiked: true,
+				likeCount: comment.likeCount,
+				wasEverNotified: existingLike.notifiedAt !== null,
+			};
+		}
+
+		const changed = existingLike
+			? await this.client.todoCommentLike.updateMany({
+					where: { commentId, userId, isActive: false },
+					data: { isActive: true },
+				})
+			: await this.client.todoCommentLike.createMany({
+					data: [{ commentId, userId, isActive: true }],
+					skipDuplicates: true,
+				});
+
+		if (changed.count === 1) {
+			const updated = await this.client.todoComment.update({
+				where: { id: commentId },
+				data: { likeCount: { increment: 1 } },
+				select: { likeCount: true },
+			});
+			return {
+				commentId,
+				commentAuthorId: comment.authorId,
+				changed: true,
+				isLiked: true,
+				likeCount: updated.likeCount,
+				wasEverNotified: existingLike?.notifiedAt !== null && existingLike !== null,
+			};
+		}
+
+		const current = await this.client.todoComment.findUniqueOrThrow({
+			where: { id: commentId },
+			select: { likeCount: true },
+		});
+		return {
+			commentId,
+			commentAuthorId: comment.authorId,
+			changed: false,
+			isLiked: true,
+			likeCount: current.likeCount,
+			wasEverNotified: true,
+		};
+	}
+
+	async markLikeNotified(commentId: string, userId: string): Promise<void> {
+		await this.client.todoCommentLike.updateMany({
+			where: { commentId, userId, notifiedAt: null },
+			data: { notifiedAt: new Date() },
+		});
+	}
+
+	async removeLike(
+		todoId: number,
+		commentId: string,
+		userId: string,
+	): Promise<TodoCommentLikeTransition> {
+		const comment = await this.client.todoComment.findFirstOrThrow({
+			where: { id: commentId, todoId },
+			select: { authorId: true, likeCount: true },
+		});
+		const changed = await this.client.todoCommentLike.updateMany({
+			where: { commentId, userId, isActive: true },
+			data: { isActive: false },
+		});
+
+		if (changed.count === 1) {
+			await this.client.todoComment.updateMany({
+				where: { id: commentId, likeCount: { gt: 0 } },
+				data: { likeCount: { decrement: 1 } },
+			});
+		}
+
+		const [current, like] = await Promise.all([
+			this.client.todoComment.findUniqueOrThrow({
+				where: { id: commentId },
+				select: { likeCount: true },
+			}),
+			this.client.todoCommentLike.findUnique({
+				where: { commentId_userId: { commentId, userId } },
+				select: { notifiedAt: true },
+			}),
+		]);
+
+		return {
+			commentId,
+			commentAuthorId: comment.authorId,
+			changed: changed.count === 1,
+			isLiked: false,
+			likeCount: current.likeCount,
+			wasEverNotified: like?.notifiedAt !== null && like !== null,
+		};
+	}
+
+	async recordView(
+		todoId: number,
+		viewerId: string,
+	): Promise<{ recorded: boolean; viewCount: number }> {
+		const inserted = await this.client.todoView.createMany({
+			data: [{ todoId, viewerId }],
+			skipDuplicates: true,
+		});
+
+		if (inserted.count === 1) {
+			const updated = await this.client.todo.update({
+				where: { id: todoId },
+				data: { viewCount: { increment: 1 } },
+				select: { viewCount: true },
+			});
+			return { recorded: true, viewCount: updated.viewCount };
+		}
+
+		const todo = await this.client.todo.findUniqueOrThrow({
+			where: { id: todoId },
+			select: { viewCount: true },
+		});
+		return { recorded: false, viewCount: todo.viewCount };
+	}
+}

--- a/apps/api/src/todo-comment/infrastructure/persistence/todo-details.mapper.ts
+++ b/apps/api/src/todo-comment/infrastructure/persistence/todo-details.mapper.ts
@@ -1,0 +1,58 @@
+import type { Todo } from "@aido/validators";
+
+import type { Prisma } from "@/generated/prisma/client";
+import {
+	toDateString,
+	toDateStringOrNull,
+	toISOString,
+	toISOStringOrNull,
+} from "@/shared/domain/date/utils/format";
+
+export const TODO_DETAILS_INCLUDE = {
+	category: true,
+	items: { orderBy: [{ sortOrder: "asc" }, { id: "asc" }] },
+	user: { include: { profile: true } },
+} satisfies Prisma.TodoInclude;
+
+export type TodoDetailsRow = Prisma.TodoGetPayload<{ include: typeof TODO_DETAILS_INCLUDE }>;
+
+export function toTodoResponse(row: TodoDetailsRow): Todo {
+	const items = row.items.map((item) => ({
+		id: item.id,
+		title: item.title,
+		completed: item.completed,
+		sortOrder: item.sortOrder,
+		createdAt: toISOString(item.createdAt),
+		updatedAt: toISOString(item.updatedAt),
+	}));
+
+	return {
+		id: row.id,
+		userId: row.userId,
+		title: row.title,
+		content: null,
+		sortOrder: row.sortOrder,
+		completed: row.completed,
+		completedAt: toISOStringOrNull(row.completedAt),
+		startDate: toDateString(row.startDate),
+		endDate: toDateStringOrNull(row.endDate),
+		scheduledTime: toISOStringOrNull(row.scheduledTime),
+		isAllDay: row.isAllDay,
+		visibility: row.visibility,
+		recurrenceGroupId: row.recurrenceGroupId,
+		category: {
+			id: row.category.id,
+			name: row.category.name,
+			color: row.category.color,
+			sortOrder: row.category.sortOrder,
+		},
+		items,
+		itemStats: {
+			total: items.length,
+			completed: items.filter((item) => item.completed).length,
+		},
+		commentCount: row.commentCount,
+		createdAt: toISOString(row.createdAt),
+		updatedAt: toISOString(row.updatedAt),
+	};
+}

--- a/apps/api/src/todo-comment/presentation/dtos/index.ts
+++ b/apps/api/src/todo-comment/presentation/dtos/index.ts
@@ -1,0 +1,2 @@
+export * from "./todo-comment.request.dto";
+export * from "./todo-comment.response.dto";

--- a/apps/api/src/todo-comment/presentation/dtos/todo-comment.request.dto.ts
+++ b/apps/api/src/todo-comment/presentation/dtos/todo-comment.request.dto.ts
@@ -1,0 +1,14 @@
+import {
+	createTodoCommentChainSchema,
+	getTodoCommentsQuerySchema,
+	todoCommentIdParamSchema,
+	todoDetailsParamSchema,
+	updateTodoCommentSchema,
+} from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class TodoDetailsParamDto extends createZodDto(todoDetailsParamSchema) {}
+export class TodoCommentIdParamDto extends createZodDto(todoCommentIdParamSchema) {}
+export class WriteTodoCommentChainDto extends createZodDto(createTodoCommentChainSchema) {}
+export class UpdateTodoCommentDto extends createZodDto(updateTodoCommentSchema) {}
+export class GetTodoCommentsQueryDto extends createZodDto(getTodoCommentsQuerySchema) {}

--- a/apps/api/src/todo-comment/presentation/dtos/todo-comment.response.dto.ts
+++ b/apps/api/src/todo-comment/presentation/dtos/todo-comment.response.dto.ts
@@ -1,0 +1,20 @@
+import {
+	deleteTodoCommentResponseSchema,
+	todoCommentLikeResponseSchema,
+	todoCommentChainResponseSchema,
+	todoCommentMutationResponseSchema,
+	todoCommentThreadResponseSchema,
+	paginatedTodoCommentsSchema,
+	todoDetailsResponseSchema,
+} from "@aido/validators";
+import { createZodDto } from "nestjs-zod";
+
+export class TodoDetailsResponseDto extends createZodDto(todoDetailsResponseSchema) {}
+export class PaginatedTodoCommentsResponseDto extends createZodDto(paginatedTodoCommentsSchema) {}
+export class TodoCommentChainResponseDto extends createZodDto(todoCommentChainResponseSchema) {}
+export class TodoCommentMutationResponseDto extends createZodDto(
+	todoCommentMutationResponseSchema,
+) {}
+export class TodoCommentLikeResponseDto extends createZodDto(todoCommentLikeResponseSchema) {}
+export class DeleteTodoCommentResponseDto extends createZodDto(deleteTodoCommentResponseSchema) {}
+export class TodoCommentThreadResponseDto extends createZodDto(todoCommentThreadResponseSchema) {}

--- a/apps/api/src/todo-comment/presentation/todo-comment.controller.ts
+++ b/apps/api/src/todo-comment/presentation/todo-comment.controller.ts
@@ -1,0 +1,234 @@
+import { ErrorCode } from "@aido/errors";
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from "@nestjs/common";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+
+import { CurrentUser, type CurrentUserPayload } from "@/auth/presentation/decorators";
+import {
+	ApiBadRequestError,
+	ApiCreatedResponse,
+	ApiDoc,
+	ApiForbiddenError,
+	ApiNotFoundError,
+	ApiSuccessResponse,
+	ApiUnauthorizedError,
+	SWAGGER_TAGS,
+} from "@/shared/presentation/swagger";
+
+import {
+	GetTodoCommentThreadUseCase,
+	GetTodoDetailsUseCase,
+	ListTodoCommentRepliesUseCase,
+	ListTodoCommentsUseCase,
+} from "../application/queries";
+import {
+	DeleteTodoCommentUseCase,
+	LikeTodoCommentUseCase,
+	UnlikeTodoCommentUseCase,
+	UpdateTodoCommentUseCase,
+	WriteTodoCommentChainUseCase,
+} from "../application/use-cases";
+import {
+	DeleteTodoCommentResponseDto,
+	GetTodoCommentsQueryDto,
+	TodoCommentIdParamDto,
+	TodoCommentChainResponseDto,
+	TodoCommentLikeResponseDto,
+	TodoCommentMutationResponseDto,
+	PaginatedTodoCommentsResponseDto,
+	TodoCommentThreadResponseDto,
+	TodoDetailsParamDto,
+	TodoDetailsResponseDto,
+	UpdateTodoCommentDto,
+	WriteTodoCommentChainDto,
+} from "./dtos";
+
+@ApiTags(SWAGGER_TAGS.TODOS)
+@ApiBearerAuth()
+@Controller("todos/:todoId")
+export class TodoCommentController {
+	constructor(
+		private readonly getTodoDetailsUseCase: GetTodoDetailsUseCase,
+		private readonly listTodoCommentsUseCase: ListTodoCommentsUseCase,
+		private readonly listTodoCommentRepliesUseCase: ListTodoCommentRepliesUseCase,
+		private readonly getTodoCommentThreadUseCase: GetTodoCommentThreadUseCase,
+		private readonly writeTodoCommentChainUseCase: WriteTodoCommentChainUseCase,
+		private readonly updateTodoCommentUseCase: UpdateTodoCommentUseCase,
+		private readonly deleteTodoCommentUseCase: DeleteTodoCommentUseCase,
+		private readonly likeTodoCommentUseCase: LikeTodoCommentUseCase,
+		private readonly unlikeTodoCommentUseCase: UnlikeTodoCommentUseCase,
+	) {}
+
+	@Get("details")
+	@ApiDoc({ summary: "댓글 화면용 할 일 상세 조회", operationId: "getTodoDetails" })
+	@ApiSuccessResponse({ type: TodoDetailsResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.TODO_0801)
+	getDetails(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoDetailsParamDto,
+	): Promise<TodoDetailsResponseDto> {
+		return this.getTodoDetailsUseCase.execute({ todoId: params.todoId, viewerId: user.userId });
+	}
+
+	@Get("comments")
+	@ApiDoc({ summary: "할 일 최상위 댓글 목록", operationId: "getTodoComments" })
+	@ApiSuccessResponse({ type: PaginatedTodoCommentsResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.TODO_0801)
+	@ApiBadRequestError(ErrorCode.SYS_0002)
+	listComments(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoDetailsParamDto,
+		@Query() query: GetTodoCommentsQueryDto,
+	): Promise<PaginatedTodoCommentsResponseDto> {
+		return this.listTodoCommentsUseCase.execute({
+			todoId: params.todoId,
+			viewerId: user.userId,
+			sort: query.sort,
+			size: query.size,
+			cursor: query.cursor,
+		});
+	}
+
+	@Get("comments/:commentId/thread")
+	@ApiDoc({
+		summary: "댓글 스레드 조회 (조상·본문·답글 첫 페이지)",
+		operationId: "getTodoCommentThread",
+	})
+	@ApiSuccessResponse({ type: TodoCommentThreadResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.TODO_0831)
+	getCommentThread(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoCommentIdParamDto,
+	): Promise<TodoCommentThreadResponseDto> {
+		return this.getTodoCommentThreadUseCase.execute({
+			todoId: params.todoId,
+			commentId: params.commentId,
+			viewerId: user.userId,
+		});
+	}
+
+	@Get("comments/:commentId/replies")
+	@ApiDoc({ summary: "댓글의 직계 답글 목록", operationId: "getTodoCommentReplies" })
+	@ApiSuccessResponse({ type: PaginatedTodoCommentsResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.TODO_0831)
+	listReplies(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoCommentIdParamDto,
+		@Query() query: GetTodoCommentsQueryDto,
+	): Promise<PaginatedTodoCommentsResponseDto> {
+		return this.listTodoCommentRepliesUseCase.execute({
+			todoId: params.todoId,
+			commentId: params.commentId,
+			viewerId: user.userId,
+			sort: query.sort,
+			size: query.size,
+			cursor: query.cursor,
+		});
+	}
+
+	@Post("comments")
+	@ApiDoc({ summary: "할 일 댓글 작성 (한 번에 이어 쓰기 가능)", operationId: "createTodoComment" })
+	@ApiCreatedResponse({ type: TodoCommentChainResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.TODO_0801)
+	writeComments(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoDetailsParamDto,
+		@Body() body: WriteTodoCommentChainDto,
+	): Promise<TodoCommentChainResponseDto> {
+		return this.writeTodoCommentChainUseCase.execute({
+			todoId: params.todoId,
+			authorId: user.userId,
+			parentId: null,
+			items: body.items,
+		});
+	}
+
+	@Post("comments/:commentId/replies")
+	@ApiDoc({
+		summary: "댓글에 답글 작성 (깊이 제한 없음, 한 번에 이어 쓰기 가능)",
+		operationId: "replyTodoComment",
+	})
+	@ApiCreatedResponse({ type: TodoCommentChainResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiNotFoundError(ErrorCode.TODO_0831)
+	writeReplies(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoCommentIdParamDto,
+		@Body() body: WriteTodoCommentChainDto,
+	): Promise<TodoCommentChainResponseDto> {
+		return this.writeTodoCommentChainUseCase.execute({
+			todoId: params.todoId,
+			authorId: user.userId,
+			parentId: params.commentId,
+			items: body.items,
+		});
+	}
+
+	@Patch("comments/:commentId")
+	@ApiDoc({ summary: "본인 댓글 수정", operationId: "updateTodoComment" })
+	@ApiSuccessResponse({ type: TodoCommentMutationResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiForbiddenError(ErrorCode.TODO_0832)
+	updateComment(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoCommentIdParamDto,
+		@Body() body: UpdateTodoCommentDto,
+	): Promise<TodoCommentMutationResponseDto> {
+		return this.updateTodoCommentUseCase.execute({
+			todoId: params.todoId,
+			commentId: params.commentId,
+			userId: user.userId,
+			content: body.content,
+		});
+	}
+
+	@Delete("comments/:commentId")
+	@ApiDoc({ summary: "본인 댓글 삭제", operationId: "deleteTodoComment" })
+	@ApiSuccessResponse({ type: DeleteTodoCommentResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	@ApiForbiddenError(ErrorCode.TODO_0832)
+	deleteComment(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoCommentIdParamDto,
+	): Promise<DeleteTodoCommentResponseDto> {
+		return this.deleteTodoCommentUseCase.execute({
+			todoId: params.todoId,
+			commentId: params.commentId,
+			userId: user.userId,
+		});
+	}
+
+	@Put("comments/:commentId/likes")
+	@ApiDoc({ summary: "댓글 좋아요", operationId: "likeTodoComment" })
+	@ApiSuccessResponse({ type: TodoCommentLikeResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	likeComment(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoCommentIdParamDto,
+	): Promise<TodoCommentLikeResponseDto> {
+		return this.likeTodoCommentUseCase.execute({
+			todoId: params.todoId,
+			commentId: params.commentId,
+			userId: user.userId,
+		});
+	}
+
+	@Delete("comments/:commentId/likes")
+	@ApiDoc({ summary: "댓글 좋아요 취소", operationId: "unlikeTodoComment" })
+	@ApiSuccessResponse({ type: TodoCommentLikeResponseDto })
+	@ApiUnauthorizedError(ErrorCode.AUTH_0107)
+	unlikeComment(
+		@CurrentUser() user: CurrentUserPayload,
+		@Param() params: TodoCommentIdParamDto,
+	): Promise<TodoCommentLikeResponseDto> {
+		return this.unlikeTodoCommentUseCase.execute({
+			todoId: params.todoId,
+			commentId: params.commentId,
+			userId: user.userId,
+		});
+	}
+}

--- a/apps/api/src/todo-comment/todo-comment.module.ts
+++ b/apps/api/src/todo-comment/todo-comment.module.ts
@@ -1,0 +1,45 @@
+import { Module } from "@nestjs/common";
+
+import { NotificationModule } from "@/notification";
+
+import { TODO_COMMENT_CACHE } from "./application/ports/todo-comment-cache.port";
+import { TODO_COMMENT_NOTIFICATION } from "./application/ports/todo-comment-notification.port";
+import { TODO_COMMENT_REPOSITORY } from "./application/ports/todo-comment.repository.port";
+import {
+	GetTodoCommentThreadUseCase,
+	GetTodoDetailsUseCase,
+	ListTodoCommentRepliesUseCase,
+	ListTodoCommentsUseCase,
+} from "./application/queries";
+import {
+	DeleteTodoCommentUseCase,
+	LikeTodoCommentUseCase,
+	UnlikeTodoCommentUseCase,
+	UpdateTodoCommentUseCase,
+	WriteTodoCommentChainUseCase,
+} from "./application/use-cases";
+import { TodoCommentNotificationAdapter } from "./infrastructure/adapters/todo-comment-notification.adapter";
+import { TodoCommentCacheAdapter } from "./infrastructure/cache/todo-comment-cache.adapter";
+import { PrismaTodoCommentRepository } from "./infrastructure/persistence/prisma-todo-comment.repository";
+import { TodoCommentController } from "./presentation/todo-comment.controller";
+
+@Module({
+	imports: [NotificationModule],
+	controllers: [TodoCommentController],
+	providers: [
+		PrismaTodoCommentRepository,
+		{ provide: TODO_COMMENT_REPOSITORY, useExisting: PrismaTodoCommentRepository },
+		{ provide: TODO_COMMENT_CACHE, useClass: TodoCommentCacheAdapter },
+		{ provide: TODO_COMMENT_NOTIFICATION, useClass: TodoCommentNotificationAdapter },
+		GetTodoDetailsUseCase,
+		ListTodoCommentsUseCase,
+		ListTodoCommentRepliesUseCase,
+		GetTodoCommentThreadUseCase,
+		WriteTodoCommentChainUseCase,
+		UpdateTodoCommentUseCase,
+		DeleteTodoCommentUseCase,
+		LikeTodoCommentUseCase,
+		UnlikeTodoCommentUseCase,
+	],
+})
+export class TodoCommentModule {}

--- a/apps/api/src/todo/application/events/index.ts
+++ b/apps/api/src/todo/application/events/index.ts
@@ -1,20 +1,5 @@
-import { TodoCreatedHandler } from "./todo-created.handler";
-import { TodoDeletedHandler } from "./todo-deleted.handler";
-import { TodoRescheduledHandler } from "./todo-rescheduled.handler";
-import { TodoToggledHandler } from "./todo-toggled.handler";
-import { TodoUpdatedHandler } from "./todo-updated.handler";
-
 export * from "./todo-created.handler";
 export * from "./todo-deleted.handler";
 export * from "./todo-rescheduled.handler";
 export * from "./todo-toggled.handler";
 export * from "./todo-updated.handler";
-
-/** 모듈 등록용 도메인 이벤트 핸들러 목록 */
-export const EventHandlers = [
-	TodoCreatedHandler,
-	TodoDeletedHandler,
-	TodoRescheduledHandler,
-	TodoToggledHandler,
-	TodoUpdatedHandler,
-];

--- a/apps/api/src/todo/application/queries/index.ts
+++ b/apps/api/src/todo/application/queries/index.ts
@@ -1,22 +1,5 @@
-import { GetFriendTodosUseCase } from "./get-friend-todos/get-friend-todos.use-case";
-import { GetTodoByIdUseCase } from "./get-todo-by-id/get-todo-by-id.use-case";
-import { GetTodoResourceLimitUseCase } from "./get-todo-resource-limit/get-todo-resource-limit.use-case";
-import { GetTodoSummaryUseCase } from "./get-todo-summary/get-todo-summary.use-case";
-import { GetTodosUseCase } from "./get-todos/get-todos.use-case";
-
-export {
-	GetFriendTodosUseCase,
-	GetTodoByIdUseCase,
-	GetTodoResourceLimitUseCase,
-	GetTodoSummaryUseCase,
-	GetTodosUseCase,
-};
-
-/** Todo 쿼리 use-case (모듈 등록용 배럴). */
-export const TodoQueryUseCases = [
-	GetTodoByIdUseCase,
-	GetTodosUseCase,
-	GetFriendTodosUseCase,
-	GetTodoResourceLimitUseCase,
-	GetTodoSummaryUseCase,
-];
+export * from "./get-friend-todos/get-friend-todos.use-case";
+export * from "./get-todo-by-id/get-todo-by-id.use-case";
+export * from "./get-todo-resource-limit/get-todo-resource-limit.use-case";
+export * from "./get-todo-summary/get-todo-summary.use-case";
+export * from "./get-todos/get-todos.use-case";

--- a/apps/api/src/todo/application/todo.providers.ts
+++ b/apps/api/src/todo/application/todo.providers.ts
@@ -1,0 +1,51 @@
+import { TodoCreatedHandler } from "./events/todo-created.handler";
+import { TodoDeletedHandler } from "./events/todo-deleted.handler";
+import { TodoRescheduledHandler } from "./events/todo-rescheduled.handler";
+import { TodoToggledHandler } from "./events/todo-toggled.handler";
+import { TodoUpdatedHandler } from "./events/todo-updated.handler";
+import { GetFriendTodosUseCase } from "./queries/get-friend-todos/get-friend-todos.use-case";
+import { GetTodoByIdUseCase } from "./queries/get-todo-by-id/get-todo-by-id.use-case";
+import { GetTodoResourceLimitUseCase } from "./queries/get-todo-resource-limit/get-todo-resource-limit.use-case";
+import { GetTodoSummaryUseCase } from "./queries/get-todo-summary/get-todo-summary.use-case";
+import { GetTodosUseCase } from "./queries/get-todos/get-todos.use-case";
+import { AddTodoItemUseCase } from "./use-cases/add-todo-item/add-todo-item.use-case";
+import { ChangeTodoCategoryUseCase } from "./use-cases/change-todo-category/change-todo-category.use-case";
+import { CreateRecurringTodosUseCase } from "./use-cases/create-recurring-todos/create-recurring-todos.use-case";
+import { CreateTodoUseCase } from "./use-cases/create-todo/create-todo.use-case";
+import { DeleteTodoItemUseCase } from "./use-cases/delete-todo-item/delete-todo-item.use-case";
+import { DeleteTodoUseCase } from "./use-cases/delete-todo/delete-todo.use-case";
+import { ReorderTodoItemsUseCase } from "./use-cases/reorder-todo-items/reorder-todo-items.use-case";
+import { ReorderTodoUseCase } from "./use-cases/reorder-todo/reorder-todo.use-case";
+import { ToggleTodoCompleteUseCase } from "./use-cases/toggle-todo-complete/toggle-todo-complete.use-case";
+import { UpdateTodoItemUseCase } from "./use-cases/update-todo-item/update-todo-item.use-case";
+import { UpdateTodoScheduleUseCase } from "./use-cases/update-todo-schedule/update-todo-schedule.use-case";
+import { UpdateTodoTitleUseCase } from "./use-cases/update-todo-title/update-todo-title.use-case";
+import { UpdateTodoVisibilityUseCase } from "./use-cases/update-todo-visibility/update-todo-visibility.use-case";
+import { UpdateTodoUseCase } from "./use-cases/update-todo/update-todo.use-case";
+
+export const TODO_PROVIDERS = [
+	AddTodoItemUseCase,
+	ChangeTodoCategoryUseCase,
+	CreateRecurringTodosUseCase,
+	CreateTodoUseCase,
+	DeleteTodoUseCase,
+	DeleteTodoItemUseCase,
+	ReorderTodoUseCase,
+	ReorderTodoItemsUseCase,
+	ToggleTodoCompleteUseCase,
+	UpdateTodoUseCase,
+	UpdateTodoItemUseCase,
+	UpdateTodoScheduleUseCase,
+	UpdateTodoTitleUseCase,
+	UpdateTodoVisibilityUseCase,
+	GetTodoByIdUseCase,
+	GetTodosUseCase,
+	GetFriendTodosUseCase,
+	GetTodoResourceLimitUseCase,
+	GetTodoSummaryUseCase,
+	TodoCreatedHandler,
+	TodoDeletedHandler,
+	TodoRescheduledHandler,
+	TodoToggledHandler,
+	TodoUpdatedHandler,
+] as const;

--- a/apps/api/src/todo/application/use-cases/index.ts
+++ b/apps/api/src/todo/application/use-cases/index.ts
@@ -1,49 +1,14 @@
-import { AddTodoItemUseCase } from "./add-todo-item/add-todo-item.use-case";
-import { ChangeTodoCategoryUseCase } from "./change-todo-category/change-todo-category.use-case";
-import { CreateRecurringTodosUseCase } from "./create-recurring-todos/create-recurring-todos.use-case";
-import { CreateTodoUseCase } from "./create-todo/create-todo.use-case";
-import { DeleteTodoItemUseCase } from "./delete-todo-item/delete-todo-item.use-case";
-import { DeleteTodoUseCase } from "./delete-todo/delete-todo.use-case";
-import { ReorderTodoItemsUseCase } from "./reorder-todo-items/reorder-todo-items.use-case";
-import { ReorderTodoUseCase } from "./reorder-todo/reorder-todo.use-case";
-import { ToggleTodoCompleteUseCase } from "./toggle-todo-complete/toggle-todo-complete.use-case";
-import { UpdateTodoItemUseCase } from "./update-todo-item/update-todo-item.use-case";
-import { UpdateTodoScheduleUseCase } from "./update-todo-schedule/update-todo-schedule.use-case";
-import { UpdateTodoTitleUseCase } from "./update-todo-title/update-todo-title.use-case";
-import { UpdateTodoVisibilityUseCase } from "./update-todo-visibility/update-todo-visibility.use-case";
-import { UpdateTodoUseCase } from "./update-todo/update-todo.use-case";
-
-export {
-	AddTodoItemUseCase,
-	ChangeTodoCategoryUseCase,
-	CreateRecurringTodosUseCase,
-	CreateTodoUseCase,
-	DeleteTodoItemUseCase,
-	DeleteTodoUseCase,
-	ReorderTodoItemsUseCase,
-	ReorderTodoUseCase,
-	ToggleTodoCompleteUseCase,
-	UpdateTodoItemUseCase,
-	UpdateTodoScheduleUseCase,
-	UpdateTodoTitleUseCase,
-	UpdateTodoUseCase,
-	UpdateTodoVisibilityUseCase,
-};
-
-/** Todo 커맨드 use-case (모듈 등록용 배럴). */
-export const TodoUseCases = [
-	AddTodoItemUseCase,
-	ChangeTodoCategoryUseCase,
-	CreateRecurringTodosUseCase,
-	CreateTodoUseCase,
-	DeleteTodoUseCase,
-	DeleteTodoItemUseCase,
-	ReorderTodoUseCase,
-	ReorderTodoItemsUseCase,
-	ToggleTodoCompleteUseCase,
-	UpdateTodoUseCase,
-	UpdateTodoItemUseCase,
-	UpdateTodoScheduleUseCase,
-	UpdateTodoTitleUseCase,
-	UpdateTodoVisibilityUseCase,
-];
+export * from "./add-todo-item/add-todo-item.use-case";
+export * from "./change-todo-category/change-todo-category.use-case";
+export * from "./create-recurring-todos/create-recurring-todos.use-case";
+export * from "./create-todo/create-todo.use-case";
+export * from "./delete-todo-item/delete-todo-item.use-case";
+export * from "./delete-todo/delete-todo.use-case";
+export * from "./reorder-todo-items/reorder-todo-items.use-case";
+export * from "./reorder-todo/reorder-todo.use-case";
+export * from "./toggle-todo-complete/toggle-todo-complete.use-case";
+export * from "./update-todo-item/update-todo-item.use-case";
+export * from "./update-todo-schedule/update-todo-schedule.use-case";
+export * from "./update-todo-title/update-todo-title.use-case";
+export * from "./update-todo-visibility/update-todo-visibility.use-case";
+export * from "./update-todo/update-todo.use-case";

--- a/apps/api/src/todo/infrastructure/persistence/todo-response.mapper.spec.ts
+++ b/apps/api/src/todo/infrastructure/persistence/todo-response.mapper.spec.ts
@@ -68,6 +68,7 @@ describe("TodoMapper — 할 일 매퍼", () => {
 				},
 				items: [],
 				itemStats: { total: 0, completed: 0 },
+				commentCount: 0,
 				createdAt: "2024-01-01T00:00:00.000Z",
 				updatedAt: "2024-01-02T00:00:00.000Z",
 			});

--- a/apps/api/src/todo/infrastructure/persistence/todo-response.mapper.ts
+++ b/apps/api/src/todo/infrastructure/persistence/todo-response.mapper.ts
@@ -72,6 +72,7 @@ export abstract class TodoMapper {
 				total: items.length,
 				completed: items.filter((i) => i.completed).length,
 			},
+			commentCount: entity.commentCount,
 			createdAt: toISOString(entity.createdAt),
 			updatedAt: toISOString(entity.updatedAt),
 		};

--- a/apps/api/src/todo/todo.module.ts
+++ b/apps/api/src/todo/todo.module.ts
@@ -5,7 +5,6 @@ import { NotificationModule } from "../notification/notification.module";
 import { SchedulerModule } from "../scheduler/scheduler.module";
 import { TodoCategoryModule } from "../todo-category/todo-category.module";
 import { UserSettingsModule } from "../user-settings/user-settings.module";
-import { EventHandlers } from "./application/events";
 import { CATEGORY_OWNERSHIP } from "./application/ports/category-ownership.port";
 import { FRIEND_PORT } from "./application/ports/friend.port";
 import { STREAK_PORT } from "./application/ports/streak.port";
@@ -14,12 +13,8 @@ import { TODO_NOTIFICATION } from "./application/ports/todo-notification.port";
 import { TODO_READ_REPOSITORY } from "./application/ports/todo-read.repository.port";
 import { TODO_REMINDER } from "./application/ports/todo-reminder.port";
 import { TODO_REPOSITORY } from "./application/ports/todo.repository.port";
-import { TodoQueryUseCases } from "./application/queries";
-import {
-	CreateRecurringTodosUseCase,
-	CreateTodoUseCase,
-	TodoUseCases,
-} from "./application/use-cases";
+import { TODO_PROVIDERS } from "./application/todo.providers";
+import { CreateRecurringTodosUseCase, CreateTodoUseCase } from "./application/use-cases";
 import { CategoryOwnershipAdapter } from "./infrastructure/adapters/category-ownership.adapter";
 import { FriendAdapter } from "./infrastructure/adapters/friend.adapter";
 import { PrismaTodoReadRepository } from "./infrastructure/adapters/prisma-todo-read.repository";
@@ -72,9 +67,7 @@ import { TodoController } from "./presentation/todo.controller";
 		{ provide: STREAK_PORT, useClass: StreakAdapter },
 		{ provide: TODO_NOTIFICATION, useClass: TodoNotificationAdapter },
 		{ provide: TODO_REMINDER, useClass: TodoReminderAdapter },
-		...TodoUseCases,
-		...TodoQueryUseCases,
-		...EventHandlers,
+		...TODO_PROVIDERS,
 	],
 	exports: [CreateTodoUseCase, CreateRecurringTodosUseCase],
 })

--- a/apps/api/src/weather/application/queries/index.ts
+++ b/apps/api/src/weather/application/queries/index.ts
@@ -1,10 +1,3 @@
-import { GetForecastsByGridBatchUseCase } from "./get-forecasts-by-grid-batch/get-forecasts-by-grid-batch.use-case";
-import { GetWeatherConditionsUseCase } from "./get-weather-conditions/get-weather-conditions.use-case";
-import { GetWeatherForecastUseCase } from "./get-weather-forecast/get-weather-forecast.use-case";
-
-/** 모듈 등록용 쿼리 use-case 목록 */
-export const WeatherQueryUseCases = [
-	GetWeatherForecastUseCase,
-	GetWeatherConditionsUseCase,
-	GetForecastsByGridBatchUseCase,
-];
+export * from "./get-forecasts-by-grid-batch/get-forecasts-by-grid-batch.use-case";
+export * from "./get-weather-conditions/get-weather-conditions.use-case";
+export * from "./get-weather-forecast/get-weather-forecast.use-case";

--- a/apps/api/src/weather/application/use-cases/index.ts
+++ b/apps/api/src/weather/application/use-cases/index.ts
@@ -1,4 +1,1 @@
-import { UpsertLocationUseCase } from "./upsert-location/upsert-location.use-case";
-
-/** 모듈 등록용 커맨드 use-case 목록 */
-export const WeatherUseCases = [UpsertLocationUseCase];
+export * from "./upsert-location/upsert-location.use-case";

--- a/apps/api/src/weather/application/weather.providers.ts
+++ b/apps/api/src/weather/application/weather.providers.ts
@@ -1,0 +1,11 @@
+import { GetForecastsByGridBatchUseCase } from "./queries/get-forecasts-by-grid-batch/get-forecasts-by-grid-batch.use-case";
+import { GetWeatherConditionsUseCase } from "./queries/get-weather-conditions/get-weather-conditions.use-case";
+import { GetWeatherForecastUseCase } from "./queries/get-weather-forecast/get-weather-forecast.use-case";
+import { UpsertLocationUseCase } from "./use-cases/upsert-location/upsert-location.use-case";
+
+export const WEATHER_PROVIDERS = [
+	GetWeatherForecastUseCase,
+	GetWeatherConditionsUseCase,
+	GetForecastsByGridBatchUseCase,
+	UpsertLocationUseCase,
+] as const;

--- a/apps/api/src/weather/weather.module.ts
+++ b/apps/api/src/weather/weather.module.ts
@@ -7,10 +7,9 @@ import { SUN_TIME_PROVIDER } from "./application/ports/sun-time-provider.port";
 import { WEATHER_CACHE } from "./application/ports/weather-cache.port";
 import { WEATHER_LOCATION_REPOSITORY } from "./application/ports/weather-location.repository.port";
 import { WEATHER_PROVIDER } from "./application/ports/weather-provider.port";
-import { WeatherQueryUseCases } from "./application/queries";
 import { GetForecastsByGridBatchUseCase } from "./application/queries/get-forecasts-by-grid-batch/get-forecasts-by-grid-batch.use-case";
 import { WeatherForecastReader } from "./application/services/weather-forecast.reader";
-import { WeatherUseCases } from "./application/use-cases";
+import { WEATHER_PROVIDERS } from "./application/weather.providers";
 import { AirkoreaProvider } from "./infrastructure/adapters/airkorea.provider";
 import { KasiSunTimeProvider } from "./infrastructure/adapters/kasi-sun-time.provider";
 import { KmaLifestyleIndexProvider } from "./infrastructure/adapters/kma-lifestyle-index.provider";
@@ -47,8 +46,7 @@ import { WeatherController } from "./presentation/weather.controller";
 		{ provide: SUN_TIME_PROVIDER, useClass: KasiSunTimeProvider },
 		// 조회 캐시 포트 (application → CacheService/CacheKeys 직접 의존 역전)
 		{ provide: WEATHER_CACHE, useClass: WeatherCacheAdapter },
-		...WeatherQueryUseCases,
-		...WeatherUseCases,
+		...WEATHER_PROVIDERS,
 	],
 	exports: [WeatherForecastAccess],
 })

--- a/apps/api/src/weekly-achievement/application/queries/index.ts
+++ b/apps/api/src/weekly-achievement/application/queries/index.ts
@@ -1,8 +1,2 @@
-import { GetWeeklyAchievementUseCase } from "./get-weekly-achievement/get-weekly-achievement.use-case";
-import { GetWeeklyAchievementsUseCase } from "./get-weekly-achievements/get-weekly-achievements.use-case";
-
-/** 모듈 등록용 쿼리 use-case 목록 */
-export const WeeklyAchievementQueryUseCases = [
-	GetWeeklyAchievementsUseCase,
-	GetWeeklyAchievementUseCase,
-];
+export * from "./get-weekly-achievement/get-weekly-achievement.use-case";
+export * from "./get-weekly-achievements/get-weekly-achievements.use-case";

--- a/apps/api/src/weekly-achievement/application/use-cases/index.ts
+++ b/apps/api/src/weekly-achievement/application/use-cases/index.ts
@@ -1,4 +1,1 @@
-import { UpsertWeeklyAchievementsUseCase } from "./upsert-weekly-achievements/upsert-weekly-achievements.use-case";
-
-/** 모듈 등록용 use-case 목록 */
-export const WeeklyAchievementUseCases = [UpsertWeeklyAchievementsUseCase];
+export * from "./upsert-weekly-achievements/upsert-weekly-achievements.use-case";

--- a/apps/api/src/weekly-achievement/application/weekly-achievement.providers.ts
+++ b/apps/api/src/weekly-achievement/application/weekly-achievement.providers.ts
@@ -1,0 +1,9 @@
+import { GetWeeklyAchievementUseCase } from "./queries/get-weekly-achievement/get-weekly-achievement.use-case";
+import { GetWeeklyAchievementsUseCase } from "./queries/get-weekly-achievements/get-weekly-achievements.use-case";
+import { UpsertWeeklyAchievementsUseCase } from "./use-cases/upsert-weekly-achievements/upsert-weekly-achievements.use-case";
+
+export const WEEKLY_ACHIEVEMENT_PROVIDERS = [
+	GetWeeklyAchievementsUseCase,
+	GetWeeklyAchievementUseCase,
+	UpsertWeeklyAchievementsUseCase,
+] as const;

--- a/apps/api/src/weekly-achievement/weekly-achievement.module.ts
+++ b/apps/api/src/weekly-achievement/weekly-achievement.module.ts
@@ -2,9 +2,8 @@ import { Module } from "@nestjs/common";
 
 import { WeeklyAchievementWriterAccess } from "./application/access/weekly-achievement-writer.access";
 import { WEEKLY_ACHIEVEMENT_REPOSITORY } from "./application/ports/weekly-achievement.repository.port";
-import { WeeklyAchievementQueryUseCases } from "./application/queries";
-import { WeeklyAchievementUseCases } from "./application/use-cases";
 import { UpsertWeeklyAchievementsUseCase } from "./application/use-cases/upsert-weekly-achievements/upsert-weekly-achievements.use-case";
+import { WEEKLY_ACHIEVEMENT_PROVIDERS } from "./application/weekly-achievement.providers";
 import { PrismaWeeklyAchievementRepository } from "./infrastructure/adapters/prisma-weekly-achievement.repository";
 import { WeeklyAchievementController } from "./presentation/weekly-achievement.controller";
 
@@ -30,8 +29,7 @@ import { WeeklyAchievementController } from "./presentation/weekly-achievement.c
 			provide: WEEKLY_ACHIEVEMENT_REPOSITORY,
 			useClass: PrismaWeeklyAchievementRepository,
 		},
-		...WeeklyAchievementQueryUseCases,
-		...WeeklyAchievementUseCases,
+		...WEEKLY_ACHIEVEMENT_PROVIDERS,
 	],
 	exports: [WeeklyAchievementWriterAccess],
 })

--- a/apps/api/test/builders/todo.builder.ts
+++ b/apps/api/test/builders/todo.builder.ts
@@ -39,6 +39,8 @@ export class TodoBuilder {
 			recurrenceGroupId: null,
 			completed: false,
 			completedAt: null,
+			viewCount: 0,
+			commentCount: 0,
 			createdAt: now,
 			updatedAt: now,
 			category: {

--- a/apps/api/test/e2e/__snapshots__/openapi-contract.e2e-spec.ts.snap
+++ b/apps/api/test/e2e/__snapshots__/openapi-contract.e2e-spec.ts.snap
@@ -1044,6 +1044,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
               "name": "중요한 일",
               "sortOrder": 0,
             },
+            "commentCount": 0,
             "completed": false,
             "completedAt": null,
             "createdAt": "2024-01-10T12:00:00.000Z",
@@ -1096,6 +1097,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                 "sortOrder",
               ],
               "type": "object",
+            },
+            "commentCount": {
+              "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
             },
             "completed": {
               "description": "완료 상태",
@@ -1268,6 +1275,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
             "category",
             "items",
             "itemStats",
+            "commentCount",
             "createdAt",
             "updatedAt",
           ],
@@ -1424,6 +1432,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                 "name": "중요한 일",
                 "sortOrder": 0,
               },
+              "commentCount": 0,
               "completed": false,
               "completedAt": null,
               "createdAt": "2024-01-10T12:00:00.000Z",
@@ -1476,6 +1485,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                   "sortOrder",
                 ],
                 "type": "object",
+              },
+              "commentCount": {
+                "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
               },
               "completed": {
                 "description": "완료 상태",
@@ -1648,6 +1663,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
               "category",
               "items",
               "itemStats",
+              "commentCount",
               "createdAt",
               "updatedAt",
             ],
@@ -1997,6 +2013,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                 "name": "중요한 일",
                 "sortOrder": 0,
               },
+              "commentCount": 0,
               "completed": false,
               "completedAt": null,
               "createdAt": "2024-01-10T12:00:00.000Z",
@@ -2049,6 +2066,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                   "sortOrder",
                 ],
                 "type": "object",
+              },
+              "commentCount": {
+                "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
               },
               "completed": {
                 "description": "완료 상태",
@@ -2221,6 +2244,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
               "category",
               "items",
               "itemStats",
+              "commentCount",
               "createdAt",
               "updatedAt",
             ],
@@ -2541,6 +2565,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
               "name": "중요한 일",
               "sortOrder": 0,
             },
+            "commentCount": 0,
             "completed": false,
             "completedAt": null,
             "createdAt": "2024-01-10T12:00:00.000Z",
@@ -2593,6 +2618,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                 "sortOrder",
               ],
               "type": "object",
+            },
+            "commentCount": {
+              "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
             },
             "completed": {
               "description": "완료 상태",
@@ -2765,6 +2796,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
             "category",
             "items",
             "itemStats",
+            "commentCount",
             "createdAt",
             "updatedAt",
           ],
@@ -3106,6 +3138,26 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
       },
       "required": [
         "message",
+      ],
+      "type": "object",
+    },
+    "DeleteTodoCommentResponseDto": {
+      "properties": {
+        "commentId": {
+          "format": "cuid",
+          "pattern": "^[cC][^\\s-]{8,}$",
+          "type": "string",
+        },
+        "isDeleted": {
+          "enum": [
+            true,
+          ],
+          "type": "boolean",
+        },
+      },
+      "required": [
+        "commentId",
+        "isDeleted",
       ],
       "type": "object",
     },
@@ -4621,6 +4673,363 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
       ],
       "type": "object",
     },
+    "PaginatedTodoCommentsResponseDto": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "author": {
+                "nullable": true,
+                "properties": {
+                  "id": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "isTodoOwner": {
+                    "type": "boolean",
+                  },
+                  "name": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "profileImage": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "profileImage",
+                  "isTodoOwner",
+                ],
+                "type": "object",
+              },
+              "content": {
+                "nullable": true,
+                "type": "string",
+              },
+              "createdAt": {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string",
+              },
+              "depth": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "editedAt": {
+                "format": "date-time",
+                "nullable": true,
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string",
+              },
+              "hasMoreReplies": {
+                "type": "boolean",
+              },
+              "hasReplies": {
+                "type": "boolean",
+              },
+              "id": {
+                "format": "cuid",
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "isDeleted": {
+                "type": "boolean",
+              },
+              "isEdited": {
+                "type": "boolean",
+              },
+              "likeCount": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "parentId": {
+                "format": "cuid",
+                "nullable": true,
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "replyCount": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "replyPreview": {
+                "items": {
+                  "properties": {
+                    "author": {
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "format": "cuid",
+                          "pattern": "^[cC][^\\s-]{8,}$",
+                          "type": "string",
+                        },
+                        "isTodoOwner": {
+                          "type": "boolean",
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "profileImage": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "profileImage",
+                        "isTodoOwner",
+                      ],
+                      "type": "object",
+                    },
+                    "content": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "createdAt": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string",
+                    },
+                    "depth": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "editedAt": {
+                      "format": "date-time",
+                      "nullable": true,
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string",
+                    },
+                    "hasMoreReplies": {
+                      "type": "boolean",
+                    },
+                    "hasReplies": {
+                      "type": "boolean",
+                    },
+                    "id": {
+                      "format": "cuid",
+                      "pattern": "^[cC][^\\s-]{8,}$",
+                      "type": "string",
+                    },
+                    "isDeleted": {
+                      "type": "boolean",
+                    },
+                    "isEdited": {
+                      "type": "boolean",
+                    },
+                    "likeCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "parentId": {
+                      "format": "cuid",
+                      "nullable": true,
+                      "pattern": "^[cC][^\\s-]{8,}$",
+                      "type": "string",
+                    },
+                    "replyCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "replyTo": {
+                      "nullable": true,
+                      "properties": {
+                        "authorName": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "commentId": {
+                          "format": "cuid",
+                          "pattern": "^[cC][^\\s-]{8,}$",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "commentId",
+                        "authorName",
+                      ],
+                      "type": "object",
+                    },
+                    "rootId": {
+                      "format": "cuid",
+                      "nullable": true,
+                      "pattern": "^[cC][^\\s-]{8,}$",
+                      "type": "string",
+                    },
+                    "todoId": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "viewer": {
+                      "properties": {
+                        "canDelete": {
+                          "type": "boolean",
+                        },
+                        "canEdit": {
+                          "type": "boolean",
+                        },
+                        "canReply": {
+                          "type": "boolean",
+                        },
+                        "isLiked": {
+                          "type": "boolean",
+                        },
+                      },
+                      "required": [
+                        "isLiked",
+                        "canEdit",
+                        "canDelete",
+                        "canReply",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "todoId",
+                    "parentId",
+                    "rootId",
+                    "depth",
+                    "author",
+                    "content",
+                    "isDeleted",
+                    "isEdited",
+                    "likeCount",
+                    "replyCount",
+                    "hasReplies",
+                    "hasMoreReplies",
+                    "replyTo",
+                    "viewer",
+                    "createdAt",
+                    "editedAt",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "replyTo": {
+                "nullable": true,
+                "properties": {
+                  "authorName": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "commentId": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "commentId",
+                  "authorName",
+                ],
+                "type": "object",
+              },
+              "rootId": {
+                "format": "cuid",
+                "nullable": true,
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "todoId": {
+                "exclusiveMinimum": true,
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "viewer": {
+                "properties": {
+                  "canDelete": {
+                    "type": "boolean",
+                  },
+                  "canEdit": {
+                    "type": "boolean",
+                  },
+                  "canReply": {
+                    "type": "boolean",
+                  },
+                  "isLiked": {
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "isLiked",
+                  "canEdit",
+                  "canDelete",
+                  "canReply",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "id",
+              "todoId",
+              "parentId",
+              "rootId",
+              "depth",
+              "author",
+              "content",
+              "isDeleted",
+              "isEdited",
+              "likeCount",
+              "replyCount",
+              "hasReplies",
+              "hasMoreReplies",
+              "replyTo",
+              "viewer",
+              "createdAt",
+              "editedAt",
+              "replyPreview",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "pagination": {
+          "properties": {
+            "hasNext": {
+              "type": "boolean",
+            },
+            "nextCursor": {
+              "nullable": true,
+              "type": "string",
+            },
+            "size": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+          },
+          "required": [
+            "nextCursor",
+            "hasNext",
+            "size",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "items",
+        "pagination",
+      ],
+      "type": "object",
+    },
     "ParseMemoRequestDto": {
       "properties": {
         "categoryId": {
@@ -6032,6 +6441,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
               "name": "중요한 일",
               "sortOrder": 0,
             },
+            "commentCount": 0,
             "completed": false,
             "completedAt": null,
             "createdAt": "2024-01-10T12:00:00.000Z",
@@ -6084,6 +6494,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                 "sortOrder",
               ],
               "type": "object",
+            },
+            "commentCount": {
+              "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
             },
             "completed": {
               "description": "완료 상태",
@@ -6256,6 +6672,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
             "category",
             "items",
             "itemStats",
+            "commentCount",
             "createdAt",
             "updatedAt",
           ],
@@ -8074,6 +8491,1502 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
       ],
       "type": "object",
     },
+    "TodoCommentChainResponseDto": {
+      "properties": {
+        "comments": {
+          "items": {
+            "properties": {
+              "author": {
+                "nullable": true,
+                "properties": {
+                  "id": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "isTodoOwner": {
+                    "type": "boolean",
+                  },
+                  "name": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "profileImage": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "profileImage",
+                  "isTodoOwner",
+                ],
+                "type": "object",
+              },
+              "content": {
+                "nullable": true,
+                "type": "string",
+              },
+              "createdAt": {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string",
+              },
+              "depth": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "editedAt": {
+                "format": "date-time",
+                "nullable": true,
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string",
+              },
+              "hasMoreReplies": {
+                "type": "boolean",
+              },
+              "hasReplies": {
+                "type": "boolean",
+              },
+              "id": {
+                "format": "cuid",
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "isDeleted": {
+                "type": "boolean",
+              },
+              "isEdited": {
+                "type": "boolean",
+              },
+              "likeCount": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "parentId": {
+                "format": "cuid",
+                "nullable": true,
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "replyCount": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "replyPreview": {
+                "items": {
+                  "properties": {
+                    "author": {
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "format": "cuid",
+                          "pattern": "^[cC][^\\s-]{8,}$",
+                          "type": "string",
+                        },
+                        "isTodoOwner": {
+                          "type": "boolean",
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "profileImage": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "profileImage",
+                        "isTodoOwner",
+                      ],
+                      "type": "object",
+                    },
+                    "content": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "createdAt": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string",
+                    },
+                    "depth": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "editedAt": {
+                      "format": "date-time",
+                      "nullable": true,
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string",
+                    },
+                    "hasMoreReplies": {
+                      "type": "boolean",
+                    },
+                    "hasReplies": {
+                      "type": "boolean",
+                    },
+                    "id": {
+                      "format": "cuid",
+                      "pattern": "^[cC][^\\s-]{8,}$",
+                      "type": "string",
+                    },
+                    "isDeleted": {
+                      "type": "boolean",
+                    },
+                    "isEdited": {
+                      "type": "boolean",
+                    },
+                    "likeCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "parentId": {
+                      "format": "cuid",
+                      "nullable": true,
+                      "pattern": "^[cC][^\\s-]{8,}$",
+                      "type": "string",
+                    },
+                    "replyCount": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "replyTo": {
+                      "nullable": true,
+                      "properties": {
+                        "authorName": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "commentId": {
+                          "format": "cuid",
+                          "pattern": "^[cC][^\\s-]{8,}$",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "commentId",
+                        "authorName",
+                      ],
+                      "type": "object",
+                    },
+                    "rootId": {
+                      "format": "cuid",
+                      "nullable": true,
+                      "pattern": "^[cC][^\\s-]{8,}$",
+                      "type": "string",
+                    },
+                    "todoId": {
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer",
+                    },
+                    "viewer": {
+                      "properties": {
+                        "canDelete": {
+                          "type": "boolean",
+                        },
+                        "canEdit": {
+                          "type": "boolean",
+                        },
+                        "canReply": {
+                          "type": "boolean",
+                        },
+                        "isLiked": {
+                          "type": "boolean",
+                        },
+                      },
+                      "required": [
+                        "isLiked",
+                        "canEdit",
+                        "canDelete",
+                        "canReply",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "todoId",
+                    "parentId",
+                    "rootId",
+                    "depth",
+                    "author",
+                    "content",
+                    "isDeleted",
+                    "isEdited",
+                    "likeCount",
+                    "replyCount",
+                    "hasReplies",
+                    "hasMoreReplies",
+                    "replyTo",
+                    "viewer",
+                    "createdAt",
+                    "editedAt",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "replyTo": {
+                "nullable": true,
+                "properties": {
+                  "authorName": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "commentId": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "commentId",
+                  "authorName",
+                ],
+                "type": "object",
+              },
+              "rootId": {
+                "format": "cuid",
+                "nullable": true,
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "todoId": {
+                "exclusiveMinimum": true,
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "viewer": {
+                "properties": {
+                  "canDelete": {
+                    "type": "boolean",
+                  },
+                  "canEdit": {
+                    "type": "boolean",
+                  },
+                  "canReply": {
+                    "type": "boolean",
+                  },
+                  "isLiked": {
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "isLiked",
+                  "canEdit",
+                  "canDelete",
+                  "canReply",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "id",
+              "todoId",
+              "parentId",
+              "rootId",
+              "depth",
+              "author",
+              "content",
+              "isDeleted",
+              "isEdited",
+              "likeCount",
+              "replyCount",
+              "hasReplies",
+              "hasMoreReplies",
+              "replyTo",
+              "viewer",
+              "createdAt",
+              "editedAt",
+              "replyPreview",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "comments",
+      ],
+      "type": "object",
+    },
+    "TodoCommentLikeResponseDto": {
+      "properties": {
+        "commentId": {
+          "format": "cuid",
+          "pattern": "^[cC][^\\s-]{8,}$",
+          "type": "string",
+        },
+        "isLiked": {
+          "type": "boolean",
+        },
+        "likeCount": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer",
+        },
+      },
+      "required": [
+        "commentId",
+        "isLiked",
+        "likeCount",
+      ],
+      "type": "object",
+    },
+    "TodoCommentMutationResponseDto": {
+      "properties": {
+        "comment": {
+          "properties": {
+            "author": {
+              "nullable": true,
+              "properties": {
+                "id": {
+                  "format": "cuid",
+                  "pattern": "^[cC][^\\s-]{8,}$",
+                  "type": "string",
+                },
+                "isTodoOwner": {
+                  "type": "boolean",
+                },
+                "name": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "profileImage": {
+                  "nullable": true,
+                  "type": "string",
+                },
+              },
+              "required": [
+                "id",
+                "name",
+                "profileImage",
+                "isTodoOwner",
+              ],
+              "type": "object",
+            },
+            "content": {
+              "nullable": true,
+              "type": "string",
+            },
+            "createdAt": {
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "depth": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "editedAt": {
+              "format": "date-time",
+              "nullable": true,
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "hasMoreReplies": {
+              "type": "boolean",
+            },
+            "hasReplies": {
+              "type": "boolean",
+            },
+            "id": {
+              "format": "cuid",
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "isDeleted": {
+              "type": "boolean",
+            },
+            "isEdited": {
+              "type": "boolean",
+            },
+            "likeCount": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "parentId": {
+              "format": "cuid",
+              "nullable": true,
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "replyCount": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "replyPreview": {
+              "items": {
+                "properties": {
+                  "author": {
+                    "nullable": true,
+                    "properties": {
+                      "id": {
+                        "format": "cuid",
+                        "pattern": "^[cC][^\\s-]{8,}$",
+                        "type": "string",
+                      },
+                      "isTodoOwner": {
+                        "type": "boolean",
+                      },
+                      "name": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "profileImage": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "profileImage",
+                      "isTodoOwner",
+                    ],
+                    "type": "object",
+                  },
+                  "content": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "createdAt": {
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string",
+                  },
+                  "depth": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "editedAt": {
+                    "format": "date-time",
+                    "nullable": true,
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string",
+                  },
+                  "hasMoreReplies": {
+                    "type": "boolean",
+                  },
+                  "hasReplies": {
+                    "type": "boolean",
+                  },
+                  "id": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "isDeleted": {
+                    "type": "boolean",
+                  },
+                  "isEdited": {
+                    "type": "boolean",
+                  },
+                  "likeCount": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "parentId": {
+                    "format": "cuid",
+                    "nullable": true,
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "replyCount": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "replyTo": {
+                    "nullable": true,
+                    "properties": {
+                      "authorName": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "commentId": {
+                        "format": "cuid",
+                        "pattern": "^[cC][^\\s-]{8,}$",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "commentId",
+                      "authorName",
+                    ],
+                    "type": "object",
+                  },
+                  "rootId": {
+                    "format": "cuid",
+                    "nullable": true,
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "todoId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "viewer": {
+                    "properties": {
+                      "canDelete": {
+                        "type": "boolean",
+                      },
+                      "canEdit": {
+                        "type": "boolean",
+                      },
+                      "canReply": {
+                        "type": "boolean",
+                      },
+                      "isLiked": {
+                        "type": "boolean",
+                      },
+                    },
+                    "required": [
+                      "isLiked",
+                      "canEdit",
+                      "canDelete",
+                      "canReply",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "id",
+                  "todoId",
+                  "parentId",
+                  "rootId",
+                  "depth",
+                  "author",
+                  "content",
+                  "isDeleted",
+                  "isEdited",
+                  "likeCount",
+                  "replyCount",
+                  "hasReplies",
+                  "hasMoreReplies",
+                  "replyTo",
+                  "viewer",
+                  "createdAt",
+                  "editedAt",
+                ],
+                "type": "object",
+              },
+              "type": "array",
+            },
+            "replyTo": {
+              "nullable": true,
+              "properties": {
+                "authorName": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "commentId": {
+                  "format": "cuid",
+                  "pattern": "^[cC][^\\s-]{8,}$",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "commentId",
+                "authorName",
+              ],
+              "type": "object",
+            },
+            "rootId": {
+              "format": "cuid",
+              "nullable": true,
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "todoId": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "viewer": {
+              "properties": {
+                "canDelete": {
+                  "type": "boolean",
+                },
+                "canEdit": {
+                  "type": "boolean",
+                },
+                "canReply": {
+                  "type": "boolean",
+                },
+                "isLiked": {
+                  "type": "boolean",
+                },
+              },
+              "required": [
+                "isLiked",
+                "canEdit",
+                "canDelete",
+                "canReply",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "id",
+            "todoId",
+            "parentId",
+            "rootId",
+            "depth",
+            "author",
+            "content",
+            "isDeleted",
+            "isEdited",
+            "likeCount",
+            "replyCount",
+            "hasReplies",
+            "hasMoreReplies",
+            "replyTo",
+            "viewer",
+            "createdAt",
+            "editedAt",
+            "replyPreview",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "comment",
+      ],
+      "type": "object",
+    },
+    "TodoCommentThreadResponseDto": {
+      "properties": {
+        "ancestors": {
+          "items": {
+            "properties": {
+              "author": {
+                "nullable": true,
+                "properties": {
+                  "id": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "isTodoOwner": {
+                    "type": "boolean",
+                  },
+                  "name": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "profileImage": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "profileImage",
+                  "isTodoOwner",
+                ],
+                "type": "object",
+              },
+              "content": {
+                "nullable": true,
+                "type": "string",
+              },
+              "createdAt": {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string",
+              },
+              "depth": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "editedAt": {
+                "format": "date-time",
+                "nullable": true,
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string",
+              },
+              "hasMoreReplies": {
+                "type": "boolean",
+              },
+              "hasReplies": {
+                "type": "boolean",
+              },
+              "id": {
+                "format": "cuid",
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "isDeleted": {
+                "type": "boolean",
+              },
+              "isEdited": {
+                "type": "boolean",
+              },
+              "likeCount": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "parentId": {
+                "format": "cuid",
+                "nullable": true,
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "replyCount": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "replyTo": {
+                "nullable": true,
+                "properties": {
+                  "authorName": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "commentId": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "commentId",
+                  "authorName",
+                ],
+                "type": "object",
+              },
+              "rootId": {
+                "format": "cuid",
+                "nullable": true,
+                "pattern": "^[cC][^\\s-]{8,}$",
+                "type": "string",
+              },
+              "todoId": {
+                "exclusiveMinimum": true,
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
+              },
+              "viewer": {
+                "properties": {
+                  "canDelete": {
+                    "type": "boolean",
+                  },
+                  "canEdit": {
+                    "type": "boolean",
+                  },
+                  "canReply": {
+                    "type": "boolean",
+                  },
+                  "isLiked": {
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "isLiked",
+                  "canEdit",
+                  "canDelete",
+                  "canReply",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "id",
+              "todoId",
+              "parentId",
+              "rootId",
+              "depth",
+              "author",
+              "content",
+              "isDeleted",
+              "isEdited",
+              "likeCount",
+              "replyCount",
+              "hasReplies",
+              "hasMoreReplies",
+              "replyTo",
+              "viewer",
+              "createdAt",
+              "editedAt",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "comment": {
+          "properties": {
+            "author": {
+              "nullable": true,
+              "properties": {
+                "id": {
+                  "format": "cuid",
+                  "pattern": "^[cC][^\\s-]{8,}$",
+                  "type": "string",
+                },
+                "isTodoOwner": {
+                  "type": "boolean",
+                },
+                "name": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "profileImage": {
+                  "nullable": true,
+                  "type": "string",
+                },
+              },
+              "required": [
+                "id",
+                "name",
+                "profileImage",
+                "isTodoOwner",
+              ],
+              "type": "object",
+            },
+            "content": {
+              "nullable": true,
+              "type": "string",
+            },
+            "createdAt": {
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "depth": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "editedAt": {
+              "format": "date-time",
+              "nullable": true,
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "hasMoreReplies": {
+              "type": "boolean",
+            },
+            "hasReplies": {
+              "type": "boolean",
+            },
+            "id": {
+              "format": "cuid",
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "isDeleted": {
+              "type": "boolean",
+            },
+            "isEdited": {
+              "type": "boolean",
+            },
+            "likeCount": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "parentId": {
+              "format": "cuid",
+              "nullable": true,
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "replyCount": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "replyPreview": {
+              "items": {
+                "properties": {
+                  "author": {
+                    "nullable": true,
+                    "properties": {
+                      "id": {
+                        "format": "cuid",
+                        "pattern": "^[cC][^\\s-]{8,}$",
+                        "type": "string",
+                      },
+                      "isTodoOwner": {
+                        "type": "boolean",
+                      },
+                      "name": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "profileImage": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "profileImage",
+                      "isTodoOwner",
+                    ],
+                    "type": "object",
+                  },
+                  "content": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "createdAt": {
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string",
+                  },
+                  "depth": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "editedAt": {
+                    "format": "date-time",
+                    "nullable": true,
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string",
+                  },
+                  "hasMoreReplies": {
+                    "type": "boolean",
+                  },
+                  "hasReplies": {
+                    "type": "boolean",
+                  },
+                  "id": {
+                    "format": "cuid",
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "isDeleted": {
+                    "type": "boolean",
+                  },
+                  "isEdited": {
+                    "type": "boolean",
+                  },
+                  "likeCount": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "parentId": {
+                    "format": "cuid",
+                    "nullable": true,
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "replyCount": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "replyTo": {
+                    "nullable": true,
+                    "properties": {
+                      "authorName": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "commentId": {
+                        "format": "cuid",
+                        "pattern": "^[cC][^\\s-]{8,}$",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "commentId",
+                      "authorName",
+                    ],
+                    "type": "object",
+                  },
+                  "rootId": {
+                    "format": "cuid",
+                    "nullable": true,
+                    "pattern": "^[cC][^\\s-]{8,}$",
+                    "type": "string",
+                  },
+                  "todoId": {
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
+                  "viewer": {
+                    "properties": {
+                      "canDelete": {
+                        "type": "boolean",
+                      },
+                      "canEdit": {
+                        "type": "boolean",
+                      },
+                      "canReply": {
+                        "type": "boolean",
+                      },
+                      "isLiked": {
+                        "type": "boolean",
+                      },
+                    },
+                    "required": [
+                      "isLiked",
+                      "canEdit",
+                      "canDelete",
+                      "canReply",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "id",
+                  "todoId",
+                  "parentId",
+                  "rootId",
+                  "depth",
+                  "author",
+                  "content",
+                  "isDeleted",
+                  "isEdited",
+                  "likeCount",
+                  "replyCount",
+                  "hasReplies",
+                  "hasMoreReplies",
+                  "replyTo",
+                  "viewer",
+                  "createdAt",
+                  "editedAt",
+                ],
+                "type": "object",
+              },
+              "type": "array",
+            },
+            "replyTo": {
+              "nullable": true,
+              "properties": {
+                "authorName": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "commentId": {
+                  "format": "cuid",
+                  "pattern": "^[cC][^\\s-]{8,}$",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "commentId",
+                "authorName",
+              ],
+              "type": "object",
+            },
+            "rootId": {
+              "format": "cuid",
+              "nullable": true,
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "todoId": {
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "viewer": {
+              "properties": {
+                "canDelete": {
+                  "type": "boolean",
+                },
+                "canEdit": {
+                  "type": "boolean",
+                },
+                "canReply": {
+                  "type": "boolean",
+                },
+                "isLiked": {
+                  "type": "boolean",
+                },
+              },
+              "required": [
+                "isLiked",
+                "canEdit",
+                "canDelete",
+                "canReply",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "id",
+            "todoId",
+            "parentId",
+            "rootId",
+            "depth",
+            "author",
+            "content",
+            "isDeleted",
+            "isEdited",
+            "likeCount",
+            "replyCount",
+            "hasReplies",
+            "hasMoreReplies",
+            "replyTo",
+            "viewer",
+            "createdAt",
+            "editedAt",
+            "replyPreview",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "ancestors",
+        "comment",
+      ],
+      "type": "object",
+    },
+    "TodoDetailsResponseDto": {
+      "properties": {
+        "metrics": {
+          "properties": {
+            "commentCount": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "viewCount": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+          },
+          "required": [
+            "viewCount",
+            "commentCount",
+          ],
+          "type": "object",
+        },
+        "owner": {
+          "properties": {
+            "id": {
+              "format": "cuid",
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "name": {
+              "nullable": true,
+              "type": "string",
+            },
+            "profileImage": {
+              "nullable": true,
+              "type": "string",
+            },
+          },
+          "required": [
+            "id",
+            "name",
+            "profileImage",
+          ],
+          "type": "object",
+        },
+        "permissions": {
+          "properties": {
+            "canComment": {
+              "type": "boolean",
+            },
+            "canEdit": {
+              "type": "boolean",
+            },
+            "canNudge": {
+              "type": "boolean",
+            },
+          },
+          "required": [
+            "canEdit",
+            "canComment",
+            "canNudge",
+          ],
+          "type": "object",
+        },
+        "todo": {
+          "example": {
+            "category": {
+              "color": "#FFB3B3",
+              "id": 1,
+              "name": "중요한 일",
+              "sortOrder": 0,
+            },
+            "commentCount": 0,
+            "completed": false,
+            "completedAt": null,
+            "createdAt": "2024-01-10T12:00:00.000Z",
+            "endDate": "2024-01-15",
+            "id": 1,
+            "isAllDay": false,
+            "itemStats": {
+              "completed": 0,
+              "total": 0,
+            },
+            "items": [],
+            "recurrenceGroupId": null,
+            "scheduledTime": "2024-01-15T09:00:00.000Z",
+            "sortOrder": 0,
+            "startDate": "2024-01-15",
+            "title": "운동하기",
+            "updatedAt": "2024-01-10T12:00:00.000Z",
+            "userId": "clz7x5p8k0010qz0z8z8z8z8z",
+            "visibility": "PUBLIC",
+          },
+          "properties": {
+            "category": {
+              "description": "카테고리 정보",
+              "properties": {
+                "color": {
+                  "description": "카테고리 색상 (HEX 7자)",
+                  "type": "string",
+                },
+                "id": {
+                  "description": "카테고리 ID (양의 정수)",
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
+                  "type": "integer",
+                },
+                "name": {
+                  "description": "카테고리 이름",
+                  "type": "string",
+                },
+                "sortOrder": {
+                  "description": "카테고리 정렬 순서 (작을수록 위)",
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
+                  "type": "integer",
+                },
+              },
+              "required": [
+                "id",
+                "name",
+                "color",
+                "sortOrder",
+              ],
+              "type": "object",
+            },
+            "commentCount": {
+              "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
+            },
+            "completed": {
+              "description": "완료 상태",
+              "type": "boolean",
+            },
+            "completedAt": {
+              "description": "완료 시각 (ISO 8601 UTC, 예: 2024-01-15T10:30:00.000Z, 미완료 시 null)",
+              "format": "date-time",
+              "nullable": true,
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "content": {
+              "description": "할 일 내용 (deprecated, 하위 호환용 — 항상 null)",
+              "nullable": true,
+              "type": "string",
+            },
+            "createdAt": {
+              "description": "생성 시각 (ISO 8601 UTC, 예: 2024-01-10T12:00:00.000Z)",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "endDate": {
+              "description": "종료 날짜 (YYYY-MM-DD, 예: 2024-01-31, 단일 날짜는 null)",
+              "nullable": true,
+              "type": "string",
+            },
+            "id": {
+              "description": "할 일 고유 ID (양의 정수)",
+              "maximum": 9007199254740991,
+              "minimum": -9007199254740991,
+              "type": "integer",
+            },
+            "isAllDay": {
+              "description": "종일 일정 여부",
+              "type": "boolean",
+            },
+            "itemStats": {
+              "description": "하위 항목 진행 통계 (카운터 뱃지/진행률 바용)",
+              "properties": {
+                "completed": {
+                  "description": "완료된 하위 항목 수",
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
+                  "type": "integer",
+                },
+                "total": {
+                  "description": "전체 하위 항목 수",
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
+                  "type": "integer",
+                },
+              },
+              "required": [
+                "total",
+                "completed",
+              ],
+              "type": "object",
+            },
+            "items": {
+              "description": "하위 항목 목록 (체크리스트, sortOrder 오름차순)",
+              "items": {
+                "properties": {
+                  "completed": {
+                    "description": "완료 상태",
+                    "type": "boolean",
+                  },
+                  "createdAt": {
+                    "description": "생성 시각 (ISO 8601 UTC)",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string",
+                  },
+                  "id": {
+                    "description": "하위 항목 고유 ID",
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer",
+                  },
+                  "sortOrder": {
+                    "description": "정렬 순서 (작을수록 위)",
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer",
+                  },
+                  "title": {
+                    "description": "하위 항목 제목",
+                    "type": "string",
+                  },
+                  "updatedAt": {
+                    "description": "수정 시각 (ISO 8601 UTC)",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                  "title",
+                  "completed",
+                  "sortOrder",
+                  "createdAt",
+                  "updatedAt",
+                ],
+                "type": "object",
+              },
+              "type": "array",
+            },
+            "recurrenceGroupId": {
+              "description": "반복 생성 그룹 ID (null이면 단일 생성)",
+              "nullable": true,
+              "type": "string",
+            },
+            "scheduledTime": {
+              "description": "예정 시각 (ISO 8601 UTC, 예: 2024-01-15T09:00:00.000Z, 종일 일정은 null)",
+              "format": "date-time",
+              "nullable": true,
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "sortOrder": {
+              "description": "정렬 순서 (작을수록 위)",
+              "maximum": 9007199254740991,
+              "minimum": -9007199254740991,
+              "type": "integer",
+            },
+            "startDate": {
+              "description": "시작 날짜 (YYYY-MM-DD, 예: 2024-01-15)",
+              "type": "string",
+            },
+            "title": {
+              "description": "할 일 제목",
+              "type": "string",
+            },
+            "updatedAt": {
+              "description": "수정 시각 (ISO 8601 UTC, 예: 2024-01-15T10:30:00.000Z)",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+              "type": "string",
+            },
+            "userId": {
+              "description": "사용자 ID (CUID 25자)",
+              "format": "cuid",
+              "pattern": "^[cC][^\\s-]{8,}$",
+              "type": "string",
+            },
+            "visibility": {
+              "description": "공개 범위 (PUBLIC | FRIENDS | PRIVATE)",
+              "enum": [
+                "PUBLIC",
+                "PRIVATE",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "id",
+            "userId",
+            "title",
+            "sortOrder",
+            "completed",
+            "completedAt",
+            "startDate",
+            "endDate",
+            "scheduledTime",
+            "isAllDay",
+            "visibility",
+            "recurrenceGroupId",
+            "category",
+            "items",
+            "itemStats",
+            "commentCount",
+            "createdAt",
+            "updatedAt",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "todo",
+        "owner",
+        "permissions",
+        "metrics",
+      ],
+      "type": "object",
+    },
     "TodoListResponseDto": {
       "example": {
         "items": [
@@ -8115,6 +10028,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                 "name": "중요한 일",
                 "sortOrder": 0,
               },
+              "commentCount": 0,
               "completed": false,
               "completedAt": null,
               "createdAt": "2024-01-10T12:00:00.000Z",
@@ -8167,6 +10081,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                   "sortOrder",
                 ],
                 "type": "object",
+              },
+              "commentCount": {
+                "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer",
               },
               "completed": {
                 "description": "완료 상태",
@@ -8339,6 +10259,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
               "category",
               "items",
               "itemStats",
+              "commentCount",
               "createdAt",
               "updatedAt",
             ],
@@ -8407,6 +10328,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
           "name": "중요한 일",
           "sortOrder": 0,
         },
+        "commentCount": 0,
         "completed": false,
         "completedAt": null,
         "createdAt": "2024-01-10T12:00:00.000Z",
@@ -8459,6 +10381,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
             "sortOrder",
           ],
           "type": "object",
+        },
+        "commentCount": {
+          "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer",
         },
         "completed": {
           "description": "완료 상태",
@@ -8631,6 +10559,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
         "category",
         "items",
         "itemStats",
+        "commentCount",
         "createdAt",
         "updatedAt",
       ],
@@ -9235,6 +11164,19 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
       ],
       "type": "object",
     },
+    "UpdateTodoCommentDto": {
+      "properties": {
+        "content": {
+          "maxLength": 500,
+          "minLength": 1,
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+      ],
+      "type": "object",
+    },
     "UpdateTodoDto": {
       "properties": {
         "categoryId": {
@@ -9340,6 +11282,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
               "name": "중요한 일",
               "sortOrder": 0,
             },
+            "commentCount": 0,
             "completed": false,
             "completedAt": null,
             "createdAt": "2024-01-10T12:00:00.000Z",
@@ -9392,6 +11335,12 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
                 "sortOrder",
               ],
               "type": "object",
+            },
+            "commentCount": {
+              "description": "댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer",
             },
             "completed": {
               "description": "완료 상태",
@@ -9564,6 +11513,7 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
             "category",
             "items",
             "itemStats",
+            "commentCount",
             "createdAt",
             "updatedAt",
           ],
@@ -10243,6 +12193,38 @@ exports[`OpenAPI 계약 (e2e) OpenAPI 문서가 스냅샷과 일치한다 (클�
         "items",
         "pagination",
         "summary",
+      ],
+      "type": "object",
+    },
+    "WriteTodoCommentChainDto": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "clientRequestId": {
+                "format": "uuid",
+                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                "type": "string",
+              },
+              "content": {
+                "maxLength": 500,
+                "minLength": 1,
+                "type": "string",
+              },
+            },
+            "required": [
+              "clientRequestId",
+              "content",
+            ],
+            "type": "object",
+          },
+          "maxItems": 5,
+          "minItems": 1,
+          "type": "array",
+        },
+      },
+      "required": [
+        "items",
       ],
       "type": "object",
     },
@@ -33185,6 +35167,1829 @@ Todo를 찾을 수 없습니다.",
         },
       ],
       "summary": "할 일 공개 범위 변경",
+      "tags": [
+        "Todos",
+      ],
+    },
+  },
+  "/v1/todos/{todoId}/comments": {
+    "get": {
+      "operationId": "getTodoComments",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "in": "query",
+          "name": "sort",
+          "required": false,
+          "schema": {
+            "default": "LATEST",
+            "enum": [
+              "POPULAR",
+              "LATEST",
+            ],
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "cursor",
+          "required": false,
+          "schema": {
+            "minLength": 1,
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "size",
+          "required": false,
+          "schema": {
+            "default": 20,
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/PaginatedTodoCommentsResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 파라미터입니다.
+
+잘못된 요청입니다",
+          "schema": {
+            "properties": {
+              "error": {
+                "properties": {
+                  "code": {
+                    "example": "SYS_0002",
+                    "type": "string",
+                  },
+                  "details": {
+                    "example": null,
+                    "nullable": true,
+                    "type": "object",
+                  },
+                  "message": {
+                    "example": "잘못된 파라미터입니다.",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
+              "success": {
+                "example": false,
+                "type": "boolean",
+              },
+              "timestamp": {
+                "example": 1700000000000,
+                "type": "number",
+              },
+            },
+            "required": [
+              "success",
+              "error",
+              "timestamp",
+            ],
+            "type": "object",
+          },
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "404": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0801",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "Todo를 찾을 수 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "Todo를 찾을 수 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "할 일 최상위 댓글 목록",
+      "tags": [
+        "Todos",
+      ],
+    },
+    "post": {
+      "operationId": "createTodoComment",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+      ],
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/WriteTodoCommentChainDto",
+            },
+          },
+        },
+        "required": true,
+      },
+      "responses": {
+        "201": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/TodoCommentChainResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "리소스가 성공적으로 생성되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "404": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0801",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "Todo를 찾을 수 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "Todo를 찾을 수 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "할 일 댓글 작성 (한 번에 이어 쓰기 가능)",
+      "tags": [
+        "Todos",
+      ],
+    },
+  },
+  "/v1/todos/{todoId}/comments/{commentId}": {
+    "delete": {
+      "operationId": "deleteTodoComment",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "description": "댓글 ID (CUID)",
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/DeleteTodoCommentResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "403": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0832",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "댓글을 변경할 권한이 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "댓글을 변경할 권한이 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "본인 댓글 삭제",
+      "tags": [
+        "Todos",
+      ],
+    },
+    "patch": {
+      "operationId": "updateTodoComment",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "description": "댓글 ID (CUID)",
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+      ],
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/UpdateTodoCommentDto",
+            },
+          },
+        },
+        "required": true,
+      },
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/TodoCommentMutationResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "403": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0832",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "댓글을 변경할 권한이 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "댓글을 변경할 권한이 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "본인 댓글 수정",
+      "tags": [
+        "Todos",
+      ],
+    },
+  },
+  "/v1/todos/{todoId}/comments/{commentId}/likes": {
+    "delete": {
+      "operationId": "unlikeTodoComment",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "description": "댓글 ID (CUID)",
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/TodoCommentLikeResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "댓글 좋아요 취소",
+      "tags": [
+        "Todos",
+      ],
+    },
+    "put": {
+      "operationId": "likeTodoComment",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "description": "댓글 ID (CUID)",
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/TodoCommentLikeResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "댓글 좋아요",
+      "tags": [
+        "Todos",
+      ],
+    },
+  },
+  "/v1/todos/{todoId}/comments/{commentId}/replies": {
+    "get": {
+      "operationId": "getTodoCommentReplies",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "description": "댓글 ID (CUID)",
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "sort",
+          "required": false,
+          "schema": {
+            "default": "LATEST",
+            "enum": [
+              "POPULAR",
+              "LATEST",
+            ],
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "cursor",
+          "required": false,
+          "schema": {
+            "minLength": 1,
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "size",
+          "required": false,
+          "schema": {
+            "default": 20,
+            "maximum": 50,
+            "minimum": 1,
+            "type": "integer",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/PaginatedTodoCommentsResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "404": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0831",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "댓글을 찾을 수 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "댓글을 찾을 수 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "댓글의 직계 답글 목록",
+      "tags": [
+        "Todos",
+      ],
+    },
+    "post": {
+      "operationId": "replyTodoComment",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "description": "댓글 ID (CUID)",
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+      ],
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/WriteTodoCommentChainDto",
+            },
+          },
+        },
+        "required": true,
+      },
+      "responses": {
+        "201": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/TodoCommentChainResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "리소스가 성공적으로 생성되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "404": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0831",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "댓글을 찾을 수 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "댓글을 찾을 수 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "댓글에 답글 작성 (깊이 제한 없음, 한 번에 이어 쓰기 가능)",
+      "tags": [
+        "Todos",
+      ],
+    },
+  },
+  "/v1/todos/{todoId}/comments/{commentId}/thread": {
+    "get": {
+      "operationId": "getTodoCommentThread",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+        {
+          "description": "댓글 ID (CUID)",
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "format": "cuid",
+            "pattern": "^[cC][^\\s-]{8,}$",
+            "type": "string",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/TodoCommentThreadResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "404": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0831",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "댓글을 찾을 수 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "댓글을 찾을 수 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "댓글 스레드 조회 (조상·본문·답글 첫 페이지)",
+      "tags": [
+        "Todos",
+      ],
+    },
+  },
+  "/v1/todos/{todoId}/details": {
+    "get": {
+      "operationId": "getTodoDetails",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "todoId",
+          "required": true,
+          "schema": {
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "$ref": "#/components/schemas/TodoDetailsResponseDto",
+                  },
+                  "success": {
+                    "example": true,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "data",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "요청이 성공적으로 처리되었습니다",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "잘못된 요청입니다",
+        },
+        "401": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "AUTH_0107",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "인증이 필요합니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "인증이 필요합니다.",
+        },
+        "404": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "example": "TODO_0801",
+                        "type": "string",
+                      },
+                      "details": {
+                        "example": null,
+                        "nullable": true,
+                        "type": "object",
+                      },
+                      "message": {
+                        "example": "Todo를 찾을 수 없습니다.",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "example": false,
+                    "type": "boolean",
+                  },
+                  "timestamp": {
+                    "example": 1700000000000,
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                  "timestamp",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "Todo를 찾을 수 없습니다.",
+        },
+        "500": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ErrorResponseSchema",
+              },
+            },
+          },
+          "description": "서버 내부 오류가 발생했습니다",
+        },
+      },
+      "security": [
+        {
+          "bearer": [],
+        },
+      ],
+      "summary": "댓글 화면용 할 일 상세 조회",
       "tags": [
         "Todos",
       ],

--- a/apps/api/test/e2e/fixtures/released-v1-openapi-contract.ts
+++ b/apps/api/test/e2e/fixtures/released-v1-openapi-contract.ts
@@ -260,8 +260,13 @@ export const RELEASED_V1_OPENAPI_CONTRACT = {
 		"/weekly-achievements",
 		"/weekly-achievements/{year}/{week}",
 	],
+	/**
+	 * 검토된 계약 진화 (sourceCommit 이후의 의도된 additive 변경):
+	 * - 2026-08-15 todoSchema.commentCount 응답 필드 추가 (목록 진입점 뱃지용).
+	 *   1.7.x 번들 Zod는 strip 모드라 미지 응답 키를 버린다 — 배포 클라이언트 무영향.
+	 */
 	schemasFingerprint:
-		"5708d02896371679e9c4dc97d82e1376e18c464ae7f6cfc0cecbbb4defeaac3d",
+		"7d54df326aea8812a463f4a7ea5e842fc333c6823276a14e29e58f8a8d3b992b",
 	pathsFingerprint:
 		"ea3b45b70f071294634c39a8523e2683112a02a87f17c1366f279ca7b46e6d8e",
 } as const;

--- a/apps/api/test/e2e/todo-comment.e2e-spec.ts
+++ b/apps/api/test/e2e/todo-comment.e2e-spec.ts
@@ -1,0 +1,333 @@
+import { randomUUID } from "node:crypto";
+
+import request from "supertest";
+
+import { createE2eApp, destroyE2eApp, type E2eTestContext } from "./helpers";
+
+describe("할 일 댓글 E2E", () => {
+	let ctx: E2eTestContext;
+
+	beforeAll(async () => {
+		ctx = await createE2eApp();
+	}, 60000);
+
+	afterAll(async () => {
+		await destroyE2eApp(ctx);
+	});
+
+	beforeEach(async () => {
+		await ctx.reset();
+	});
+
+	async function createTodo(accessToken: string): Promise<number> {
+		const categoryId = await ctx.helpers.getDefaultCategoryId(accessToken);
+		const response = await request(ctx.app.getHttpServer())
+			.post("/v1/todos")
+			.set("Authorization", `Bearer ${accessToken}`)
+			.send({ title: "댓글 테스트", categoryId, startDate: "2026-08-14" })
+			.expect(201);
+
+		return response.body.data.todo.id as number;
+	}
+
+	async function writeChain(
+		accessToken: string,
+		todoId: number,
+		contents: string[],
+		parentId?: string,
+	): Promise<string[]> {
+		const path =
+			parentId === undefined
+				? `/v1/todos/${todoId}/comments`
+				: `/v1/todos/${todoId}/comments/${parentId}/replies`;
+		const response = await request(ctx.app.getHttpServer())
+			.post(path)
+			.set("Authorization", `Bearer ${accessToken}`)
+			.send({ items: contents.map((content) => ({ clientRequestId: randomUUID(), content })) })
+			.expect(201);
+
+		return (response.body.data.comments as { id: string }[]).map((comment) => comment.id);
+	}
+
+	async function writeComment(
+		accessToken: string,
+		todoId: number,
+		content: string,
+		parentId?: string,
+	): Promise<string> {
+		const [id] = await writeChain(accessToken, todoId, [content], parentId);
+
+		return id ?? "";
+	}
+
+	it("깊이 제한 없이 답글을 이어 달고 어느 깊이에서도 좋아요·미리보기·조상 사슬을 제공한다", async () => {
+		const user = await ctx.helpers.createVerifiedUser("todo-comment@example.com", "Test1234!");
+		const todoId = await createTodo(user.accessToken);
+
+		// 댓글 → 답글 → 답글의 답글 → 그 답글의 답글 (깊이 3)
+		const depth0 = await writeComment(user.accessToken, todoId, "댓글");
+		const depth1 = await writeComment(user.accessToken, todoId, "답글", depth0);
+		const depth2 = await writeComment(user.accessToken, todoId, "답글의 답글", depth1);
+		const depth3 = await writeComment(user.accessToken, todoId, "그 답글의 답글", depth2);
+
+		const listResponse = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments`)
+			.query({ sort: "LATEST", size: 20 })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		// 최상위 목록은 자기 자식만 담는다 — 손자부터는 다음 화면 몫이다.
+		expect(listResponse.body.data.items).toHaveLength(1);
+		expect(listResponse.body.data.items[0]).toMatchObject({
+			id: depth0,
+			parentId: null,
+			rootId: null,
+			depth: 0,
+			replyCount: 1,
+			hasReplies: true,
+			hasMoreReplies: false,
+		});
+		expect(listResponse.body.data.items[0].replyPreview).toHaveLength(1);
+		expect(listResponse.body.data.items[0].replyPreview[0]).toMatchObject({
+			id: depth1,
+			parentId: depth0,
+			rootId: depth0,
+			depth: 1,
+			replyCount: 1,
+			hasReplies: true,
+			hasMoreReplies: true,
+			replyTo: { commentId: depth0 },
+		});
+
+		// 깊이 2의 스레드 머리말 — 조상은 뿌리 → 부모 순서로 쌓인다.
+		const threadResponse = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments/${depth2}/thread`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(
+			threadResponse.body.data.ancestors.map((ancestor: { id: string }) => ancestor.id),
+		).toEqual([depth0, depth1]);
+		expect(threadResponse.body.data.comment).toMatchObject({ id: depth2, depth: 2 });
+
+		const depth2Replies = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments/${depth2}/replies`)
+			.query({ sort: "LATEST", size: 20 })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(depth2Replies.body.data.items).toHaveLength(1);
+		expect(depth2Replies.body.data.items[0]).toMatchObject({ id: depth3, depth: 3 });
+
+		// 좋아요는 깊이와 무관하다.
+		await request(ctx.app.getHttpServer())
+			.put(`/v1/todos/${todoId}/comments/${depth3}/likes`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		const likedReplies = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments/${depth2}/replies`)
+			.query({ sort: "LATEST", size: 20 })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(likedReplies.body.data.items[0]).toMatchObject({
+			likeCount: 1,
+			viewer: { isLiked: true },
+		});
+
+		const details = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/details`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(details.body.data.metrics.commentCount).toBe(4);
+	});
+
+	it("답글 목록은 정렬과 cursor를 최상위 목록과 같은 계약으로 제공한다", async () => {
+		const user = await ctx.helpers.createVerifiedUser("todo-comment@example.com", "Test1234!");
+		const todoId = await createTodo(user.accessToken);
+		const parentId = await writeComment(user.accessToken, todoId, "댓글");
+
+		// 첫 페이지 캐시를 먼저 채워 답글 작성이 무효화하는지도 함께 본다.
+		await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments`)
+			.query({ sort: "LATEST", size: 20 })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		for (const content of ["첫 번째 답글", "두 번째 답글", "세 번째 답글"]) {
+			await writeComment(user.accessToken, todoId, content, parentId);
+		}
+
+		const listResponse = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments`)
+			.query({ sort: "LATEST", size: 20 })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(listResponse.body.data.items[0]).toMatchObject({
+			replyCount: 3,
+			hasMoreReplies: true,
+		});
+		expect(listResponse.body.data.items[0].replyPreview).toHaveLength(2);
+		expect(
+			listResponse.body.data.items[0].replyPreview.map(
+				(reply: { content: string }) => reply.content,
+			),
+		).toContain("세 번째 답글");
+
+		const firstPage = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments/${parentId}/replies`)
+			.query({ sort: "LATEST", size: 2 })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(firstPage.body.data.items).toHaveLength(2);
+		expect(firstPage.body.data.pagination.hasNext).toBe(true);
+
+		const secondPage = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments/${parentId}/replies`)
+			.query({ sort: "LATEST", size: 2, cursor: firstPage.body.data.pagination.nextCursor })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(secondPage.body.data.items).toHaveLength(1);
+		expect(secondPage.body.data.pagination.hasNext).toBe(false);
+	});
+
+	it("답글이 남은 댓글은 묘비로 자리를 지키고, 마지막 답글이 사라지면 묘비도 함께 걷힌다", async () => {
+		const user = await ctx.helpers.createVerifiedUser("todo-comment@example.com", "Test1234!");
+		const todoId = await createTodo(user.accessToken);
+		const depth0 = await writeComment(user.accessToken, todoId, "댓글");
+		const depth1 = await writeComment(user.accessToken, todoId, "답글", depth0);
+		const depth2 = await writeComment(user.accessToken, todoId, "답글의 답글", depth1);
+
+		async function listTopLevel() {
+			const response = await request(ctx.app.getHttpServer())
+				.get(`/v1/todos/${todoId}/comments`)
+				.query({ sort: "LATEST", size: 20 })
+				.set("Authorization", `Bearer ${user.accessToken}`)
+				.expect(200);
+
+			return response.body.data.items;
+		}
+
+		// 답글이 남았으므로 중간 댓글은 묘비로 남는다.
+		await request(ctx.app.getHttpServer())
+			.delete(`/v1/todos/${todoId}/comments/${depth1}`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		const afterMiddleDelete = await listTopLevel();
+
+		expect(afterMiddleDelete[0]).toMatchObject({ id: depth0, replyCount: 1 });
+		expect(afterMiddleDelete[0].replyPreview[0]).toMatchObject({
+			id: depth1,
+			isDeleted: true,
+			content: null,
+			author: null,
+			replyCount: 1,
+		});
+
+		// 마지막 답글이 사라지면 빈 묘비도 함께 걷히고 그만큼 위로 정산된다.
+		await request(ctx.app.getHttpServer())
+			.delete(`/v1/todos/${todoId}/comments/${depth2}`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		const afterLeafDelete = await listTopLevel();
+
+		expect(afterLeafDelete[0]).toMatchObject({
+			id: depth0,
+			isDeleted: false,
+			replyCount: 0,
+			hasReplies: false,
+			hasMoreReplies: false,
+		});
+		expect(afterLeafDelete[0].replyPreview).toEqual([]);
+
+		const details = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/details`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(details.body.data.metrics.commentCount).toBe(1);
+	});
+
+	it("한 번에 이어 쓴 글은 사슬이 되고, 부모의 답글 수는 하나만 오른다", async () => {
+		const user = await ctx.helpers.createVerifiedUser("todo-comment@example.com", "Test1234!");
+		const todoId = await createTodo(user.accessToken);
+		const parentId = await writeComment(user.accessToken, todoId, "댓글");
+
+		const chain = await writeChain(user.accessToken, todoId, ["하나", "둘", "셋"], parentId);
+
+		expect(chain).toHaveLength(3);
+
+		// 각 글이 바로 앞 글의 답글로 이어진다.
+		const [first, second, third] = chain;
+		const depths = await Promise.all(
+			chain.map(async (commentId) => {
+				const response = await request(ctx.app.getHttpServer())
+					.get(`/v1/todos/${todoId}/comments/${commentId}/thread`)
+					.set("Authorization", `Bearer ${user.accessToken}`)
+					.expect(200);
+
+				return response.body.data.comment as { depth: number; parentId: string | null };
+			}),
+		);
+
+		expect(depths[0]).toMatchObject({ depth: 1, parentId });
+		expect(depths[1]).toMatchObject({ depth: 2, parentId: first });
+		expect(depths[2]).toMatchObject({ depth: 3, parentId: second });
+		expect(third).toBeDefined();
+
+		// 직계 자식은 사슬의 첫 글 하나뿐이다.
+		const listResponse = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/comments`)
+			.query({ sort: "LATEST", size: 20 })
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(listResponse.body.data.items[0]).toMatchObject({ id: parentId, replyCount: 1 });
+
+		// 할 일의 댓글 수는 사슬 길이만큼 오른다.
+		const details = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/details`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(details.body.data.metrics.commentCount).toBe(4);
+	});
+
+	it("같은 멱등 키로 다시 보내면 사슬이 두 번 생기지 않는다", async () => {
+		const user = await ctx.helpers.createVerifiedUser("todo-comment@example.com", "Test1234!");
+		const todoId = await createTodo(user.accessToken);
+		const items = [
+			{ clientRequestId: randomUUID(), content: "하나" },
+			{ clientRequestId: randomUUID(), content: "둘" },
+		];
+
+		const first = await request(ctx.app.getHttpServer())
+			.post(`/v1/todos/${todoId}/comments`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.send({ items })
+			.expect(201);
+		const retried = await request(ctx.app.getHttpServer())
+			.post(`/v1/todos/${todoId}/comments`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.send({ items })
+			.expect(201);
+
+		expect(retried.body.data.comments.map((c: { id: string }) => c.id)).toEqual(
+			first.body.data.comments.map((c: { id: string }) => c.id),
+		);
+
+		const details = await request(ctx.app.getHttpServer())
+			.get(`/v1/todos/${todoId}/details`)
+			.set("Authorization", `Bearer ${user.accessToken}`)
+			.expect(200);
+
+		expect(details.body.data.metrics.commentCount).toBe(2);
+	});
+});

--- a/apps/api/test/fixtures/todo.fixture.ts
+++ b/apps/api/test/fixtures/todo.fixture.ts
@@ -82,6 +82,8 @@ export const TodoFixture = {
 			sortOrder: overrides.sortOrder ?? id,
 			visibility: overrides.visibility ?? "PRIVATE",
 			recurrenceGroupId: overrides.recurrenceGroupId ?? null,
+			viewCount: overrides.viewCount ?? 0,
+			commentCount: overrides.commentCount ?? 0,
 			createdAt: overrides.createdAt ?? now,
 			updatedAt: overrides.updatedAt ?? now,
 		};

--- a/apps/api/test/integration/admin.integration-spec.ts
+++ b/apps/api/test/integration/admin.integration-spec.ts
@@ -16,11 +16,10 @@ import { Test, type TestingModule } from "@nestjs/testing";
 import { createMockDatabaseService } from "@test/mocks/mock-database.factory";
 import { suppressLogger } from "@test/setup/suppress-logger";
 
+import { ADMIN_PROVIDERS } from "@/admin/application/admin.providers";
 import { ADMIN_BROADCAST_NOTIFIER } from "@/admin/application/ports/admin-broadcast-notifier.port";
 import { ADMIN_GROWTH_METRICS } from "@/admin/application/ports/admin-growth-metrics.port";
 import { ADMIN_USER_DIRECTORY } from "@/admin/application/ports/admin-user-directory.port";
-import { AdminQueries } from "@/admin/application/queries";
-import { AdminUseCases } from "@/admin/application/use-cases";
 import { BroadcastNotificationUseCase } from "@/admin/application/use-cases/broadcast-notification/broadcast-notification.use-case";
 import { SendTargetedNotificationUseCase } from "@/admin/application/use-cases/send-targeted-notification/send-targeted-notification.use-case";
 import { NotificationAdminBroadcastNotifierAdapter } from "@/admin/infrastructure/adapters/notification-admin-broadcast-notifier.adapter";
@@ -52,8 +51,7 @@ describe("Admin 수직 통합 테스트 (Mock DB/Notification)", () => {
 
 		module = await Test.createTestingModule({
 			providers: [
-				...AdminUseCases,
-				...AdminQueries,
+				...ADMIN_PROVIDERS,
 				{
 					provide: ADMIN_GROWTH_METRICS,
 					useValue: { getSummary: jest.fn() },

--- a/apps/api/test/integration/daily-completion.integration-spec.ts
+++ b/apps/api/test/integration/daily-completion.integration-spec.ts
@@ -26,10 +26,10 @@ import { createDailyCompletionCacheMock, createDailyCompletionFriendMock } from 
 import { suppressLogger } from "@test/setup/suppress-logger";
 import dayjs from "dayjs";
 
+import { DAILY_COMPLETION_PROVIDERS } from "@/daily-completion/application/daily-completion.providers";
 import { DAILY_COMPLETION_CACHE } from "@/daily-completion/application/ports/daily-completion-cache.port";
 import { FRIEND_PORT } from "@/daily-completion/application/ports/friend.port";
 import { TODO_COMPLETION_REPOSITORY } from "@/daily-completion/application/ports/todo-completion.repository.port";
-import { DailyCompletionQueryUseCases } from "@/daily-completion/application/queries";
 import { GetDailyCompletionsUseCase } from "@/daily-completion/application/queries/get-daily-completions/get-daily-completions.use-case";
 import { PrismaTodoCompletionRepository } from "@/daily-completion/infrastructure/adapters/prisma-todo-completion.repository";
 import type { DatabaseService } from "@/shared/infrastructure/database/database.service";
@@ -56,7 +56,7 @@ describe("DailyCompletion 통합 테스트 (실제 DB)", () => {
 		// 클린아키 수직 배선: Facade → use-case → Prisma 어댑터(실제 DB)
 		module = await Test.createTestingModule({
 			providers: [
-				...DailyCompletionQueryUseCases,
+				...DAILY_COMPLETION_PROVIDERS,
 				{
 					provide: TODO_COMPLETION_REPOSITORY,
 					useClass: PrismaTodoCompletionRepository,

--- a/apps/api/test/integration/weather.integration-spec.ts
+++ b/apps/api/test/integration/weather.integration-spec.ts
@@ -38,12 +38,11 @@ import {
 	WEATHER_PROVIDER,
 	type WeatherProvider,
 } from "@/weather/application/ports/weather-provider.port";
-import { WeatherQueryUseCases } from "@/weather/application/queries";
 import { GetWeatherConditionsUseCase } from "@/weather/application/queries/get-weather-conditions/get-weather-conditions.use-case";
 import { GetWeatherForecastUseCase } from "@/weather/application/queries/get-weather-forecast/get-weather-forecast.use-case";
 import { WeatherForecastReader } from "@/weather/application/services/weather-forecast.reader";
-import { WeatherUseCases } from "@/weather/application/use-cases";
 import { UpsertLocationUseCase } from "@/weather/application/use-cases/upsert-location/upsert-location.use-case";
+import { WEATHER_PROVIDERS } from "@/weather/application/weather.providers";
 import { WeatherCacheAdapter } from "@/weather/infrastructure/adapters/weather-cache.adapter";
 import { PrismaWeatherLocationRepository } from "@/weather/infrastructure/persistence/prisma-weather-location.repository";
 
@@ -119,8 +118,7 @@ describe("Weather 통합 테스트 (Mock DB)", () => {
 		module = await Test.createTestingModule({
 			providers: [
 				WeatherForecastReader,
-				...WeatherQueryUseCases,
-				...WeatherUseCases,
+				...WEATHER_PROVIDERS,
 				{
 					provide: WEATHER_LOCATION_REPOSITORY,
 					useClass: PrismaWeatherLocationRepository,

--- a/apps/api/test/integration/weekly-achievement.integration-spec.ts
+++ b/apps/api/test/integration/weekly-achievement.integration-spec.ts
@@ -28,10 +28,9 @@ import { PaginationService } from "@/shared/application/pagination/services/pagi
 import { UNIT_OF_WORK } from "@/shared/application/ports";
 import { ApplicationException } from "@/shared/domain/exceptions/application.exception";
 import { WEEKLY_ACHIEVEMENT_REPOSITORY } from "@/weekly-achievement/application/ports/weekly-achievement.repository.port";
-import { WeeklyAchievementQueryUseCases } from "@/weekly-achievement/application/queries";
 import { GetWeeklyAchievementUseCase } from "@/weekly-achievement/application/queries/get-weekly-achievement/get-weekly-achievement.use-case";
 import { GetWeeklyAchievementsUseCase } from "@/weekly-achievement/application/queries/get-weekly-achievements/get-weekly-achievements.use-case";
-import { WeeklyAchievementUseCases } from "@/weekly-achievement/application/use-cases";
+import { WEEKLY_ACHIEVEMENT_PROVIDERS } from "@/weekly-achievement/application/weekly-achievement.providers";
 import { PrismaWeeklyAchievementRepository } from "@/weekly-achievement/infrastructure/adapters/prisma-weekly-achievement.repository";
 
 describe("WeeklyAchievement 통합 테스트 (Mock DB)", () => {
@@ -80,8 +79,7 @@ describe("WeeklyAchievement 통합 테스트 (Mock DB)", () => {
 		// 클린아키 수직 배선: Facade → use-case → Prisma 어댑터(mock DB)
 		module = await Test.createTestingModule({
 			providers: [
-				...WeeklyAchievementQueryUseCases,
-				...WeeklyAchievementUseCases,
+				...WEEKLY_ACHIEVEMENT_PROVIDERS,
 				PaginationService,
 				{
 					provide: WEEKLY_ACHIEVEMENT_REPOSITORY,

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -159,6 +159,9 @@ export const ErrorCode = {
   TODO_0813: 'TODO_0813',
   TODO_0821: 'TODO_0821',
   TODO_0822: 'TODO_0822',
+  TODO_0831: 'TODO_0831',
+  TODO_0832: 'TODO_0832',
+  TODO_0833: 'TODO_0833',
 
   // =========================================================================
   // Todo 카테고리 (TODO_CATEGORY_0850-0899)
@@ -833,6 +836,24 @@ export const Errors: Record<ErrorCodeType, ErrorDefinition> = {
     message: '하위 항목을 찾을 수 없습니다.',
     description: '해당 ID의 하위 항목이 존재하지 않거나 해당 투두에 속하지 않습니다.',
     httpStatus: HttpStatus.NOT_FOUND,
+  },
+  [ErrorCode.TODO_0831]: {
+    code: 'TODO_0831',
+    message: '댓글을 찾을 수 없습니다.',
+    description: '해당 댓글이 존재하지 않거나 현재 사용자가 접근할 수 없습니다.',
+    httpStatus: HttpStatus.NOT_FOUND,
+  },
+  [ErrorCode.TODO_0832]: {
+    code: 'TODO_0832',
+    message: '댓글을 변경할 권한이 없습니다.',
+    description: '댓글 작성자만 댓글을 수정하거나 삭제할 수 있습니다.',
+    httpStatus: HttpStatus.FORBIDDEN,
+  },
+  [ErrorCode.TODO_0833]: {
+    code: 'TODO_0833',
+    message: '삭제된 댓글에는 이 작업을 할 수 없습니다.',
+    description: '삭제된 댓글은 수정하거나 답글 또는 좋아요를 추가할 수 없습니다.',
+    httpStatus: HttpStatus.CONFLICT,
   },
 
   // =========================================================================

--- a/packages/validators/src/domains/todo-comment/index.ts
+++ b/packages/validators/src/domains/todo-comment/index.ts
@@ -1,0 +1,3 @@
+export * from './todo-comment.constants';
+export * from './todo-comment.request';
+export * from './todo-comment.response';

--- a/packages/validators/src/domains/todo-comment/todo-comment.constants.ts
+++ b/packages/validators/src/domains/todo-comment/todo-comment.constants.ts
@@ -1,0 +1,20 @@
+/**
+ * 스레드 깊이에는 상한이 없다 — 답글의 답글이 얼마든 이어진다.
+ * 대신 목록 응답이 깊이에 따라 커지지 않도록, 어떤 목록이든 자식 미리보기를 한 겹만 싣는다.
+ */
+export const TODO_COMMENT_LIMITS = {
+  CONTENT_MAX_LENGTH: 500,
+  DEFAULT_PAGE_SIZE: 20,
+  MAX_PAGE_SIZE: 50,
+  /** 한 댓글에 함께 보여줄 답글 수 */
+  REPLY_PREVIEW_SIZE: 2,
+  /** 한 번에 이어 쓸 수 있는 글 수 — 각 글이 앞 글의 답글이 되는 사슬의 최대 길이 */
+  CHAIN_MAX_SIZE: 5,
+} as const;
+
+export const TODO_COMMENT_SORT = {
+  POPULAR: 'POPULAR',
+  LATEST: 'LATEST',
+} as const;
+
+export type TodoCommentSort = (typeof TODO_COMMENT_SORT)[keyof typeof TODO_COMMENT_SORT];

--- a/packages/validators/src/domains/todo-comment/todo-comment.request.ts
+++ b/packages/validators/src/domains/todo-comment/todo-comment.request.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+import { TODO_COMMENT_LIMITS, TODO_COMMENT_SORT } from './todo-comment.constants';
+
+export const todoCommentIdSchema = z.cuid().describe('댓글 ID (CUID)');
+
+export const todoCommentIdParamSchema = z.object({
+  todoId: z.coerce.number().int().positive(),
+  commentId: todoCommentIdSchema,
+});
+
+export const todoDetailsParamSchema = z.object({
+  todoId: z.coerce.number().int().positive(),
+});
+
+export const todoCommentContentSchema = z
+  .string()
+  .trim()
+  .min(1, '댓글 내용을 입력해주세요.')
+  .max(
+    TODO_COMMENT_LIMITS.CONTENT_MAX_LENGTH,
+    `댓글은 ${TODO_COMMENT_LIMITS.CONTENT_MAX_LENGTH}자 이내로 입력해주세요.`,
+  );
+
+/**
+ * 한 번에 이어 쓰는 글 묶음.
+ * 첫 글만 대상(할 일 또는 댓글)의 직계 자식이고, 나머지는 바로 앞 글의 답글로 이어진다.
+ * 멱등 키를 글마다 받아 재시도해도 사슬이 두 번 생기지 않는다.
+ */
+export const createTodoCommentChainSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        clientRequestId: z.uuid(),
+        content: todoCommentContentSchema,
+      }),
+    )
+    .min(1)
+    .max(TODO_COMMENT_LIMITS.CHAIN_MAX_SIZE),
+});
+
+export const updateTodoCommentSchema = z.object({
+  content: todoCommentContentSchema,
+});
+
+/** 기본은 최신순 — 쓰레드도 답글을 시간순으로만 세운다(인기순 개념이 없다). */
+const todoCommentSortSchema = z
+  .enum(TODO_COMMENT_SORT)
+  .optional()
+  .default(TODO_COMMENT_SORT.LATEST);
+
+const todoCommentPageSizeSchema = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .max(TODO_COMMENT_LIMITS.MAX_PAGE_SIZE)
+  .optional()
+  .default(TODO_COMMENT_LIMITS.DEFAULT_PAGE_SIZE);
+
+/** 최상위 댓글 목록과 어떤 댓글의 답글 목록이 같은 계약을 쓴다. */
+export const getTodoCommentsQuerySchema = z.object({
+  sort: todoCommentSortSchema,
+  cursor: z.string().min(1).optional(),
+  size: todoCommentPageSizeSchema,
+});
+
+export type CreateTodoCommentChainInput = z.infer<typeof createTodoCommentChainSchema>;
+export type UpdateTodoCommentInput = z.infer<typeof updateTodoCommentSchema>;
+export type GetTodoCommentsQuery = z.infer<typeof getTodoCommentsQuerySchema>;

--- a/packages/validators/src/domains/todo-comment/todo-comment.response.ts
+++ b/packages/validators/src/domains/todo-comment/todo-comment.response.ts
@@ -1,0 +1,140 @@
+import { z } from 'zod';
+
+import { datetimeSchema, nullableDatetimeSchema } from '../../common/datetime';
+import { todoSchema } from '../todo/todo.response';
+
+export const todoCommentAuthorSchema = z.object({
+  id: z.cuid(),
+  name: z.string().nullable(),
+  profileImage: z.string().nullable(),
+  isTodoOwner: z.boolean(),
+});
+
+export const todoCommentReplyTargetSchema = z.object({
+  commentId: z.cuid(),
+  authorName: z.string().nullable(),
+});
+
+export const todoCommentViewerSchema = z.object({
+  isLiked: z.boolean(),
+  canEdit: z.boolean(),
+  canDelete: z.boolean(),
+  canReply: z.boolean(),
+});
+
+/**
+ * 댓글 한 건. 최상위 댓글과 답글은 같은 모양이고, parentId가 있느냐로만 갈린다.
+ * 깊이 상한은 없다 — 화면이 들여쓰기를 접을 뿐이다.
+ */
+const todoCommentBaseSchema = z.object({
+  id: z.cuid(),
+  todoId: z.number().int().positive(),
+  /** 직계 부모. null이면 최상위 댓글 */
+  parentId: z.cuid().nullable(),
+  /** 대화의 뿌리. 최상위 댓글이면 null */
+  rootId: z.cuid().nullable(),
+  /** 뿌리에서 이 댓글까지의 깊이 (최상위는 0) */
+  depth: z.number().int().nonnegative(),
+  author: todoCommentAuthorSchema.nullable(),
+  content: z.string().nullable(),
+  isDeleted: z.boolean(),
+  isEdited: z.boolean(),
+  likeCount: z.number().int().nonnegative(),
+  /** 직계 답글 수 (자손 총합이 아니다) */
+  replyCount: z.number().int().nonnegative(),
+  /** 답글이 하나라도 있는지 — 클라이언트가 다음 화면으로 이어갈 근거 */
+  hasReplies: z.boolean(),
+  /** 미리보기 밖에 답글이 더 남았는지 — 클라이언트가 재계산하지 않도록 서버가 확정한다 */
+  hasMoreReplies: z.boolean(),
+  /** 누구에게 단 답글인지 — @멘션의 근거 */
+  replyTo: todoCommentReplyTargetSchema.nullable(),
+  viewer: todoCommentViewerSchema,
+  createdAt: datetimeSchema,
+  editedAt: nullableDatetimeSchema,
+});
+
+/**
+ * 목록에 함께 실려 오는 답글 한 겹.
+ * 자기 답글은 개수(replyCount)로만 알린다 — 서버가 미리보기를 한 겹까지만 채우기 때문이다.
+ */
+export const todoCommentPreviewSchema = todoCommentBaseSchema;
+
+/** 목록의 댓글. 자식 미리보기를 함께 싣는다. */
+export const todoCommentSchema = todoCommentBaseSchema.extend({
+  /** 최신 답글 미리보기 (최대 TODO_COMMENT_LIMITS.REPLY_PREVIEW_SIZE건) */
+  replyPreview: z.array(todoCommentPreviewSchema),
+});
+
+/** 커서 페이지네이션 메타. */
+const cursorPaginationSchema = z.object({
+  nextCursor: z.string().nullable(),
+  hasNext: z.boolean(),
+  size: z.number().int().positive(),
+});
+
+/** 최상위 목록이든 어떤 댓글의 답글 목록이든 같은 모양이다. */
+export const paginatedTodoCommentsSchema = z.object({
+  items: z.array(todoCommentSchema),
+  pagination: cursorPaginationSchema,
+});
+
+export const todoDetailsResponseSchema = z.object({
+  todo: todoSchema,
+  owner: todoCommentAuthorSchema.omit({ isTodoOwner: true }),
+  permissions: z.object({
+    canEdit: z.boolean(),
+    canComment: z.boolean(),
+    canNudge: z.boolean(),
+  }),
+  metrics: z.object({
+    viewCount: z.number().int().nonnegative(),
+    commentCount: z.number().int().nonnegative(),
+  }),
+});
+
+/**
+ * 스레드 화면의 머리말. 정렬과 무관한 값만 담아 정렬을 바꿔도 다시 받지 않는다.
+ * 답글 목록은 GET /comments/{commentId}/replies가 따로 맡는다.
+ */
+export const todoCommentThreadResponseSchema = z.object({
+  /** 뿌리 → 부모 순서의 조상들 (지금 보는 댓글이 최상위면 빈 배열) */
+  ancestors: z.array(todoCommentPreviewSchema),
+  /** 지금 보고 있는 댓글 */
+  comment: todoCommentSchema,
+});
+
+/**
+ * 작성 응답 — 한 번에 이어 쓴 사슬 전체를 위에서 아래 순서로 돌려준다.
+ * 한 개만 썼으면 길이 1이다.
+ */
+export const todoCommentChainResponseSchema = z.object({
+  comments: z.array(todoCommentSchema),
+});
+
+/** 수정 응답. 최상위와 답글이 같은 모양이라 분기가 없다. */
+export const todoCommentMutationResponseSchema = z.object({
+  comment: todoCommentSchema,
+});
+
+export const todoCommentLikeResponseSchema = z.object({
+  commentId: z.cuid(),
+  isLiked: z.boolean(),
+  likeCount: z.number().int().nonnegative(),
+});
+
+export const deleteTodoCommentResponseSchema = z.object({
+  commentId: z.cuid(),
+  isDeleted: z.literal(true),
+});
+
+export type TodoComment = z.infer<typeof todoCommentSchema>;
+export type TodoCommentPreview = z.infer<typeof todoCommentPreviewSchema>;
+export type TodoCommentAuthor = z.infer<typeof todoCommentAuthorSchema>;
+export type TodoCommentReplyTarget = z.infer<typeof todoCommentReplyTargetSchema>;
+export type PaginatedTodoComments = z.infer<typeof paginatedTodoCommentsSchema>;
+export type TodoDetailsResponse = z.infer<typeof todoDetailsResponseSchema>;
+export type TodoCommentChainResponse = z.infer<typeof todoCommentChainResponseSchema>;
+export type TodoCommentMutationResponse = z.infer<typeof todoCommentMutationResponseSchema>;
+export type TodoCommentLikeResponse = z.infer<typeof todoCommentLikeResponseSchema>;
+export type DeleteTodoCommentResponse = z.infer<typeof deleteTodoCommentResponseSchema>;
+export type TodoCommentThreadResponse = z.infer<typeof todoCommentThreadResponseSchema>;

--- a/packages/validators/src/domains/todo/todo.response.ts
+++ b/packages/validators/src/domains/todo/todo.response.ts
@@ -54,6 +54,11 @@ export const todoSchema = z
       .array(todoItemResponseSchema)
       .describe('하위 항목 목록 (체크리스트, sortOrder 오름차순)'),
     itemStats: todoItemStatsSchema.describe('하위 항목 진행 통계 (카운터 뱃지/진행률 바용)'),
+    commentCount: z
+      .number()
+      .int()
+      .nonnegative()
+      .describe('댓글 수 (삭제된 댓글 제외 — 목록 진입점 뱃지용)'),
     createdAt: datetimeSchema.describe('생성 시각 (ISO 8601 UTC, 예: 2024-01-10T12:00:00.000Z)'),
     updatedAt: datetimeSchema.describe('수정 시각 (ISO 8601 UTC, 예: 2024-01-15T10:30:00.000Z)'),
   })
@@ -79,6 +84,7 @@ export const todoSchema = z
       },
       items: [],
       itemStats: { total: 0, completed: 0 },
+      commentCount: 0,
       createdAt: '2024-01-10T12:00:00.000Z',
       updatedAt: '2024-01-10T12:00:00.000Z',
     },

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -18,6 +18,7 @@ export * from './domains/notification';
 export * from './domains/nudge';
 export * from './domains/subscription';
 export * from './domains/todo';
+export * from './domains/todo-comment';
 export * from './domains/todo-category';
 export * from './domains/user-consent';
 export * from './domains/user-preference';


### PR DESCRIPTION
## 📋 개요

댓글을 고정 2단계에서 **임의 깊이 트리**로 바꾸고, 한 번에 여러 개를 이어 쓰는 **연쇄 작성**을 지원합니다. Threads의 "스레드에 추가"와 같은 흐름입니다.

이 PR은 Stack #755의 3단입니다. 댓글 기능은 아직 배포되지 않았으므로 레거시를 보존하지 않습니다.

## 🏷️ 변경 유형

- [x] 🚀 `feat` - 댓글 트리·연쇄 작성 도메인
- [x] ♻️ `refactor` - create/reply use-case 통합

## 📦 영향 범위

- [x] `apps/api` - todo-comment 도메인/영속/캐시/프레젠테이션, Prisma 스키마
- [x] `packages/validators` - 댓글 요청·응답 계약, 할 일 응답

## Before / After

| 영역 | Before | After |
|---|---|---|
| 트리 깊이 | 고정 2단계(`rootCommentId`·`replyToCommentId`) | 임의 깊이(`parentId` + `rootId`·`path`·`depth`) |
| 작성 계약 | 단건 생성 / 단건 답글 | 언제나 글 묶음(`items[]`, 최대 5) |
| use-case | `create-todo-comment` + `reply-todo-comment` | `write-todo-comment-chain` 하나 |
| 조상 조회 | 없음 | `path`로 깊이와 무관하게 1회 쿼리 |
| 삭제된 댓글 | 사라짐 | 답글이 남아 있으면 묘비로 유지 |
| 알림 문구 | 댓글·답글·좋아요가 한 종류 | 종류별로 구분, 연쇄는 개수로 |

## 설계 판단

- **저장은 인접 리스트 + 비정규화**입니다. `parentId`가 유일한 진실이고 `rootId`·`path`·`depth`는 그로부터 파생됩니다. `path` 덕분에 조상 사슬을 깊이와 무관하게 한 번의 쿼리로 가져옵니다.
- **연쇄에서 부모의 답글 수는 하나만 오릅니다.** 직계 자식은 사슬의 첫 글뿐입니다. 그리고 사슬의 각 마디는 다음 마디를 직계 자식으로 가지므로, 마지막을 뺀 모든 마디의 `replyCount`를 **심는 순간 1로 박아 넣습니다** — 뒤따라 세는 쿼리를 만들지 않습니다.
- `clientRequestId`를 **글마다** 받아 `@@unique([authorId, clientRequestId])` 멱등 계약을 살립니다.
- create/reply를 하나로 합친 이유는 부모 유무만 다르고 흐름이 같기 때문입니다. `ThreadPlacement.under()`가 이미 자리를 이어 붙이므로 도메인에 새 개념을 만들지 않았습니다.
- 💬 수는 **직계 답글 수**를 유지합니다(후손 총합이 아님). Threads의 `GET {id}/replies`가 직계 자식을 반환하는 것과 같은 의미입니다.
- 답글 정렬에 인기순을 두지 않고 최신순을 기본으로 합니다 — Meta의 Threads API도 답글에는 `reverse`만 제공합니다.

## ⚠️ 구버전 클라이언트 영향

`todoSchema`에 `commentCount`를 추가했습니다. 배포된 1.7.x 앱의 번들 Zod는 **strip 모드**라 모르는 응답 키를 조용히 버리므로 영향이 없습니다.

다만 이 추가로 `released-v1-openapi-contract.ts`의 `schemasFingerprint`가 바뀝니다(`pathsFingerprint`는 불변). **기계적 게이트가 한 번 소비되었으므로** 그 근거를 픽스처 주석에 남겼습니다. 리뷰에서 이 판단을 함께 확인해 주세요.

`NOTIFICATION_TYPE`·`NOTIFICATION_ACTION_TYPE`에는 값을 추가하지 않았습니다 — 구버전은 목록 응답을 `z.enum`으로 파싱하다 throw하고 알림 화면 전체가 죽습니다.

## ✅ 검증

```
apps/api 유닛      2,639건 통과
typecheck          통과
```

연쇄 작성은 로컬 개발 DB에 실제 요청을 넣어 확인했습니다.

```
쓰기 전 부모 replyCount = 0  →  POST 3개 사슬  →  부모 = 1 (3이 아님)
  depth 1  rc 1
    depth 2  rc 1
      depth 3  rc 1
        depth 4  rc 0
알림: 1건 — "매튜가 댓글에 답글 3개를 남겼어요."
```
