### PR TITLE
fix(api): 좋아요 알림이 한 번 실패하면 영영 사라지던 것을 고친다

### DIFF
--- a/apps/api/src/todo-comment/application/use-cases/like-todo-comment/like-todo-comment.use-case.spec.ts
+++ b/apps/api/src/todo-comment/application/use-cases/like-todo-comment/like-todo-comment.use-case.spec.ts
@@ -1,0 +1,119 @@
+import {
+	createTodoCommentCacheMock,
+	createTodoCommentNotificationMock,
+	createTodoCommentRepositoryMock,
+	createUnitOfWorkMock,
+} from "@test/mocks/ports";
+
+import { TodoComment } from "../../../domain/entities/todo-comment.aggregate";
+import type { TodoCommentLikeTransition } from "../../types";
+import { LikeTodoCommentUseCase } from "./like-todo-comment.use-case";
+
+const TODO_ID = 1;
+const COMMENT_ID = "cm1todoacomment00000000001";
+const LIKER_ID = "cm1liker00000000000000001";
+const AUTHOR_ID = "cm1author0000000000000001";
+
+function createTransition(
+	overrides: Partial<TodoCommentLikeTransition> = {},
+): TodoCommentLikeTransition {
+	return {
+		commentId: COMMENT_ID,
+		commentAuthorId: AUTHOR_ID,
+		changed: true,
+		isLiked: true,
+		likeCount: 1,
+		wasEverNotified: false,
+		...overrides,
+	};
+}
+
+function setup(transition = createTransition()) {
+	const repository = createTodoCommentRepositoryMock();
+	const cache = createTodoCommentCacheMock();
+	const notification = createTodoCommentNotificationMock();
+
+	const createdAt = new Date("2026-08-16T00:00:00.000Z");
+	jest.mocked(repository.canAccessTodo).mockResolvedValue(true);
+	jest.mocked(repository.findComment).mockResolvedValue(
+		TodoComment.reconstitute({
+			id: COMMENT_ID,
+			todoId: TODO_ID,
+			authorId: AUTHOR_ID,
+			parentId: null,
+			rootId: null,
+			path: [],
+			content: "함께 해요",
+			deletedAt: null,
+			editedAt: null,
+			createdAt,
+			updatedAt: createdAt,
+		}),
+	);
+	jest.mocked(repository.findUserDisplayName).mockResolvedValue("좋아요 누른 사람");
+	jest.mocked(repository.setLike).mockResolvedValue(transition);
+
+	const useCase = new LikeTodoCommentUseCase(
+		repository,
+		cache,
+		notification,
+		createUnitOfWorkMock(),
+	);
+
+	return { useCase, repository, cache, notification };
+}
+
+describe("LikeTodoCommentUseCase", () => {
+	it("알림을 보낸 뒤에 보냈다고 표시한다", async () => {
+		const { useCase, repository, notification } = setup();
+
+		await useCase.execute({ todoId: TODO_ID, commentId: COMMENT_ID, userId: LIKER_ID });
+
+		expect(notification.notifyCommentLiked).toHaveBeenCalledTimes(1);
+		expect(repository.markLikeNotified).toHaveBeenCalledWith(COMMENT_ID, LIKER_ID);
+		expect(jest.mocked(notification.notifyCommentLiked).mock.invocationCallOrder[0]).toBeLessThan(
+			jest.mocked(repository.markLikeNotified).mock.invocationCallOrder[0] ?? 0,
+		);
+	});
+
+	/**
+	 * 표시가 남으면 껐다 켜도 다시 시도되지 않아 그 좋아요는 영영 알려지지 않는다.
+	 * 이 use-case가 지켜야 할 가장 중요한 불변식이다.
+	 */
+	it("알림 발송이 실패하면 보냈다고 표시하지 않는다", async () => {
+		const { useCase, repository, notification } = setup();
+		jest.mocked(notification.notifyCommentLiked).mockRejectedValue(new Error("push down"));
+
+		const result = await useCase.execute({
+			todoId: TODO_ID,
+			commentId: COMMENT_ID,
+			userId: LIKER_ID,
+		});
+
+		expect(repository.markLikeNotified).not.toHaveBeenCalled();
+		expect(result.isLiked).toBe(true);
+	});
+
+	it("알림이 실패해도 좋아요 자체는 성공으로 돌려준다", async () => {
+		const { useCase, cache, notification } = setup();
+		jest.mocked(notification.notifyCommentLiked).mockRejectedValue(new Error("push down"));
+
+		await expect(
+			useCase.execute({ todoId: TODO_ID, commentId: COMMENT_ID, userId: LIKER_ID }),
+		).resolves.toMatchObject({ commentId: COMMENT_ID, likeCount: 1 });
+
+		expect(cache.invalidateTopLevelFirstPages).toHaveBeenCalledWith(TODO_ID);
+	});
+
+	it("이미 알린 좋아요는 껐다 켜도 다시 알리지 않는다", async () => {
+		const { useCase, repository, notification, cache } = setup(
+			createTransition({ wasEverNotified: true }),
+		);
+
+		await useCase.execute({ todoId: TODO_ID, commentId: COMMENT_ID, userId: LIKER_ID });
+
+		expect(notification.notifyCommentLiked).not.toHaveBeenCalled();
+		expect(repository.markLikeNotified).not.toHaveBeenCalled();
+		expect(cache.invalidateTopLevelFirstPages).toHaveBeenCalledWith(TODO_ID);
+	});
+});

