### PR TITLE
fix(mobile): 오버레이가 얼어붙은 진행 상태를 쓰지 않게 한다

### DIFF
--- a/apps/mobile/.claude/ui-components.md
+++ b/apps/mobile/.claude/ui-components.md
@@ -288,6 +288,40 @@ Shared UI에 있는 컴포넌트를 다른 곳에서 가져오면 안 됩니다.
 import { Text, View } from 'react-native';
 ```
 
+### 3. 오버레이에 진행 중 상태를 넘기지 않기 (중요!)
+
+`overlay.open(render)`는 **열 때의 클로저를 그대로 붙잡는다.** 부모가 다시 렌더돼도
+그 클로저는 갱신되지 않으므로, 부모에서 읽어 props로 넘긴 반응형 값은 **열린 순간의
+값에 얼어붙는다.** 로딩 표시가 영영 안 뜨고, 그 값으로 막던 중복 요청이 그대로 나간다.
+
+띄우는 내용이 **자기 상태를 스스로 가져야** 한다. 콜백을 `Promise`로 받아 안에서 재고,
+여는 쪽은 `mutateAsync`를 쓴다. 열 때 정해지고 변하지 않는 값(대상, 초기값)만 넘긴다.
+
+```tsx
+// ❌ 금지 - mutation.isPending이 false로 얼어붙는다
+overlay.open(({ isOpen, close }) => (
+  <SomeSheet
+    isOpen={isOpen}
+    onSubmit={(v) => mutation.mutate(v)}
+    isSubmitting={mutation.isPending}
+  />
+));
+
+// ✅ 올바름 - 시트가 보내는 동안을 스스로 안다
+overlay.open(({ isOpen, close }) => (
+  <SomeSheet
+    isOpen={isOpen}
+    onSubmit={async (v) => {
+      const saved = await mutation.mutateAsync(v).catch(() => null);
+      if (saved) close();
+    }}
+  />
+));
+```
+
+> oxlint에는 이걸 잡을 `no-restricted-syntax`가 없어 규칙으로 강제하지 못한다.
+> `useOverlay`의 JSDoc에도 같은 경고를 두었다.
+
 ---
 
 ## Compound Component 패턴

--- a/apps/mobile/app/(app)/memo/[id]/ai-review.tsx
+++ b/apps/mobile/app/(app)/memo/[id]/ai-review.tsx
@@ -381,7 +381,6 @@ function CategorySelectModalContent({
       selectedCategoryId={selectedCategoryId}
       onSelect={onSelect}
       submitLabel={t('aiReview.select')}
-      isLoading={false}
     />
   );
 }

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -8,6 +8,9 @@ module.exports = {
     'node_modules/(?!(.pnpm/[^/]+/node_modules/)?(react-native|@react-native|expo|@expo|heroui-native|uniwind|tailwind-variants|tailwind-merge|@gorhom|react-native-reanimated|react-native-gesture-handler|react-native-svg|react-native-worklets|ky|standard-navigation))',
   ],
   moduleNameMapper: {
+    // .svg는 별칭보다 먼저 잡아야 한다 — @assets/... 규칙이 먼저 걸리면 에셋으로 새어 나간다
+    '\\.svg$': '<rootDir>/src/shared/__tests__/mocks/svg.tsx',
+
     // Path aliases
     '^@src/(.*)$': '<rootDir>/src/$1',
     '^@/(.*)$': '<rootDir>/app/$1',

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -31,6 +31,9 @@ jest.mock('@gorhom/bottom-sheet', () => ({
   __esModule: true,
   ...require('@gorhom/bottom-sheet/mock'),
 }));
+jest.mock('expo-speech-recognition', () =>
+  require('./src/shared/__tests__/mocks/expo-speech-recognition'),
+);
 jest.mock('react-native-keyboard-controller', () =>
   require('./src/shared/__tests__/mocks/react-native-keyboard-controller'),
 );

--- a/apps/mobile/src/features/ai/presentations/components/SuggestionCategoryBottomSheet.tsx
+++ b/apps/mobile/src/features/ai/presentations/components/SuggestionCategoryBottomSheet.tsx
@@ -39,23 +39,21 @@ export function SuggestionCategoryBottomSheet({
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       selectedCategoryId={defaultCategoryId}
-      onSelect={(categoryId) => {
+      onSelect={async (categoryId) => {
         if (suggestionId == null) {
           return;
         }
 
-        handleSuggestionMutation.mutate(
-          { suggestionId, input: { action: 'accept', categoryId } },
-          {
-            onSuccess: () => {
-              onOpenChange(false);
-              onAccepted();
-            },
-          },
-        );
+        const accepted = await handleSuggestionMutation
+          .mutateAsync({ suggestionId, input: { action: 'accept', categoryId } })
+          .catch(() => null);
+
+        if (accepted) {
+          onOpenChange(false);
+          onAccepted();
+        }
       }}
       submitLabel={t('suggestions.category.submit')}
-      isLoading={handleSuggestionMutation.isPending}
     />
   );
 }

--- a/apps/mobile/src/features/friend/presentations/components/FriendDeleteConfirmDialog.tsx
+++ b/apps/mobile/src/features/friend/presentations/components/FriendDeleteConfirmDialog.tsx
@@ -3,7 +3,6 @@ import { ConfirmDialog } from '@src/shared/ui';
 
 interface FriendDeleteConfirmDialogProps {
   isOpen: boolean;
-  isProcessing: boolean;
   onOpenChange: (open: boolean) => void;
   onCancel: () => void;
   onConfirm: () => void;
@@ -11,7 +10,6 @@ interface FriendDeleteConfirmDialogProps {
 
 export function FriendDeleteConfirmDialog({
   isOpen,
-  isProcessing,
   onOpenChange,
   onCancel,
   onConfirm,
@@ -27,12 +25,12 @@ export function FriendDeleteConfirmDialog({
         <ConfirmDialog.Description>{t('deleteDialog.description')}</ConfirmDialog.Description>
       }
       cancelButton={
-        <ConfirmDialog.CancelButton onPress={onCancel} disabled={isProcessing}>
+        <ConfirmDialog.CancelButton onPress={onCancel}>
           {t('common:actions.cancel')}
         </ConfirmDialog.CancelButton>
       }
       confirmButton={
-        <ConfirmDialog.ConfirmButton color="danger" onPress={onConfirm} isLoading={isProcessing}>
+        <ConfirmDialog.ConfirmButton color="danger" onPress={onConfirm}>
           {t('common:actions.delete')}
         </ConfirmDialog.ConfirmButton>
       }

--- a/apps/mobile/src/features/friend/presentations/components/FriendList.tsx
+++ b/apps/mobile/src/features/friend/presentations/components/FriendList.tsx
@@ -73,12 +73,9 @@ export function FriendList() {
         close();
         exit();
       };
-      const isProcessing = removeMutation.isPending && removeMutation.variables === id;
-
       return (
         <FriendDeleteConfirmDialog
           isOpen={isOpen}
-          isProcessing={isProcessing}
           onOpenChange={(open) => {
             if (!open) {
               closeDialog();

--- a/apps/mobile/src/features/todo/presentations/components/AddSubTodoBottomSheet.test.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/AddSubTodoBottomSheet.test.tsx
@@ -1,0 +1,99 @@
+import '@src/shared/i18n/init';
+import { renderUi } from '@src/shared/__tests__/render-ui';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+
+import { AddSubTodoBottomSheet } from './AddSubTodoBottomSheet';
+
+function createDeferred() {
+  let settle: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  return { promise, settle: () => settle() };
+}
+
+const submitButton = () => screen.getByTestId('sub-todo-submit');
+const deleteButton = () => screen.getByTestId('sub-todo-delete');
+
+/**
+ * 진행 중 플래그를 밖에서 받던 시절, 이 시트는 오버레이로만 열려서 그 값이 열릴 때의
+ * false에 얼어붙었다. 수정 모드는 보낸 뒤에도 입력을 비우지 않으므로 버튼이 계속 열려 있어
+ * 연타하면 같은 PATCH가 여러 번 나갔다.
+ */
+describe('AddSubTodoBottomSheet 수정 모드', () => {
+  it('보내는 동안 전송과 삭제가 모두 잠긴다', async () => {
+    const deferred = createDeferred();
+    await renderUi(
+      <AddSubTodoBottomSheet
+        mode="edit"
+        initialValue="장 보기"
+        isOpen
+        onOpenChange={jest.fn()}
+        onClose={jest.fn()}
+        onSubmit={() => deferred.promise}
+        onDelete={jest.fn()}
+      />,
+    );
+
+    // 끝나지 않은 채로 둔다 — 그 사이의 잠금이 이 테스트의 대상이다.
+    const pressing = fireEvent.press(submitButton());
+
+    await waitFor(() => {
+      expect(submitButton()).toBeDisabled();
+    });
+    expect(deleteButton()).toBeDisabled();
+
+    deferred.settle();
+    await pressing;
+
+    await waitFor(() => {
+      expect(submitButton()).toBeEnabled();
+    });
+  });
+
+  it('지우는 동안에도 전송이 함께 잠긴다', async () => {
+    const deferred = createDeferred();
+    await renderUi(
+      <AddSubTodoBottomSheet
+        mode="edit"
+        initialValue="장 보기"
+        isOpen
+        onOpenChange={jest.fn()}
+        onClose={jest.fn()}
+        onSubmit={jest.fn()}
+        onDelete={() => deferred.promise}
+      />,
+    );
+
+    const pressing = fireEvent.press(deleteButton());
+
+    await waitFor(() => {
+      expect(deleteButton()).toBeDisabled();
+    });
+    expect(submitButton()).toBeDisabled();
+
+    deferred.settle();
+    await pressing;
+  });
+
+  it('보낸 뒤에도 수정 모드는 쓰던 값을 지우지 않는다', async () => {
+    const onSubmit = jest.fn();
+    await renderUi(
+      <AddSubTodoBottomSheet
+        mode="edit"
+        initialValue="장 보기"
+        isOpen
+        onOpenChange={jest.fn()}
+        onClose={jest.fn()}
+        onSubmit={onSubmit}
+        onDelete={jest.fn()}
+      />,
+    );
+
+    await fireEvent.press(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith('장 보기');
+    expect(screen.getByTestId('sub-todo-input')).toHaveProp('value', '장 보기');
+  });
+});

--- a/apps/mobile/src/features/todo/presentations/components/AddSubTodoBottomSheet.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/AddSubTodoBottomSheet.tsx
@@ -29,16 +29,14 @@ interface BaseProps {
 
 interface CreateProps extends BaseProps {
   mode: 'create';
-  onSubmit: (value: string) => void;
-  isSubmitting: boolean;
+  onSubmit: (value: string) => Promise<unknown> | void;
 }
 
 interface EditProps extends BaseProps {
   mode: 'edit';
   initialValue: string;
-  onSubmit: (value: string) => void;
-  onDelete: () => void;
-  isSubmitting: boolean;
+  onSubmit: (value: string) => Promise<unknown> | void;
+  onDelete: () => Promise<unknown> | void;
 }
 
 type AddSubTodoBottomSheetProps = CreateProps | EditProps;
@@ -54,13 +52,42 @@ export const AddSubTodoBottomSheet = (props: AddSubTodoBottomSheetProps) => {
   const [value, setValue] = useState(defaultValue);
   const inputRef = useRef<TextInput>(null);
 
-  const isSubmitDisabled = !value.trim() || props.isSubmitting;
+  // 보내는 동안의 상태는 이 시트가 스스로 안다 — 오버레이는 열릴 때의 화면을 스냅샷으로
+  // 들고 있어서, 밖에서 넘긴 진행 중 플래그는 갱신되지 않고 얼어붙는다.
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isBusy = isSubmitting || isDeleting;
 
-  const handleSubmit = () => {
+  const isSubmitDisabled = !value.trim() || isBusy;
+
+  const handleSubmit = async () => {
     const trimmed = value.trim();
-    if (!trimmed) return;
-    props.onSubmit(trimmed);
-    if (props.mode === 'create') setValue('');
+    if (!trimmed || isBusy) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await props.onSubmit(trimmed);
+      if (props.mode === 'create') {
+        setValue('');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (onDelete: () => Promise<unknown> | void) => {
+    if (isBusy) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   return (
@@ -68,6 +95,7 @@ export const AddSubTodoBottomSheet = (props: AddSubTodoBottomSheetProps) => {
       <VStack gap={12}>
         <BottomSheetInput
           ref={inputRef}
+          testID="sub-todo-input"
           autoFocus
           placeholder={tGlobal('todo:subTodo.placeholder')}
           value={value}
@@ -84,8 +112,9 @@ export const AddSubTodoBottomSheet = (props: AddSubTodoBottomSheetProps) => {
         <HStack gap={8} align="center">
           {props.mode === 'edit' && (
             <PressableFeedback
-              onPress={props.onDelete}
-              isDisabled={props.isSubmitting}
+              testID="sub-todo-delete"
+              onPress={() => handleDelete(props.onDelete)}
+              isDisabled={isBusy}
               className="size-9 items-center justify-center rounded-full bg-error/10"
             >
               <TrashIcon
@@ -101,6 +130,7 @@ export const AddSubTodoBottomSheet = (props: AddSubTodoBottomSheetProps) => {
           <SpeechTooltip />
           <SpeechButton onResult={setValue} />
           <PressableFeedback
+            testID="sub-todo-submit"
             isDisabled={isSubmitDisabled}
             onPress={handleSubmit}
             style={{ width: fontScaledSize(36), height: fontScaledSize(36) }}
@@ -109,7 +139,7 @@ export const AddSubTodoBottomSheet = (props: AddSubTodoBottomSheetProps) => {
               isSubmitDisabled ? 'bg-gray-3' : 'bg-main',
             )}
           >
-            {props.isSubmitting ? (
+            {isSubmitting ? (
               <Spinner size="sm" color="white" />
             ) : (
               <ArrowUpIcon

--- a/apps/mobile/src/features/todo/presentations/components/AddTodoBottomSheet.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/AddTodoBottomSheet.tsx
@@ -612,7 +612,6 @@ function CategorySelectModalContent({
       selectedCategoryId={selectedCategoryId}
       onSelect={onSelect}
       submitLabel={tGlobal('todo:add.submit')}
-      isLoading={false}
     />
   );
 }

--- a/apps/mobile/src/features/todo/presentations/components/CategorySelectBottomSheet.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/CategorySelectBottomSheet.tsx
@@ -10,9 +10,8 @@ interface CategorySelectBottomSheetProps {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   selectedCategoryId: number;
-  onSelect: (categoryId: number) => void;
+  onSelect: (categoryId: number) => Promise<unknown> | void;
   submitLabel: string;
-  isLoading?: boolean;
 }
 
 export function CategorySelectBottomSheet({
@@ -21,7 +20,6 @@ export function CategorySelectBottomSheet({
   selectedCategoryId,
   onSelect,
   submitLabel,
-  isLoading = false,
 }: CategorySelectBottomSheetProps) {
   const { data } = useSuspenseQuery(useGetTodoCategoriesQueryOptions());
 
@@ -33,7 +31,6 @@ export function CategorySelectBottomSheet({
           selectedCategoryId={selectedCategoryId}
           onSelect={onSelect}
           submitLabel={submitLabel}
-          isLoading={isLoading}
         />
       )}
     </BottomSheet>
@@ -43,9 +40,8 @@ export function CategorySelectBottomSheet({
 interface CategorySelectContentProps {
   categories: TodoCategory[];
   selectedCategoryId: number;
-  onSelect: (categoryId: number) => void;
+  onSelect: (categoryId: number) => Promise<unknown> | void;
   submitLabel: string;
-  isLoading: boolean;
 }
 
 export function CategorySelectContent({
@@ -53,10 +49,22 @@ export function CategorySelectContent({
   selectedCategoryId,
   onSelect,
   submitLabel,
-  isLoading,
 }: CategorySelectContentProps) {
   const { t } = useTranslation('todo');
   const [localCategoryId, setLocalCategoryId] = useState(selectedCategoryId);
+
+  // 보내는 동안의 상태는 이 시트가 스스로 안다 — 오버레이는 열릴 때의 화면을 스냅샷으로
+  // 들고 있어서, 밖에서 넘긴 진행 중 플래그는 갱신되지 않고 얼어붙는다.
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const submit = async () => {
+    setIsSubmitting(true);
+    try {
+      await onSelect(localCategoryId);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <VStack gap={20}>
@@ -96,7 +104,7 @@ export function CategorySelectContent({
         })}
       </VStack>
 
-      <Button size="large" onPress={() => onSelect(localCategoryId)} isLoading={isLoading}>
+      <Button size="large" onPress={submit} isLoading={isSubmitting}>
         {submitLabel}
       </Button>
     </VStack>

--- a/apps/mobile/src/features/todo/presentations/components/SubTodoList/SubTodoActionsBottomSheet.test.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/SubTodoList/SubTodoActionsBottomSheet.test.tsx
@@ -1,0 +1,39 @@
+import '@src/shared/i18n/init';
+import { renderUi } from '@src/shared/__tests__/render-ui';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+
+import { SubTodoActionsBottomSheet } from './SubTodoActionsBottomSheet';
+
+function renderSheet(onDelete: () => Promise<unknown> | void) {
+  return renderUi(
+    <SubTodoActionsBottomSheet
+      isOpen
+      onOpenChange={jest.fn()}
+      onClose={jest.fn()}
+      onEdit={jest.fn()}
+      onDelete={onDelete}
+    />,
+  );
+}
+
+describe('SubTodoActionsBottomSheet', () => {
+  it('지우는 동안 라벨이 바뀌고 다시 눌리지 않는다', async () => {
+    let settle: () => void = () => undefined;
+    const pending = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const onDelete = jest.fn(() => pending);
+    await renderSheet(onDelete);
+
+    // 끝나지 않은 채로 둔다 — 그 사이의 표시와 잠금이 이 테스트의 대상이다.
+    const pressing = fireEvent.press(screen.getByText('삭제하기'));
+
+    await waitFor(() => {
+      expect(screen.getByText('삭제 중...')).toBeOnTheScreen();
+    });
+    expect(onDelete).toHaveBeenCalledTimes(1);
+
+    settle();
+    await pressing;
+  });
+});

--- a/apps/mobile/src/features/todo/presentations/components/SubTodoList/SubTodoActionsBottomSheet.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/SubTodoList/SubTodoActionsBottomSheet.tsx
@@ -9,14 +9,14 @@ import {
   VStack,
 } from '@src/shared/ui';
 import { PressableFeedback } from 'heroui-native';
+import { useState } from 'react';
 
 interface SubTodoActionsBottomSheetProps {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   onClose: () => void;
   onEdit: () => void;
-  onDelete: () => void;
-  isDeleting: boolean;
+  onDelete: () => Promise<unknown> | void;
 }
 
 export const SubTodoActionsBottomSheet = ({
@@ -25,9 +25,26 @@ export const SubTodoActionsBottomSheet = ({
   onClose,
   onEdit,
   onDelete,
-  isDeleting,
 }: SubTodoActionsBottomSheetProps) => {
   const { t } = useTranslation('todo');
+
+  // 지우는 동안의 상태는 이 시트가 스스로 안다 — 오버레이는 열릴 때의 화면을 스냅샷으로
+  // 들고 있어서, 밖에서 넘긴 진행 중 플래그는 갱신되지 않고 얼어붙는다.
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (isDeleting) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <BottomSheet isOpen={isOpen} onOpenChange={onOpenChange}>
       <VStack gap={8}>
@@ -53,7 +70,7 @@ export const SubTodoActionsBottomSheet = ({
           />
         </PressableFeedback>
 
-        <PressableFeedback onPress={onDelete} isDisabled={isDeleting}>
+        <PressableFeedback onPress={handleDelete} isDisabled={isDeleting}>
           <ListRow
             horizontalPadding="medium"
             verticalPadding="medium"

--- a/apps/mobile/src/features/todo/presentations/components/TodoList/TodoItem.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/TodoList/TodoItem.tsx
@@ -4,6 +4,8 @@ import {
   BottomSheet,
   ChatBubbleIcon,
   HStack,
+  ICON_COUNT_BUTTON_ICON_SIZE,
+  IconCountButton,
   LockIcon,
   MoreIcon,
   Text,
@@ -170,16 +172,15 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
           }
         }}
         selectedCategoryId={todo.category.id}
-        onSelect={(categoryId) => {
-          todoActions.changeCategory(categoryId, {
-            onSuccess: () => {
-              close();
-              exit();
-            },
-          });
+        onSelect={async (categoryId) => {
+          const changed = await todoActions.changeCategory(categoryId).catch(() => null);
+
+          if (changed) {
+            close();
+            exit();
+          }
         }}
         submitLabel={t('actions.changeSubmit')}
-        isLoading={todoActions.isCategoryPending}
       />
     ));
   };
@@ -196,8 +197,13 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
             exit();
           }
         }}
-        onSubmit={(value) => subTodoActions.add(value, { onSuccess: () => close() })}
-        isSubmitting={subTodoActions.isAddPending}
+        onSubmit={async (value) => {
+          const added = await subTodoActions.add(value).catch(() => null);
+
+          if (added) {
+            close();
+          }
+        }}
       />
     ));
   };
@@ -226,16 +232,30 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
                   editExit();
                 }
               }}
-              onSubmit={(value) =>
-                subTodoActions.update(subTodoId, value, { onSuccess: () => editClose() })
-              }
-              onDelete={() => subTodoActions.remove(subTodoId, { onSuccess: () => editClose() })}
-              isSubmitting={subTodoActions.isUpdatePending}
+              onSubmit={async (value) => {
+                const updated = await subTodoActions.update(subTodoId, value).catch(() => null);
+
+                if (updated) {
+                  editClose();
+                }
+              }}
+              onDelete={async () => {
+                const removed = await subTodoActions.remove(subTodoId).catch(() => null);
+
+                if (removed) {
+                  editClose();
+                }
+              }}
             />
           ));
         }}
-        onDelete={() => subTodoActions.remove(subTodoId, { onSuccess: () => close() })}
-        isDeleting={subTodoActions.isRemovePending}
+        onDelete={async () => {
+          const removed = await subTodoActions.remove(subTodoId).catch(() => null);
+
+          if (removed) {
+            close();
+          }
+        }}
       />
     ));
   };
@@ -271,20 +291,19 @@ export function TodoItem({ todo, drag, isActive, isDragDisabled }: TodoItemProps
       }
       right={
         <HStack gap={8} align="center">
-          <PressableFeedback
+          <IconCountButton
+            icon={
+              <ChatBubbleIcon
+                width={ICON_COUNT_BUTTON_ICON_SIZE}
+                height={ICON_COUNT_BUTTON_ICON_SIZE}
+                colorClassName="text-gray-6"
+              />
+            }
+            count={todo.commentCount}
             onPress={openComments}
-            hitSlop={6}
             accessibilityRole="button"
             accessibilityLabel={t('detail.open')}
-            className="h-10 flex-row items-center justify-center gap-1 rounded-full px-2"
-          >
-            <ChatBubbleIcon width={21} height={21} colorClassName="text-gray-6" />
-            {todo.commentCount > 0 && (
-              <Text size="e1" shade={6}>
-                {todo.commentCount}
-              </Text>
-            )}
-          </PressableFeedback>
+          />
           <PressableFeedback onPress={isOptimistic ? undefined : openActionsSheet} hitSlop={8}>
             <MoreIcon width={20} height={20} colorClassName="text-gray-5" />
           </PressableFeedback>

--- a/apps/mobile/src/features/todo/presentations/hooks/use-sub-todo-actions.ts
+++ b/apps/mobile/src/features/todo/presentations/hooks/use-sub-todo-actions.ts
@@ -17,9 +17,8 @@ export function useSubTodoActions(todo: TodoItemViewModel) {
   const reorderMutation = useMutation(useReorderSubTodosMutationOptions());
 
   return {
-    add: (title: string, callbacks?: { onSuccess?: () => void }) =>
-      addMutation.mutate({ todoId: todo.id, title, startDate: todo.startDate }, callbacks),
-    isAddPending: addMutation.isPending,
+    add: (title: string) =>
+      addMutation.mutateAsync({ todoId: todo.id, title, startDate: todo.startDate }),
 
     toggle: (subTodoId: number, completed: boolean) =>
       toggleMutation.mutate({
@@ -29,21 +28,19 @@ export function useSubTodoActions(todo: TodoItemViewModel) {
         startDate: todo.startDate,
       }),
 
-    update: (subTodoId: number, title: string, callbacks?: { onSuccess?: () => void }) =>
-      updateMutation.mutate(
-        { todoId: todo.id, subTodoId, title, startDate: todo.startDate },
-        callbacks,
-      ),
-    isUpdatePending: updateMutation.isPending,
+    update: (subTodoId: number, title: string) =>
+      updateMutation.mutateAsync({ todoId: todo.id, subTodoId, title, startDate: todo.startDate }),
 
-    remove: (subTodoId: number, callbacks?: { onSuccess?: () => void }) =>
-      deleteMutation.mutate({ todoId: todo.id, subTodoId, startDate: todo.startDate }, callbacks),
-    isRemovePending: deleteMutation.isPending,
+    remove: (subTodoId: number) =>
+      deleteMutation.mutateAsync({ todoId: todo.id, subTodoId, startDate: todo.startDate }),
 
     canAdd: SubTodoPolicy.canAddSubTodo(todo),
 
     handleDragEnd: ({ data, from, to }: DragEndParams<SubTodo>) => {
-      if (from === to || reorderMutation.isPending) return;
+      if (from === to || reorderMutation.isPending) {
+        return;
+      }
+
       reorderMutation.mutate({
         todoId: todo.id,
         subTodoIds: data.map((item) => item.id),

--- a/apps/mobile/src/features/todo/presentations/hooks/use-todo-actions.ts
+++ b/apps/mobile/src/features/todo/presentations/hooks/use-todo-actions.ts
@@ -26,8 +26,7 @@ export function useTodoActions(todo: TodoItemViewModel) {
       isAllDay: boolean;
     }) => updateScheduleMutation.mutate({ todoId: todo.id, input }),
 
-    changeCategory: (categoryId: number, callbacks?: { onSuccess?: () => void }) =>
-      changeCategoryMutation.mutate({ todoId: todo.id, input: { categoryId } }, callbacks),
-    isCategoryPending: changeCategoryMutation.isPending,
+    changeCategory: (categoryId: number) =>
+      changeCategoryMutation.mutateAsync({ todoId: todo.id, input: { categoryId } }),
   };
 }

--- a/apps/mobile/src/shared/__tests__/mocks/expo-speech-recognition.js
+++ b/apps/mobile/src/shared/__tests__/mocks/expo-speech-recognition.js
@@ -1,0 +1,13 @@
+/**
+ * expo-speech-recognition은 공식 jest mock을 내주지 않고, import 시점에 네이티브
+ * 모듈을 붙잡아 그대로 터진다. 앱이 쓰는 표면이 좁아 그만큼만 채운다.
+ */
+module.exports = {
+  ExpoSpeechRecognitionModule: {
+    start: jest.fn(),
+    stop: jest.fn(),
+    getPermissionsAsync: jest.fn(async () => ({ granted: true, canAskAgain: true })),
+    requestPermissionsAsync: jest.fn(async () => ({ granted: true, canAskAgain: true })),
+  },
+  useSpeechRecognitionEvent: jest.fn(),
+};

--- a/apps/mobile/src/shared/__tests__/mocks/svg.tsx
+++ b/apps/mobile/src/shared/__tests__/mocks/svg.tsx
@@ -1,0 +1,12 @@
+import { View, type ViewProps } from 'react-native';
+
+/**
+ * Metro에서는 react-native-svg-transformer가 .svg를 컴포넌트로 바꿔 주지만 jest는 그
+ * 변환을 거치지 않아 에셋 객체가 들어온다. createStyledIcon이 그 객체를 감싸는 순간
+ * 컴포넌트가 아니게 되어 아이콘을 품은 화면은 통째로 렌더가 깨진다.
+ *
+ * 테스트에 그림은 필요 없고 자리만 있으면 되므로 빈 View로 대신한다.
+ */
+export default function SvgMock(props: ViewProps) {
+  return <View {...props} />;
+}


### PR DESCRIPTION
## 📋 개요

`overlay.open(render)`는 **열 때의 클로저를 그대로 붙잡습니다.** 부모가 다시 렌더돼도 그 클로저는 갱신되지 않아, 부모에서 읽어 props로 넘긴 반응형 값은 **열린 순간의 값에 얼어붙습니다.**

결정적 증거 — 이 네 플래그는 소비처가 **전부 오버레이 안**이라 **항상 `false`**였습니다. 죽은 코드이면서 동시에 버그였습니다.

```
use-sub-todo-actions.ts  isAddPending      → TodoItem.tsx:202  ← 유일한 소비처
use-sub-todo-actions.ts  isUpdatePending   → TodoItem.tsx:235  ← 유일한 소비처
use-sub-todo-actions.ts  isRemovePending   → TodoItem.tsx:240  ← 유일한 소비처
use-todo-actions.ts      isCategoryPending → TodoItem.tsx:184  ← 유일한 소비처
```

Stack #766의 3층입니다.

## 🏷️ 변경 유형

- [x] 🐛 `fix` - 중복 요청이 서버로 나가던 3곳
- [x] 🧪 `test` - jest에서 SVG 아이콘이 렌더되지 않던 것

## 📦 영향 범위

- [x] `apps/mobile` - todo·ai·friend feature, 테스트 설정

## 실제 피해

| 등급 | 자리 | 일어나던 일 |
|---|---|---|
| 🔴 | 하위 할 일 **수정** | 수정 모드는 보낸 뒤에도 입력을 비우지 않음 + 플래그가 false 고정 ⇒ 버튼이 계속 활성 ⇒ **PATCH 중복.** 저장 중 삭제도 가능 |
| 🔴 | 하위 할 일 **삭제** | 라벨이 "삭제하기" 그대로, 행도 계속 눌림 ⇒ **DELETE 중복** |
| 🔴 | **카테고리 변경** | `Button`의 `isLoading`이 유일한 중복 방지 장치인데 false 고정 ⇒ **PATCH 중복** |
| 🟡 | 하위 할 일 **추가** | 중복은 `setValue('')`가 우연히 막지만 스피너가 안 뜸 |
| ⚪ | `FriendDeleteConfirmDialog.isProcessing` | 죽은 프롭 (다이얼로그가 mutate 전에 언마운트됨) |

## Before / After

```tsx
// Before — mutation.isPending이 false로 얼어붙는다
onSubmit={(v) => subTodoActions.add(v, { onSuccess: () => close() })}
isSubmitting={subTodoActions.isAddPending}

