### PR TITLE
perf(mobile): 댓글 목록 파생을 select로 옮기고 시트가 스크롤되게 한다

### DIFF
--- a/apps/mobile/src/features/todo-comment/presentations/components/CommentThreadList.tsx
+++ b/apps/mobile/src/features/todo-comment/presentations/components/CommentThreadList.tsx
@@ -12,7 +12,6 @@ import {
   type QueryErrorFallbackProps,
 } from '@src/shared/ui';
 import { useQueryClient, useSuspenseInfiniteQuery } from '@tanstack/react-query';
-import { uniqBy } from 'es-toolkit';
 import { times } from 'es-toolkit/compat';
 import { Separator, Skeleton } from 'heroui-native';
 import { type ReactNode, memo, useCallback, useEffect, useRef } from 'react';
@@ -25,7 +24,10 @@ import { TODO_COMMENT_QUERY_KEYS } from '../constants/todo-comment-query-keys.co
 import { CommentRowScrollContext } from '../hooks/use-comment-row-scroll';
 import { useCommentSort } from '../hooks/use-comment-sort';
 import { useThreadParentId } from '../hooks/use-thread-parent-id';
-import { useTodoCommentsQueryOptions } from '../queries/use-todo-comment-query-options';
+import {
+  type CommentRow,
+  useTodoCommentsQueryOptions,
+} from '../queries/use-todo-comment-query-options';
 import { CommentActionMenu } from './CommentActionMenu';
 import { CommentArticle } from './CommentArticle';
 import { CommentAvatarColumn } from './CommentAvatarColumn';
@@ -63,20 +65,12 @@ const AVATAR_SIZE = 36;
 /** 아바타 한가운데(18px)를 지나는 1.5px 선. 좌표는 세 가지 경우가 공유한다. */
 const THREAD_LINE = 'absolute left-[17px] w-[1.5px] bg-gray-4';
 
-/** 매 렌더마다 새 함수가 생기면 FlashList가 행을 통째로 다시 그린다 — 모듈 스코프에 고정한다. */
-const keyExtractor = (comment: TodoComment) => comment.id;
-
-/** 같은 사람이 이어 쓴 댓글인지 — 두 행을 한 덩어리로 잇는 기준. */
-const isSameAuthor = (one: TodoComment | undefined, other: TodoComment | undefined) =>
-  one?.author != null && other?.author != null && one.author.id === other.author.id;
-
 /**
- * 위 댓글에서 아래 댓글로 선이 이어지는지.
- * 답글이 달린 댓글은 이미 선을 답글 가지에 넘겼으므로, 아래 댓글까지 또 잇지 않는다 —
- * 두 갈래를 함께 그리면 답글 뭉치를 건너뛴 선이 허공에서 끊겨 보인다.
+ * 매 렌더마다 새 함수가 생기면 FlashList가 행을 통째로 다시 그린다 — 모듈 스코프에 고정한다.
+ * 줄이 자기 정보를 다 들고 오므로 renderItem도 바깥 값을 읽을 일이 없다.
  */