--- a/apps/api/src/todo-comment/application/use-cases/like-todo-comment/like-todo-comment.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/like-todo-comment/like-todo-comment.use-case.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from "@aido/errors";
 import type { TodoCommentLikeResponse } from "@aido/validators";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 
 import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
 import { ApplicationException } from "@/shared/domain";
@@ -15,6 +15,7 @@ import {
 	TODO_COMMENT_REPOSITORY,
 	type TodoCommentRepositoryPort,
 } from "../../ports/todo-comment.repository.port";
+import { settleAfterCommit } from "../../settle-after-commit";
 
 export interface LikeTodoCommentInput {
 	todoId: number;
@@ -24,6 +25,8 @@ export interface LikeTodoCommentInput {
 
 @Injectable()
 export class LikeTodoCommentUseCase {
+	readonly #logger = new Logger(LikeTodoCommentUseCase.name);
+
 	constructor(
 		@Inject(TODO_COMMENT_REPOSITORY)
 		private readonly repository: TodoCommentRepositoryPort,
@@ -52,22 +55,27 @@ export class LikeTodoCommentUseCase {
 			return { transition, senderName, threadRootId: comment.threadRootId.getValue() };
 		});
 
-		// 이미 한 번 알린 좋아요는 껐다 켜도 다시 알리지 않는다.
-		if (likeOutcome.transition.changed && !likeOutcome.transition.wasEverNotified) {
-			await this.repository.markLikeNotified(input.commentId, input.userId);
-			await Promise.all([
-				this.cache.invalidateTopLevelFirstPages(input.todoId),
-				this.notification.notifyCommentLiked({
-					recipientId: likeOutcome.transition.commentAuthorId,
-					senderId: input.userId,
-					senderName: likeOutcome.senderName,
-					todoId: input.todoId,
-					commentId: input.commentId,
-					threadRootId: likeOutcome.threadRootId,
-				}),
-			]);
-		} else if (likeOutcome.transition.changed) {
-			await this.cache.invalidateTopLevelFirstPages(input.todoId);
+		if (likeOutcome.transition.changed) {
+			const tasks = [
+				{
+					label: "comment first pages cache",
+					run: () => this.cache.invalidateTopLevelFirstPages(input.todoId),
+				},
+			];
+
+			// 이미 한 번 알린 좋아요는 껐다 켜도 다시 알리지 않는다.
+			if (!likeOutcome.transition.wasEverNotified) {
+				tasks.push({
+					label: "comment like notification",
+					run: () =>
+						this.#notifyLiked(input, likeOutcome.transition.commentAuthorId, {
+							senderName: likeOutcome.senderName,
+							threadRootId: likeOutcome.threadRootId,
+						}),
+				});
+			}
+
+			await settleAfterCommit(this.#logger, tasks);
 		}
 
 		return {
@@ -75,5 +83,25 @@ export class LikeTodoCommentUseCase {
 			isLiked: true,
 			likeCount: likeOutcome.transition.likeCount,
 		};
+	}
+
+	/**
+	 * 보내고 나서 표시한다 — 순서를 뒤집으면 발송이 한 번 실패했을 때 notifiedAt이 남아
+	 * 껐다 켜도 다시 시도되지 않는다. 중복 알림 한 번이 영구 유실보다 낫다.
+	 */
+	async #notifyLiked(
+		input: LikeTodoCommentInput,
+		recipientId: string,
+		context: { senderName: string | null; threadRootId: string },
+	): Promise<void> {
+		await this.notification.notifyCommentLiked({
+			recipientId,
+			senderId: input.userId,
+			senderName: context.senderName,
+			todoId: input.todoId,
+			commentId: input.commentId,
+			threadRootId: context.threadRootId,
+		});
+		await this.repository.markLikeNotified(input.commentId, input.userId);
 	}
 }

--- a/apps/mobile/src/features/notification/presentations/queries/use-mark-all-as-read-mutation-options.ts
+++ b/apps/mobile/src/features/notification/presentations/queries/use-mark-all-as-read-mutation-options.ts
@@ -13,6 +13,12 @@ export const useMarkAllAsReadMutationOptions = () => {
   const notificationService = useNotificationService();
   const queryClient = useQueryClient();
 
+  // 배지는 겉모습이다 — 일부 안드로이드 런처에서 이 네이티브 호출이 거부하는데,
+  // 그것 때문에 읽음 처리가 통째로 실패하면 안 된다.
+  const clearBadgeQuietly = () => {
+    notificationService.clearBadge().catch(() => undefined);
+  };
+
   return mutationOptions({
     mutationFn: async () => {
       const result = await notificationService.markAllAsRead();
@@ -20,19 +26,17 @@ export const useMarkAllAsReadMutationOptions = () => {
     },
     onMutate: async () => {
       const snapshot = await optimisticallyMarkNotificationsRead(queryClient);
-      await notificationService.clearBadge();
+      clearBadgeQuietly();
       return { snapshot };
     },
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: NOTIFICATION_QUERY_KEYS.all,
-        }),
-        notificationService.clearBadge(),
-      ]);
+      await queryClient.invalidateQueries({ queryKey: NOTIFICATION_QUERY_KEYS.all });
+      clearBadgeQuietly();
     },
     onError: (_error, _variables, context) => {
-      if (context?.snapshot) restoreNotificationCache(queryClient, context.snapshot);
+      if (context?.snapshot) {
+        restoreNotificationCache(queryClient, context.snapshot);
+      }
       void notificationService.syncBadgeCount();
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     },