// After — 시트가 보내는 동안을 스스로 안다
onSubmit={async (v) => {
  const added = await subTodoActions.add(v).catch(() => null);
  if (added) close();
}}
```

## 설계 판단

- **근본 수정은 불가능합니다.** `open()`은 한 번만 불리므로 이미 굳은 클로저는 바뀌지 않습니다. 선언형 API로 바꾸면 "라우트 밖 루트에서 그린다"와 `Promise<T>` 반환을 잃습니다. **띄우는 내용이 자기 상태를 갖는 것**만이 답입니다.
- **처방을 하나로 통일했습니다** — 진행 플래그 프롭 제거 → 콜백이 `Promise` 반환 → 시트가 `useState`로 잼 → 호출부는 `mutateAsync`. `CategorySelectBottomSheet`의 `isLoading`을 없애며 소비처 4곳이 자연히 같은 모양이 됐습니다.
- **멀쩡한 것은 건드리지 않았습니다.** `FriendList` 삭제 다이얼로그(`mutate`보다 `closeDialog()`가 먼저라 이미 언마운트), 마케팅 동의 시트(자기 mutation 소유 + `settledRef`), 날짜·시간 피커(넘기는 건 초기값)는 스냅샷이어도 맞습니다.
- **린트로 강제하지 못했습니다.** oxlint에 `no-restricted-syntax`가 없습니다(`Rule not found in plugin 'eslint'`). `useOverlay` JSDoc과 `.claude/ui-components.md` 금지사항에 근거를 남겼습니다.

## 🧪 테스트 인프라 (부수 발견)

**jest에서 SVG 아이콘이 하나도 렌더되지 않고 있었습니다.** Metro의 `react-native-svg-transformer`가 jest엔 없어 `.svg`가 에셋 객체로 들어오고, `createStyledIcon`이 그걸 감싸는 순간 컴포넌트가 아니게 됩니다. **아이콘을 품은 화면은 전부 렌더 테스트가 불가능**했습니다. 매퍼 한 줄로 풀었고, 이 PR의 시트 테스트들이 그 위에 섰습니다.

## ✅ 검증

```
typecheck / lint / format:check   통과
apps/mobile   1,204건 통과 (신규 4건: 시트 잠금·라벨 전환)
```

## 📱 기기 확인 권장

- 하위 할 일 **수정** 저장 **연타** → `PATCH`가 한 번만 나가고 스피너가 뜨는지
- 하위 할 일 **삭제** 연타 → `DELETE` 한 번, 라벨이 "삭제 중..."으로 바뀌는지
- **카테고리 변경** 연타 → `PATCH` 한 번
- 기내 모드로 저장 → 시트가 **열린 채** 남고 콘솔에 unhandled rejection이 없는지