-const continuesInto = (one: TodoComment | undefined, other: TodoComment | undefined) =>
-  isSameAuthor(one, other) && one?.hasReplies === false;
+const keyExtractor = (row: CommentRow) => row.comment.id;
+const renderComment = ({ item }: { item: CommentRow }) => <CommentThreadList.Item {...item} />;
 
 interface CommentThreadListProps {
   /** 댓글과 함께 스크롤되는 상단 영역 (할 일 본문, 조상 사슬, 정렬 바). */
@@ -95,7 +89,7 @@ export function CommentThreadList({ children }: CommentThreadListProps) {
   const [sort] = useCommentSort();
   const queryClient = useQueryClient();
   const { color: refreshTint } = useResolveClassNames('text-main');
-  const listRef = useRef<FlashListRef<TodoComment>>(null);
+  const listRef = useRef<FlashListRef<CommentRow>>(null);
 
   // 정렬을 바꾸면 줄 세우는 기준 자체가 달라진다.
   // 보던 자리를 붙잡아 두면 화면이 엉뚱한 곳으로 밀리므로, 맨 위에서 다시 읽게 한다.
@@ -106,52 +100,40 @@ export function CommentThreadList({ children }: CommentThreadListProps) {
   const commentsQuery = useSuspenseInfiniteQuery(
     useTodoCommentsQueryOptions(todoId, parentId, sort),
   );
-  // 방금 쓴 글은 정렬과 무관하게 맨 위에 꽂아두는데, 인기순에서는 좋아요가 0이라
-  // 뒷 페이지에서 제자리로 한 번 더 실려 온다 — 먼저 그린 쪽만 남긴다.
-  const comments = uniqBy(
-    commentsQuery.data.pages.flatMap((page) => page.comments),
-    (comment) => comment.id,
-  );
-
-  // 같은 사람이 이어 쓴 댓글은 구분선을 지우고 선으로 이어 한 흐름으로 읽히게 한다.
-  const renderComment = useCallback(
-    ({ item, index }: { item: TodoComment; index: number }) => (
-      <CommentThreadList.Item
-        comment={item}
-        continuesFromAbove={continuesInto(comments[index - 1], item)}
-        continuesBelow={continuesInto(item, comments[index + 1])}
-      />
-    ),
-    [comments],
-  );
+  const rows = commentsQuery.data;
 
   // 이 리스트가 화면의 스크롤 컨테이너이므로, 당겨서 새로고침은 화면 전체를 새로 받는다.
-  const [isRefreshing, refresh] = useRefresh(() =>
-    Promise.all([
-      queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.details(todoId) }),
-      queryClient.invalidateQueries({ queryKey: TODO_COMMENT_QUERY_KEYS.all(todoId) }),
-    ]),
+  const [isRefreshing, refresh] = useRefresh(
+    useCallback(
+      () =>
+        Promise.all([
+          queryClient.invalidateQueries({ queryKey: TODO_QUERY_KEYS.details(todoId) }),
+          queryClient.invalidateQueries({ queryKey: TODO_COMMENT_QUERY_KEYS.all(todoId) }),
+        ]),
+      [queryClient, todoId],
+    ),
   );
 
-  const scrollRowToTop = useCallback(
-    (commentId: string) => {
-      const index = comments.findIndex((comment) => comment.id === commentId);
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
 
-      if (index >= 0) {
-        listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true });
-      }
-    },
-    [comments],
-  );
+  // 이 Context는 값이 아니라 명령을 나른다 — 참조가 바뀌면 memo를 뚫고 모든 행의
+  // ReplyButton이 다시 그려지므로, 최신 목록은 ref로 읽고 함수는 고정한다.
+  const scrollRowToTop = useCallback((commentId: string) => {
+    const index = rowsRef.current.findIndex((row) => row.comment.id === commentId);
+
+    if (index >= 0) {
+      listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true });
+    }
+  }, []);
 
   return (
     <CommentRowScrollContext value={scrollRowToTop}>
       <FlashList
         ref={listRef}
-        data={comments}
+        data={rows}
         keyExtractor={keyExtractor}
         renderItem={renderComment}
-        extraData={comments}
         ListHeaderComponent={<>{children}</>}
         ListEmptyComponent={CommentThreadList.Empty}
         ListFooterComponent={

--- a/apps/mobile/src/features/todo-comment/presentations/queries/todo-comment-cache.util.test.ts
+++ b/apps/mobile/src/features/todo-comment/presentations/queries/todo-comment-cache.util.test.ts
@@ -1,5 +1,3 @@
-import { uniqBy } from 'es-toolkit';
-
 import { createTodoComment, createTodoCommentReply } from '../../__tests__/todo-comment.factories';
 import type { TodoComment } from '../../models/todo-comment.model';
 import {
@@ -11,6 +9,7 @@ import {
   withReplacedComment,
 } from './todo-comment-cache.util';
 import { likeToggled } from './todo-comment-optimistic';
+import { selectCommentRows } from './use-todo-comment-query-options';
 
 const pagesOf = (...comments: TodoComment[]): CommentPages => ({
   pages: [{ comments, nextCursor: null, hasNext: false }],
@@ -163,13 +162,10 @@ describe('페이지를 가로지르는 중복', () => {
       pageParams: [undefined, 'cursor-1'],
     };
 
-    // When - 목록이 그리는 것과 같은 방식으로 펼친다
-    const comments = uniqBy(
-      pages.pages.flatMap((page) => page.comments),
-      (comment) => comment.id,
-    );
+    // When - 목록이 실제로 쓰는 select를 그대로 부른다
+    const rows = selectCommentRows(pages);
 
     // Then - 먼저 그린 쪽(맨 위)만 남아 자리가 흔들리지 않는다
-    expect(comments.map((comment) => comment.id)).toEqual(['comment-fresh', 'comment-popular']);
+    expect(rows.map((row) => row.comment.id)).toEqual(['comment-fresh', 'comment-popular']);
   });
 });

--- a/apps/mobile/src/features/todo-comment/presentations/queries/use-todo-comment-query-options.ts
+++ b/apps/mobile/src/features/todo-comment/presentations/queries/use-todo-comment-query-options.ts
@@ -1,11 +1,53 @@
 import { TODO_COMMENT_LIMITS } from '@aido/validators';
 import { useTodoCommentService } from '@src/bootstrap/providers/di-context';
 import { unwrap } from '@src/shared/errors/result';
-import { infiniteQueryOptions, queryOptions, useQueryClient } from '@tanstack/react-query';
+import {
+  type InfiniteData,
+  infiniteQueryOptions,
+  queryOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { uniqBy } from 'es-toolkit';
 
-import type { TodoCommentSort, TodoCommentThread } from '../../models/todo-comment.model';
+import type {
+  TodoComment,
+  TodoCommentPage,
+  TodoCommentSort,
+  TodoCommentThread,
+} from '../../models/todo-comment.model';
+import { resolveThreadContinuity } from '../components/thread-continuity';
 import { TODO_COMMENT_QUERY_KEYS } from '../constants/todo-comment-query-keys.constant';
 import { findCommentInCache } from './todo-comment-cache.util';
+
+/** 목록이 그리는 한 줄 — 글과, 위아래로 선을 잇는지까지 다 들고 있다. */
+export interface CommentRow {
+  comment: TodoComment;
+  continuesFromAbove: boolean;
+  continuesBelow: boolean;
+}
+
+/**
+ * 페이지를 펴고 중복을 걷어 그릴 수 있는 줄로 만든다.
+ *
+ * 방금 쓴 글은 정렬과 무관하게 맨 위에 꽂아두는데, 인기순에서는 좋아요가 0이라
+ * 뒷 페이지에서 제자리로 한 번 더 실려 온다 — 먼저 그린 쪽만 남긴다.
+ *
+ * 훅 밖 모듈 스코프에 둬야 한다. TanStack은 select 함수의 참조가 같을 때만 결과를
+ * 재사용하므로, 인라인으로 두면 매 렌더 새 배열이 나와 목록이 통째로 다시 그려진다.
+ */
+export const selectCommentRows = (data: InfiniteData<TodoCommentPage>): CommentRow[] => {
+  const comments = uniqBy(
+    data.pages.flatMap((page) => page.comments),
+    (comment) => comment.id,
+  );
+  const continuity = resolveThreadContinuity(comments);
+
+  return comments.map((comment, index) => ({
+    comment,
+    continuesFromAbove: continuity[index]?.continuesFromAbove ?? false,
+    continuesBelow: continuity[index]?.continuesBelow ?? false,
+  }));
+};
 
 /**
  * 한 댓글의 직계 답글 목록. parentId가 없으면 할 일의 최상위 댓글 목록이다.
@@ -31,6 +73,7 @@ export function useTodoCommentsQueryOptions(
         }),
       ),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    select: selectCommentRows,
   });
 }
 

--- a/apps/mobile/src/shared/ui/BottomSheet/BottomSheet.md
+++ b/apps/mobile/src/shared/ui/BottomSheet/BottomSheet.md
@@ -24,6 +24,10 @@ import { BottomSheet } from '@src/shared/ui/BottomSheet';
 
 ### KeyboardBottomSheet
 
+내용은 스크롤된다. 짧으면 시트가 그 높이로 줄어들지만, 키보드가 올라온 채로 내용이
+길어지면 아래쪽 버튼에 손이 닿지 않기 때문이다. 그래서 시트 안에 세로 스크롤 컨테이너를
+또 두면 안 된다 (가로 스크롤은 무방하다).
+
 ```tsx
 import { KeyboardBottomSheet } from '@src/shared/ui/BottomSheet';
 

--- a/apps/mobile/src/shared/ui/BottomSheet/KeyboardBottomSheet.tsx
+++ b/apps/mobile/src/shared/ui/BottomSheet/KeyboardBottomSheet.tsx
@@ -1,7 +1,7 @@
 import GorhomBottomSheet, {
   BottomSheetBackdrop,
   type BottomSheetBackdropProps,
-  BottomSheetView,
+  BottomSheetScrollView,
 } from '@gorhom/bottom-sheet';
 import {
   type ComponentRef,
@@ -15,7 +15,6 @@ import {
   AppState,
   type AppStateStatus,
   Keyboard,
-  type LayoutChangeEvent,
   Platform,
   StyleSheet,
   useWindowDimensions,
@@ -42,6 +41,11 @@ interface KeyboardBottomSheetProps {
 
 /**
  * 키보드 연동 BottomSheet.
+ *
+ * 내용은 스크롤된다. 내용이 짧으면 시트가 그 높이에 맞춰 줄어들지만(enableDynamicSizing),
+ * 키보드가 올라온 채로 내용이 길어지면 시트만으로는 아래쪽에 손이 닿지 않기 때문이다.
+ * keyboardShouldPersistTaps가 'always'인 것도 같은 이유다 — 없으면 키보드가 떠 있을 때
+ * 첫 탭이 키보드를 내리는 데 먹혀 버튼을 두 번 눌러야 한다.
  */
 export const KeyboardBottomSheet = ({
   isOpen,
@@ -183,12 +187,12 @@ export const KeyboardBottomSheet = ({
     [],
   );
 
-  const handleContentLayout = (event: LayoutChangeEvent) => {
+  const handleContentSizeChange = (_width: number, height: number) => {
     if (!isOpen || isClosingRef.current) {
       return;
     }
 
-    const nextHeight = Math.round(event.nativeEvent.layout.height);
+    const nextHeight = Math.round(height);
     const prevHeight = lastContentHeightRef.current;
 
     if (Math.abs(nextHeight - prevHeight) < 2) {
@@ -219,12 +223,15 @@ export const KeyboardBottomSheet = ({
       onAnimate={handleAnimate}
       onChange={handleSheetChange}
     >
-      <BottomSheetView
-        onLayout={handleContentLayout}
-        style={[styles.content, { paddingBottom: (insets.bottom || 20) + 4 }]}
+      <BottomSheetScrollView
+        onContentSizeChange={handleContentSizeChange}
+        contentContainerStyle={[styles.content, { paddingBottom: (insets.bottom || 20) + 4 }]}
+        keyboardShouldPersistTaps="always"
+        showsVerticalScrollIndicator={false}
+        bounces={false}
       >
         {children}
-      </BottomSheetView>
+      </BottomSheetScrollView>
     </GorhomBottomSheet>
   );
 };


### PR DESCRIPTION
## 📋 개요

댓글 목록의 파생이 **컴포넌트 렌더 본문**에 있어 매 렌더 새 배열이 나왔습니다. 그리고 이어 쓰기를 늘리면 **키보드에 가려 게시 버튼에 손이 닿지 않았습니다.**

Stack #766의 최상단입니다.

## 🏷️ 변경 유형

- [x] ⚡ `perf` - 목록 파생을 `select`로
- [x] 🐛 `fix` - 바텀시트 스크롤, 스레드 선 어긋남

## 📦 영향 범위

- [x] `apps/mobile` - todo-comment, shared/ui/BottomSheet

## 지금 무슨 일이 벌어지고 있었나

FlashList v2의 행 memo는 **참조 동일성만** 봅니다 (`ViewHolder.tsx`: `prevProps.extraData === nextProps.extraData && prevProps.renderItem === nextProps.renderItem`).

| 대상 | 판정 |
|---|---|
| `useCallback(renderComment, [continuity])` | **효과 0%** — 의존성이 매 렌더 새 배열이라 인라인 화살표와 동일. 비교 비용만 추가 |
| `useCallback(scrollRowToTop, [comments])` | **효과 0% + 역효과** — Context 값이라 **`memo(Item)`을 관통**해 행마다 `ReplyButton`을 다시 그림 |
| `extraData={comments}` | **순손실** — `data`와 같은 배열이라 정보량 0인데 붙어 있는 모든 행의 memo를 무력화 |

## Before / After

```ts
// Before — 렌더 본문. 매 렌더 새 배열
const comments = uniqBy(query.data.pages.flatMap((p) => p.comments), (c) => c.id);
const continuity = resolveThreadContinuity(comments);

// After — use-todo-comment-query-options.ts (모듈 스코프)
export const selectCommentRows = (data: InfiniteData<TodoCommentPage>): CommentRow[] => { ... };
// infiniteQueryOptions({ …, select: selectCommentRows })
```

| 영역 | Before | After |
|---|---|---|
| 파생 위치 | 컴포넌트 렌더 본문 | 모듈 스코프 `select` |
| `renderItem` | `useCallback([continuity])` | **모듈 스코프** (줄이 자기 정보를 다 들고 옴) |
| `extraData` | `comments` | 제거 |
| `scrollRowToTop` | `useCallback([comments])` | ref로 최신값을 읽어 **참조 영구 고정** |
| 시트 내용 | `BottomSheetView` (스크롤 안 됨) | `BottomSheetScrollView` |
| 캐시 테스트 | 프로덕션 로직을 **복제** | 실제 `select` 호출 |

## 설계 판단

- **`select`는 반드시 모듈 스코프여야 합니다.** `queryObserver.ts`가 `options.select === this.#selectFn`으로 캐시를 판정하므로, 인라인 화살표면 매 렌더 재실행이라 지금과 다를 게 없습니다. 저장소에 이미 같은 선례가 있습니다 (`use-get-notifications-infinite-query-options.ts` — 이유까지 주석에 있음).
- **`scrollRowToTop`은 값이 아니라 명령을 나릅니다.** 참조가 바뀌면 memo를 뚫으므로, `rows`가 안정돼도 좋아요 하나에 또 갈립니다. ref로 최신 목록을 읽고 함수는 고정합니다.
- **`keyboardShouldPersistTaps="always"`가 함께 필요합니다.** 없으면 키보드가 떠 있을 때 첫 탭이 키보드 내리는 데 먹혀 버튼을 두 번 눌러야 합니다. 소비처 8곳을 확인했고, `AddTodoBottomSheet`의 스크롤은 **가로**라 충돌하지 않습니다.
- **선**: `ThreadRow` 주석은 "아바타는 언제나 맨 위"라고 하는데 `endsAt`인 행만 가운데 정렬로 예외였습니다. 글꼴을 키우면 아바타가 내려가 위에서 온 선이 빗나갑니다.

## ⚠️ 실측하지 않았습니다

FlashList·TanStack **소스의 비교 방식을 근거로** 구조를 바꾼 것이지, 프로파일러 수치로 확인한 것은 아닙니다. 긴 스레드에서 좋아요를 눌렀을 때 그 행만 다시 그려지는지 확인하면 좋겠습니다.

## ✅ 검증

```
typecheck / lint / format:check   통과
apps/mobile   1,204건 통과
apps/api      2,647건 통과
```

## 📱 기기 확인 권장

- 이어 쓰기를 **5개까지** 늘려도 게시 버튼에 손이 닿는지 (키보드 올라온 채로)
- 게시 버튼이 **한 번**에 눌리는지
- 글꼴을 키웠을 때 "답글 또 달기"의 선이 아바타 한가운데에 맺히는지
