### PR TITLE
feat(api): 댓글 알림 이동 계약과 큐 폴링 계층을 정리한다

### DIFF
--- a/apps/api/src/admin-notification/infrastructure/queue/admin-notification-queue.constants.spec.ts
+++ b/apps/api/src/admin-notification/infrastructure/queue/admin-notification-queue.constants.spec.ts
@@ -1,3 +1,5 @@
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
+
 import {
 	ADMIN_NOTIFICATION_JOB_POLICY,
 	ADMIN_NOTIFICATION_QUEUE,
@@ -20,7 +22,8 @@ describe("Admin notification queue contract", () => {
 		});
 		expect(ADMIN_NOTIFICATION_WORKER_POLICY).toEqual({
 			teamSize: 3,
-			pollingIntervalSeconds: 2,
+			// 관리자 공지는 사람이 기다리지 않는다 — 폴링은 예약 작업 주기를 따른다.
+			pollingIntervalSeconds: JOB_POLLING_SECONDS.SCHEDULED,
 		});
 		expect(DAILY_SIGNUP_SUMMARY_SCHEDULE.key).toBe("daily-signup-summary-scheduler");
 		expect(DAILY_SIGNUP_SUMMARY_SCHEDULE.timezone).toBe("Asia/Seoul");

--- a/apps/api/src/admin-notification/infrastructure/queue/admin-notification-queue.constants.ts
+++ b/apps/api/src/admin-notification/infrastructure/queue/admin-notification-queue.constants.ts
@@ -4,6 +4,8 @@
 
 import { z } from "zod";
 
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
+
 import type { AdminNotification } from "../../domain/value-objects/admin-notification-message.vo";
 
 // =============================================================================
@@ -35,7 +37,7 @@ export const ADMIN_NOTIFICATION_JOB_POLICY = {
 
 export const ADMIN_NOTIFICATION_WORKER_POLICY = {
 	teamSize: 3,
-	pollingIntervalSeconds: 2,
+	pollingIntervalSeconds: JOB_POLLING_SECONDS.SCHEDULED,
 } as const;
 
 export const DAILY_SIGNUP_SUMMARY_SCHEDULE = {

--- a/apps/api/src/ai-report/infrastructure/queue/ai-report-queue.ts
+++ b/apps/api/src/ai-report/infrastructure/queue/ai-report-queue.ts
@@ -5,6 +5,8 @@
  * 딥임포트하지 않고 큐 상수만 참조하도록 한다.
  */
 
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
+
 export const AI_REPORT_QUEUE = "ai-report-generation.v1";
 export const AI_REPORT_LEGACY_QUEUE = "ai-report-generation";
 
@@ -16,7 +18,7 @@ export const AiReportJobName = {
 
 export const AI_REPORT_WORKER_POLICY = {
 	teamSize: 5,
-	pollingIntervalSeconds: 2,
+	pollingIntervalSeconds: JOB_POLLING_SECONDS.BACKGROUND,
 } as const;
 
 export const AiReportRuntimeJobSchema = z.discriminatedUnion("name", [

--- a/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-queue.ts
+++ b/apps/api/src/ai-suggestion/infrastructure/queue/ai-suggestion-queue.ts
@@ -9,7 +9,7 @@ export const AiSuggestionJobName = {
 
 export const AI_SUGGESTION_WORKER_POLICY = {
 	teamSize: 5,
-	pollingIntervalSeconds: 2,
+	pollingIntervalSeconds: JOB_POLLING_SECONDS.BACKGROUND,
 } as const;
 
 export const AiSuggestionRuntimeJobSchema = z.discriminatedUnion("name", [
@@ -57,3 +57,5 @@ export type AiSuggestionJobData = AiSuggestionJobMap[keyof AiSuggestionJobMap];
 export type AiSuggestionRuntimeJob = z.infer<typeof AiSuggestionRuntimeJobSchema>;
 
 import { z } from "zod";
+
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";

--- a/apps/api/src/auth/infrastructure/queue/account-purge.processor.ts
+++ b/apps/api/src/auth/infrastructure/queue/account-purge.processor.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger, type OnModuleInit, Optional } from "@nestjs/common";
 
 import type { AccountPurgeJob } from "@/auth/infrastructure/scheduler/account-purge.job";
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
 import {
 	JOB_RUNTIME,
 	type JobData,
@@ -40,11 +41,11 @@ export class AccountPurgeProcessor implements OnModuleInit {
 		const handler = async () => this.process();
 		await this.runtime.work<JobData>(ACCOUNT_PURGE_QUEUE, handler, {
 			teamSize: 1,
-			pollingIntervalSeconds: 2,
+			pollingIntervalSeconds: JOB_POLLING_SECONDS.BACKGROUND,
 		});
 		await this.runtime.work<JobData>(ACCOUNT_PURGE_LEGACY_QUEUE, handler, {
 			teamSize: 1,
-			pollingIntervalSeconds: 2,
+			pollingIntervalSeconds: JOB_POLLING_SECONDS.BACKGROUND,
 		});
 	}
 

--- a/apps/api/src/notification/domain/services/notification-routing.ts
+++ b/apps/api/src/notification/domain/services/notification-routing.ts
@@ -1,0 +1,17 @@
+import { type NotificationRouting, notificationRoutingSchema } from "@aido/validators";
+
+/**
+ * 전용 컬럼이 없어 metadata에 실려 있는 이동 재료를 꺼낸다.
+ * 알림마다 metadata 모양이 달라 통과하지 못하면 빈 값으로 둔다.
+ */
+export function toNotificationRouting(metadata: unknown): NotificationRouting | undefined {
+	const parsed = notificationRoutingSchema.safeParse(metadata);
+
+	if (!parsed.success) {
+		return undefined;
+	}
+
+	const hasRouting = Object.values(parsed.data).some((value) => value !== undefined);
+
+	return hasRouting ? parsed.data : undefined;
+}

--- a/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
+++ b/apps/api/src/notification/infrastructure/adapters/push-dispatcher.adapter.ts
@@ -52,6 +52,7 @@ import {
 	supportsFeatureDiscoveryMarketing,
 } from "../../domain/services/feature-marketing-capability";
 import { isNightTime } from "../../domain/services/night-time";
+import { toNotificationRouting } from "../../domain/services/notification-routing";
 import {
 	isAutomatedEngagementNotification,
 	isMarketingNotification,
@@ -525,6 +526,7 @@ export class PushDispatcherAdapter implements PushDispatcherPort, BeforeApplicat
 		if (data.cheerId) {
 			context.cheerId = data.cheerId;
 		}
+		const routing = toNotificationRouting(data.metadata);
 
 		return {
 			notificationId: notificationId ?? 0,
@@ -534,6 +536,7 @@ export class PushDispatcherAdapter implements PushDispatcherPort, BeforeApplicat
 				...(action.url && { url: action.url }),
 			},
 			...(Object.keys(context).length > 0 && { context }),
+			...(routing && { routing }),
 			...(data.campaignKey && { campaignKey: data.campaignKey }),
 			...(data.variantId && { variantId: data.variantId }),
 			...(data.purpose && { purpose: data.purpose }),

--- a/apps/api/src/notification/infrastructure/queue/notification-queue.constants.ts
+++ b/apps/api/src/notification/infrastructure/queue/notification-queue.constants.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
+
 /** 알림 큐의 이름·메시지 스키마·운영 정책을 소유하는 단일 계약. */
 
 // =============================================================================
@@ -37,7 +39,7 @@ export const NOTIFICATION_JOB_POLICY = {
 
 export const NOTIFICATION_WORKER_POLICY = {
 	teamSize: 5,
-	pollingIntervalSeconds: 2,
+	pollingIntervalSeconds: JOB_POLLING_SECONDS.INTERACTIVE,
 } as const;
 
 export const PUSH_RECEIPT_SCHEDULE = {

--- a/apps/api/src/notification/presentation/notification.mapper.ts
+++ b/apps/api/src/notification/presentation/notification.mapper.ts
@@ -4,7 +4,7 @@
  * Prisma 엔티티를 DTO 형식으로 변환
  */
 
-import type { NotificationContext, Notification as NotificationDto } from "@aido/validators";
+import { type NotificationContext, type Notification as NotificationDto } from "@aido/validators";
 
 import { toISOString, toISOStringOrNull } from "@/shared/domain/date/utils/format";
 
@@ -16,10 +16,18 @@ export abstract class NotificationMapper {
 	 */
 	static toDto(notification: NotificationRecord): NotificationDto {
 		const context: NotificationContext = {};
-		if (notification.todoId != null) context.todoId = notification.todoId;
-		if (notification.friendId != null) context.friendId = notification.friendId;
-		if (notification.nudgeId != null) context.nudgeId = notification.nudgeId;
-		if (notification.cheerId != null) context.cheerId = notification.cheerId;
+		if (notification.todoId != null) {
+			context.todoId = notification.todoId;
+		}
+		if (notification.friendId != null) {
+			context.friendId = notification.friendId;
+		}
+		if (notification.nudgeId != null) {
+			context.nudgeId = notification.nudgeId;
+		}
+		if (notification.cheerId != null) {
+			context.cheerId = notification.cheerId;
+		}
 		const hasContext = Object.keys(context).length > 0;
 
 		return {

--- a/apps/api/src/retention/infrastructure/queue/retention-queue.constants.ts
+++ b/apps/api/src/retention/infrastructure/queue/retention-queue.constants.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
+
 export const RETENTION_QUEUE = "retention.v1";
 export const RETENTION_LEGACY_QUEUE = "retention";
 
@@ -11,7 +13,7 @@ export const RetentionJobName = {
 
 export const RETENTION_WORKER_POLICY = {
 	teamSize: 1,
-	pollingIntervalSeconds: 2,
+	pollingIntervalSeconds: JOB_POLLING_SECONDS.SCHEDULED,
 } as const;
 
 export const RetentionRuntimeJobSchema = z.discriminatedUnion("name", [

--- a/apps/api/src/scheduler/infrastructure/processors/todo-reminder.processor.ts
+++ b/apps/api/src/scheduler/infrastructure/processors/todo-reminder.processor.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger, type OnModuleInit, Optional } from "@nestjs/common";
 
 import { NotificationMessageBuilder, NotificationSender } from "@/notification";
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
 import {
 	JOB_RUNTIME,
 	type JobData,
@@ -48,14 +49,14 @@ export class TodoReminderProcessor implements OnModuleInit {
 			async (jobs) => {
 				for (const job of jobs) await this.process(job.data.data);
 			},
-			{ teamSize: 1, pollingIntervalSeconds: 2 },
+			{ teamSize: 1, pollingIntervalSeconds: JOB_POLLING_SECONDS.SCHEDULED },
 		);
 		await this.runtime.work<JobData>(
 			TODO_REMINDER_LEGACY_QUEUE,
 			async (jobs) => {
 				for (const job of jobs) await this.process(fromLegacyJob<TodoReminderJobMap>(job).data);
 			},
-			{ teamSize: 1, pollingIntervalSeconds: 2 },
+			{ teamSize: 1, pollingIntervalSeconds: JOB_POLLING_SECONDS.SCHEDULED },
 		);
 	}
 

--- a/apps/api/src/scheduler/infrastructure/queue/timezone-reminder-queue.constants.ts
+++ b/apps/api/src/scheduler/infrastructure/queue/timezone-reminder-queue.constants.ts
@@ -6,6 +6,8 @@
  */
 import { z } from "zod";
 
+import { JOB_POLLING_SECONDS } from "@/shared/application/ports";
+
 import type {
 	ReminderHourChangedJobData,
 	SocialDigestJobData,
@@ -31,7 +33,7 @@ export const TimezoneReminderJobName = {
 
 export const TIMEZONE_REMINDER_WORKER_POLICY = {
 	teamSize: 1,
-	pollingIntervalSeconds: 2,
+	pollingIntervalSeconds: JOB_POLLING_SECONDS.SCHEDULED,
 } as const;
 
 const ReminderHourChangedJobDataSchema = z.object({

--- a/apps/api/src/shared/application/ports/job-runtime.port.ts
+++ b/apps/api/src/shared/application/ports/job-runtime.port.ts
@@ -71,3 +71,19 @@ export interface JobRuntimePort {
 }
 
 export const JOB_RUNTIME = Symbol("JOB_RUNTIME");
+
+/**
+ * 큐 폴링 주기.
+ *
+ * 폴링은 일이 없어도 도는 비용이다 — pg-boss는 주기마다 큐별로
+ * `UPDATE ... FOR UPDATE SKIP LOCKED`를 날리므로, 유휴 상태에서도 WAL과 죽은 튜플이 쌓인다.
+ * 그래서 주기는 "사람이 기다리고 있는가"로 정한다.
+ */
+export const JOB_POLLING_SECONDS = {
+	/** 사람이 결과를 기다린다 — 푸시 발송처럼 늦으면 체감되는 일. */
+	INTERACTIVE: 2,
+	/** 정해진 시각에 도는 일 — 몇 초 늦어도 아무도 모른다. */
+	SCHEDULED: 15,
+	/** 배경에서 알아서 되는 일 — 지연이 의미를 갖지 않는다. */
+	BACKGROUND: 30,
+} as const;

--- a/packages/validators/src/domains/notification/notification.payload.ts
+++ b/packages/validators/src/domains/notification/notification.payload.ts
@@ -40,6 +40,10 @@ export const notificationActionTypeSchema = z.enum([
  *
  * 클라이언트가 type + context 조합으로 라우트를 결정합니다.
  */
+/**
+ * 배포된 알림 목록 DTO에 그대로 박혀 있는 모양이라 필드를 늘리지 않는다.
+ * 이동에 더 필요한 값은 notificationRoutingSchema가 따로 실어 나른다.
+ */
 export const notificationContextSchema = z.object({
   todoId: z.number().optional(),
   friendId: z.string().optional(),
@@ -59,6 +63,18 @@ export type NotificationContext = z.infer<typeof notificationContextSchema>;
  * - type: 액션 타입 (DEEP_LINK, BROWSER, WEBVIEW, NONE)
  * - url: DEEP_LINK의 경우 선택적, BROWSER/WEBVIEW의 경우 필수
  */
+/**
+ * 전용 컬럼이 없어 context에 담지 못하는 이동 재료.
+ * REST에서는 metadata에, 푸시에서는 payload의 routing에 실린다 — 둘 다 구버전이 조용히 버린다.
+ */
+export const notificationRoutingSchema = z.object({
+  commentId: z.cuid().optional(),
+  threadRootId: z.cuid().optional(),
+  activityKind: z.enum(['COMMENT', 'REPLY', 'LIKE']).optional(),
+});
+
+export type NotificationRouting = z.infer<typeof notificationRoutingSchema>;
+
 export const notificationActionSchema = z.object({
   type: notificationActionTypeSchema,
   url: z.string().optional(),
@@ -82,6 +98,7 @@ export const pushNotificationDataSchema = z.object({
   type: z.enum(notificationTypes),
   action: notificationActionSchema,
   context: notificationContextSchema.optional(),
+  routing: notificationRoutingSchema.optional(),
   dispatchId: z.number().int().positive().optional(),
   campaignKey: z.string().max(100).optional(),
   variantId: z.string().max(100).optional(),


### PR DESCRIPTION
## 📋 개요

푸시가 **어느 댓글로** 가야 하는지 실어 보내고, 일이 없어도 도는 큐 폴링 비용을 줄입니다.

이 PR은 Stack #755의 4단입니다.

## 🏷️ 변경 유형

- [x] 🚀 `feat` - 알림 이동 계약(routing)
- [x] ⚡ `perf` - 큐 폴링 계층화

## 📦 영향 범위

- [x] `apps/api` - 푸시 페이로드, 알림 매퍼, 전 모듈 큐 상수
- [x] `packages/validators` - 푸시 페이로드 계약

## Before / After

| 영역 | Before | After |
|---|---|---|
| 푸시 페이로드 | 댓글 식별자 없음 → 목록 화면까지만 이동 | `routing`(commentId·threadRootId·activityKind) |
| 큐 폴링 | 10개 큐가 전부 2초 | 계층화(대화형 2s / 예약 15s / 배경 30s) |
| 유휴 DB 부하 | **22.8 쿼리/초** | **10.8 쿼리/초** (-53%) |

## 설계 판단

- **`NOTIFICATION_TYPE`에 값을 추가하지 않습니다.** 배포된 앱은 알림 목록 응답을 `z.enum`으로 파싱하고, 모르는 값이 한 줄이라도 섞이면 배열 전체 파싱이 실패해 `throw` → ErrorBoundary → **알림 화면 전체가 죽습니다**. 반면 필드 추가는 strip되어 안전하므로, 구분은 `routing.activityKind`와 문구가 맡습니다.
- **폴링 주기는 "사람이 기다리는가"로 나눕니다.** 상수 하나에 그 기준을 적어 두어 새 큐가 추가될 때 판단이 반복되지 않게 했습니다.
  - `INTERACTIVE: 2s` — 푸시 발송처럼 늦으면 체감되는 일
  - `SCHEDULED: 15s` — 정해진 시각에 도는 일
  - `BACKGROUND: 30s` — 배경에서 알아서 되는 일
- 이 폴링은 **읽기가 아니라 쓰기**입니다. pg-boss는 주기마다 큐별로 `UPDATE ... FOR UPDATE SKIP LOCKED`를 날리므로, 할 일이 없어도 WAL과 죽은 튜플이 쌓입니다. 그래서 유휴 상태의 비용이 실제로 의미가 있습니다.
- 계약 테스트가 매직넘버 대신 계층 상수를 보도록 함께 고쳤습니다.

## 📊 실측

로컬 도커 PostgreSQL, 앱 요청이 하나도 없는 유휴 상태에서 `log_statement='all'`로 20초 측정:

| | 쿼리/초 |
|---|---:|
| Before | 22.8 |
| After | 10.8 |

## ✅ 검증

```
apps/api 유닛   2,639건 통과
typecheck       통과
```