### PR DESCRIPTION
## 📋 개요

`Promise.all` 사용을 전수 감사하다 **알림이 영구 유실되는 경로**를 찾았습니다. 좋아요 알림에서 **"보냈다고 표시"가 "보내기"보다 앞서 있었습니다.**

```ts
await this.repository.markLikeNotified(...);   // ← 표시가 먼저
await Promise.all([
  this.cache.invalidateTopLevelFirstPages(...),
  this.notification.notifyCommentLiked({ ... }),  // ← 발송이 나중
]);
```

발송이 한 번 던지면 `notifiedAt`은 이미 박혀 있고, 껐다 켜도 `wasEverNotified`가 참이라 조건이 거짓이 됩니다. **그 좋아요는 두 번 다시 알려지지 않습니다.** try/catch도 로깅도 없었습니다.

Stack #766의 2층입니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 좋아요 알림 영구 유실, "모두 읽음"이 배지 때문에 실패

## 📦 영향 범위

- [x] `apps/api` - todo-comment
- [x] `apps/mobile` - notification

## Before / After

| 영역 | Before | After |
|---|---|---|
| 좋아요 알림 순서 | 표시 → 발송 | **발송 → 표시** |
| 발송 실패 시 | `notifiedAt`이 남아 재시도 불가 + 500 | `null`로 남아 다음 토글에서 재시도, 요청은 성공 |
| 모바일 "모두 읽음" | 배지 네이티브 호출을 `await` → 거부하면 **API 호출조차 안 나감** | 배지는 조용히 흘림 |

## 설계 판단

- **순서를 뒤집는 쪽을 골랐습니다.** 표시가 실패하면 다음 토글에서 알림이 한 번 더 갈 수 있습니다. **중복 알림 한 번이 영구 유실보다 낫습니다.**
- **커밋 후 실패는 요청을 죽이지 않습니다.** 좋아요는 이미 커밋됐으므로 알림 실패로 500을 내면 사용자에게는 "좋아요가 안 됐다"로 보입니다. 실제로는 됐는데.
- **배지는 겉모습입니다.** `clearBadge`는 `Notifications.setBadgeCountAsync`를 그대로 노출한 것이라 일부 안드로이드 런처에서 거부합니다. 그게 `onMutate`를 실패시키면 뮤테이션 자체가 안 나가고, `onError`가 낙관적 갱신을 되돌려 "읽음 처리 실패"로 보입니다.

## ✅ 검증

**양방향 대조군을 확인했습니다.** 고치기 전 코드에 새 스펙을 돌리면 **4건 중 3건이 실패**하고, 고친 뒤 4건 전부 통과합니다.

```
✕ 알림을 보낸 뒤에 보냈다고 표시한다
✕ 알림 발송이 실패하면 보냈다고 표시하지 않는다
✕ 알림이 실패해도 좋아요 자체는 성공으로 돌려준다
✓ 이미 알린 좋아요는 껐다 켜도 다시 알리지 않는다
```

```
typecheck / lint / format:check   통과
apps/api      2,647건 통과
apps/mobile   1,204건 통과
```

## 이번에 하지 않은 것

감사에서 9건이 나왔고 이 PR은 **정확성 문제만** 다룹니다. 부하 규모 2건(winback이 미접속 사용자 전원을 `take` 없이 조회해 팬아웃, 날씨 API 무제한 동시 호출)과 지연·정돈 3건은 별도 작업으로 남깁니다.
