### PR TITLE
feat(mobile): 친구 할 일에도 댓글을 열고 댓글 수를 제때 맞춘다

### DIFF
--- a/apps/api/src/todo-comment/application/ports/todo-view-cache.port.ts
+++ b/apps/api/src/todo-comment/application/ports/todo-view-cache.port.ts
@@ -1,0 +1,12 @@
+export const TODO_VIEW_CACHE = Symbol("TODO_VIEW_CACHE");
+
+/**
+ * 댓글 수가 바뀌면 할 일 목록 캐시도 낡는다.
+ *
+ * 댓글 작성·삭제는 `Todo.commentCount`를 바꾸는데, 친구 목록은 그 값을 담은 채로
+ * 60초간 캐싱된다. 그 캐시를 지우는 건 todo 모듈의 몫이므로 이쪽은 "낡았다"만 알린다 —
+ * 어느 키인지, 소유자가 누구인지는 알 필요도 없고 알아서도 안 된다.
+ */
+export interface TodoViewCachePort {
+	invalidateForTodo(todoId: number): Promise<void>;
+}

--- a/apps/api/src/todo-comment/application/settle-after-commit.ts
+++ b/apps/api/src/todo-comment/application/settle-after-commit.ts
@@ -1,0 +1,29 @@
+import type { LoggerService } from "@nestjs/common";
+
+interface AfterCommitTask {
+	label: string;
+	run: () => Promise<unknown>;
+}
+
+/**
+ * 커밋 후 부수 작업을 모두 끝까지 실행하고, 실패는 요청이 아니라 로그로 흘린다.
+ *
+ * 여기서 던지면 이미 저장된 쓰기에 500이 붙는다. 그리고 클라이언트가 같은
+ * clientRequestId로 재시도하면 멱등 경로가 "새로 쓴 것 없음"을 돌려줘 이 블록을
+ * 통째로 건너뛰므로, 알림도 캐시 무효화도 두 번 다시 시도되지 않는다.
+ */
+export async function settleAfterCommit(
+	logger: LoggerService,
+	tasks: readonly AfterCommitTask[],
+): Promise<void> {
+	const settled = await Promise.allSettled(tasks.map((task) => task.run()));
+
+	settled.forEach((result, index) => {
+		if (result.status === "rejected") {
+			logger.warn(
+				`After-commit task failed: ${tasks[index]?.label ?? "unknown"} — ${result.reason}`,
+				result.reason instanceof Error ? result.reason.stack : undefined,
+			);
+		}
+	});
+}

--- a/apps/api/src/todo-comment/application/use-cases/delete-todo-comment/delete-todo-comment.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/delete-todo-comment/delete-todo-comment.use-case.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from "@aido/errors";
 import type { DeleteTodoCommentResponse } from "@aido/validators";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 
 import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
 import { ApplicationException } from "@/shared/domain";
@@ -12,6 +12,8 @@ import {
 	TODO_COMMENT_REPOSITORY,
 	type TodoCommentRepositoryPort,
 } from "../../ports/todo-comment.repository.port";
+import { TODO_VIEW_CACHE, type TodoViewCachePort } from "../../ports/todo-view-cache.port";
+import { settleAfterCommit } from "../../settle-after-commit";
 
 export interface DeleteTodoCommentInput {
 	todoId: number;
@@ -21,11 +23,15 @@ export interface DeleteTodoCommentInput {
 
 @Injectable()
 export class DeleteTodoCommentUseCase {
+	readonly #logger = new Logger(DeleteTodoCommentUseCase.name);
+
 	constructor(
 		@Inject(TODO_COMMENT_REPOSITORY)
 		private readonly repository: TodoCommentRepositoryPort,
 		@Inject(TODO_COMMENT_CACHE)
 		private readonly cache: TodoCommentCachePort,
+		@Inject(TODO_VIEW_CACHE)
+		private readonly todoViewCache: TodoViewCachePort,
 		@Inject(UNIT_OF_WORK)
 		private readonly unitOfWork: UnitOfWorkPort,
 	) {}
@@ -53,7 +59,16 @@ export class DeleteTodoCommentUseCase {
 		});
 
 		if (wasDeleted) {
-			await this.cache.invalidateTopLevelFirstPages(input.todoId);
+			await settleAfterCommit(this.#logger, [
+				{
+					label: "comment first pages cache",
+					run: () => this.cache.invalidateTopLevelFirstPages(input.todoId),
+				},
+				{
+					label: "todo view cache",
+					run: () => this.todoViewCache.invalidateForTodo(input.todoId),
+				},
+			]);
 		}
 
 		return { commentId: input.commentId, isDeleted: true };

--- a/apps/api/src/todo-comment/application/use-cases/write-todo-comment-chain/write-todo-comment-chain.use-case.spec.ts
+++ b/apps/api/src/todo-comment/application/use-cases/write-todo-comment-chain/write-todo-comment-chain.use-case.spec.ts
@@ -1,0 +1,93 @@
+import {
+	createTodoCommentCacheMock,
+	createTodoCommentNotificationMock,
+	createTodoCommentRepositoryMock,
+	createTodoViewCacheMock,
+	createUnitOfWorkMock,
+} from "@test/mocks/ports";
+
+import type { TodoCommentRecord } from "../../types";
+import { WriteTodoCommentChainUseCase } from "./write-todo-comment-chain.use-case";
+
+const TODO_ID = 1;
+const AUTHOR_ID = "cm1author0000000000000001";
+const OWNER_ID = "cm1owner00000000000000001";
+const COMMENT_ID = "cm1todoacomment00000000001";
+
+function createRecord(): TodoCommentRecord {
+	return {
+		id: COMMENT_ID,
+		todoId: TODO_ID,
+		parentId: null,
+		rootId: null,
+		path: [],
+		depth: 0,
+		parentAuthorName: null,
+		authorId: AUTHOR_ID,
+		authorName: "쓴 사람",
+		authorProfileImage: null,
+		todoOwnerId: OWNER_ID,
+		content: "함께 해요",
+		likeCount: 0,
+		replyCount: 0,
+		deletedAt: null,
+		editedAt: null,
+		createdAt: "2026-08-16T00:00:00.000Z",
+		children: [],
+	};
+}
+
+function setup() {
+	const repository = createTodoCommentRepositoryMock();
+	const cache = createTodoCommentCacheMock();
+	const notification = createTodoCommentNotificationMock();
+	const todoViewCache = createTodoViewCacheMock();
+
+	jest.mocked(repository.canAccessTodo).mockResolvedValue(true);
+	jest
+		.mocked(repository.createCommentChain)
+		.mockResolvedValue({ comments: [createRecord()], createdCount: 1 });
+
+	const useCase = new WriteTodoCommentChainUseCase(
+		repository,
+		cache,
+		notification,
+		todoViewCache,
+		createUnitOfWorkMock(),
+	);
+
+	const execute = () =>
+		useCase.execute({
+			todoId: TODO_ID,
+			authorId: AUTHOR_ID,
+			parentId: null,
+			items: [{ clientRequestId: "b7b0f6d4-6f1e-4d6a-9e0a-2d6a1c1f3a11", content: "함께 해요" }],
+		});
+
+	return { execute, cache, notification, todoViewCache };
+}
+
+/**
+ * 트랜잭션은 이미 커밋된 뒤다. 여기서 던지면 글은 남았는데 500이 나가고,
+ * 같은 clientRequestId로 재시도하면 멱등 경로가 이 블록을 통째로 건너뛴다.
+ */
+describe("WriteTodoCommentChainUseCase 커밋 후 부수 작업", () => {
+	it("알림이 실패해도 쓴 글을 성공으로 돌려준다", async () => {
+		const { execute, notification } = setup();
+		jest.mocked(notification.notifyCommentsWritten).mockRejectedValue(new Error("push down"));
+
+		await expect(execute()).resolves.toMatchObject({ comments: [{ id: COMMENT_ID }] });
+	});
+
+	it("한 다리가 실패해도 나머지 다리는 그대로 실행한다", async () => {
+		const { execute, cache, notification, todoViewCache } = setup();
+		jest
+			.mocked(todoViewCache.invalidateForTodo)
+			.mockRejectedValue(new Error("owner lookup failed"));
+
+		await execute();
+
+		expect(cache.invalidateTopLevelFirstPages).toHaveBeenCalledWith(TODO_ID);
+		expect(notification.notifyCommentsWritten).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/todo-comment/application/use-cases/write-todo-comment-chain/write-todo-comment-chain.use-case.ts
+++ b/apps/api/src/todo-comment/application/use-cases/write-todo-comment-chain/write-todo-comment-chain.use-case.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from "@aido/errors";
 import type { TodoCommentChainResponse } from "@aido/validators";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 
 import { UNIT_OF_WORK, type UnitOfWorkPort } from "@/shared/application/ports";
 import { ApplicationException } from "@/shared/domain";
@@ -17,6 +17,8 @@ import {
 	TODO_COMMENT_REPOSITORY,
 	type TodoCommentRepositoryPort,
 } from "../../ports/todo-comment.repository.port";
+import { TODO_VIEW_CACHE, type TodoViewCachePort } from "../../ports/todo-view-cache.port";
+import { settleAfterCommit } from "../../settle-after-commit";
 import { toTodoCommentResponse } from "../../types";
 
 export interface WriteTodoCommentChainInput {
@@ -36,6 +38,8 @@ export interface WriteTodoCommentChainInput {
  */
 @Injectable()
 export class WriteTodoCommentChainUseCase {
+	readonly #logger = new Logger(WriteTodoCommentChainUseCase.name);
+
 	constructor(
 		@Inject(TODO_COMMENT_REPOSITORY)
 		private readonly repository: TodoCommentRepositoryPort,
@@ -43,6 +47,8 @@ export class WriteTodoCommentChainUseCase {
 		private readonly cache: TodoCommentCachePort,
 		@Inject(TODO_COMMENT_NOTIFICATION)
 		private readonly notification: TodoCommentNotificationPort,
+		@Inject(TODO_VIEW_CACHE)
+		private readonly todoViewCache: TodoViewCachePort,
 		@Inject(UNIT_OF_WORK)
 		private readonly unitOfWork: UnitOfWorkPort,
 	) {}
@@ -88,19 +94,32 @@ export class WriteTodoCommentChainUseCase {
 			};
 		});
 
-		if (outcome.addedCount > 0 && outcome.recipientId !== undefined) {
-			await Promise.all([
-				this.cache.invalidateTopLevelFirstPages(input.todoId),
-				this.notification.notifyCommentsWritten({
-					recipientId: outcome.recipientId,
-					senderId: input.authorId,
-					senderName: outcome.written[0]?.authorName ?? null,
-					todoId: input.todoId,
-					commentId: outcome.written[0]?.id ?? "",
-					threadRootId: outcome.threadRootId ?? "",
-					isReply: input.parentId !== null,
-					count: outcome.addedCount,
-				}),
+		const { recipientId } = outcome;
+
+		if (outcome.addedCount > 0 && recipientId !== undefined) {
+			await settleAfterCommit(this.#logger, [
+				{
+					label: "comment first pages cache",
+					run: () => this.cache.invalidateTopLevelFirstPages(input.todoId),
+				},
+				{
+					label: "todo view cache",
+					run: () => this.todoViewCache.invalidateForTodo(input.todoId),
+				},
+				{
+					label: "comment notification",
+					run: () =>
+						this.notification.notifyCommentsWritten({
+							recipientId,
+							senderId: input.authorId,
+							senderName: outcome.written[0]?.authorName ?? null,
+							todoId: input.todoId,
+							commentId: outcome.written[0]?.id ?? "",
+							threadRootId: outcome.threadRootId ?? "",
+							isReply: input.parentId !== null,
+							count: outcome.addedCount,
+						}),
+				},
 			]);
 		}
 

--- a/apps/api/src/todo-comment/infrastructure/adapters/todo-view-cache.adapter.ts
+++ b/apps/api/src/todo-comment/infrastructure/adapters/todo-view-cache.adapter.ts
@@ -1,0 +1,14 @@
+import { Injectable } from "@nestjs/common";
+
+import { TodoViewCacheInvalidator } from "@/todo";
+
+import type { TodoViewCachePort } from "../../application/ports/todo-view-cache.port";
+
+@Injectable()
+export class TodoViewCacheAdapter implements TodoViewCachePort {
+	constructor(private readonly invalidator: TodoViewCacheInvalidator) {}
+
+	invalidateForTodo(todoId: number): Promise<void> {
+		return this.invalidator.invalidateForTodo(todoId);
+	}
+}

--- a/apps/api/src/todo-comment/todo-comment.module.ts
+++ b/apps/api/src/todo-comment/todo-comment.module.ts
@@ -1,10 +1,12 @@
 import { Module } from "@nestjs/common";
 
 import { NotificationModule } from "@/notification";
+import { TodoModule } from "@/todo";
 
 import { TODO_COMMENT_CACHE } from "./application/ports/todo-comment-cache.port";
 import { TODO_COMMENT_NOTIFICATION } from "./application/ports/todo-comment-notification.port";
 import { TODO_COMMENT_REPOSITORY } from "./application/ports/todo-comment.repository.port";
+import { TODO_VIEW_CACHE } from "./application/ports/todo-view-cache.port";
 import {
 	GetTodoCommentThreadUseCase,
 	GetTodoDetailsUseCase,
@@ -19,18 +21,20 @@ import {
 	WriteTodoCommentChainUseCase,
 } from "./application/use-cases";
 import { TodoCommentNotificationAdapter } from "./infrastructure/adapters/todo-comment-notification.adapter";
+import { TodoViewCacheAdapter } from "./infrastructure/adapters/todo-view-cache.adapter";
 import { TodoCommentCacheAdapter } from "./infrastructure/cache/todo-comment-cache.adapter";
 import { PrismaTodoCommentRepository } from "./infrastructure/persistence/prisma-todo-comment.repository";
 import { TodoCommentController } from "./presentation/todo-comment.controller";
 
 @Module({
-	imports: [NotificationModule],
+	imports: [NotificationModule, TodoModule],
 	controllers: [TodoCommentController],
 	providers: [
 		PrismaTodoCommentRepository,
 		{ provide: TODO_COMMENT_REPOSITORY, useExisting: PrismaTodoCommentRepository },
 		{ provide: TODO_COMMENT_CACHE, useClass: TodoCommentCacheAdapter },
 		{ provide: TODO_COMMENT_NOTIFICATION, useClass: TodoCommentNotificationAdapter },
+		{ provide: TODO_VIEW_CACHE, useClass: TodoViewCacheAdapter },
 		GetTodoDetailsUseCase,
 		ListTodoCommentsUseCase,
 		ListTodoCommentRepliesUseCase,

--- a/apps/api/src/todo/application/ports/todo-read.repository.port.ts
+++ b/apps/api/src/todo/application/ports/todo-read.repository.port.ts
@@ -21,6 +21,9 @@ export interface TodaySummaryTodoRow {
 export interface TodoReadRepositoryPort {
 	findByIdAndUserId(id: number, userId: string): Promise<TodoResponse | null>;
 
+	/** 소유자만 알면 되는 자리 — 목록 캐시 키가 소유자 기준이라 이 한 컬럼이면 충분하다. */
+	findOwnerId(id: number): Promise<string | null>;
+
 	/** 반복 그룹 전체 조회 (sortOrder asc — 생성 순서와 동일) */
 	findManyByRecurrenceGroupId(userId: string, recurrenceGroupId: string): Promise<TodoResponse[]>;
 

--- a/apps/api/src/todo/application/services/todo-view-cache.invalidator.spec.ts
+++ b/apps/api/src/todo/application/services/todo-view-cache.invalidator.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * TodoViewCacheInvalidator 단위 테스트
+ *
+ * 다른 모듈이 보는 유일한 표면이라, 소유자 해석과 무효화 위임만 검증한다.
+ */
+
+import { createTodoCacheMock, createTodoReadRepositoryMock } from "@test/mocks/ports";
+
+import { TodoViewCacheInvalidator } from "./todo-view-cache.invalidator";
+
+describe("TodoViewCacheInvalidator", () => {
+	it("할 일의 소유자를 찾아 그 사람의 친구 목록 캐시를 버린다", async () => {
+		// Given - 캐시 키는 소유자 기준이므로 todoId만으로는 지울 수 없다
+		const readRepository = createTodoReadRepositoryMock();
+		const cache = createTodoCacheMock();
+		jest.mocked(readRepository.findOwnerId).mockResolvedValue("owner-1");
+		const invalidator = new TodoViewCacheInvalidator(readRepository, cache);
+
+		// When
+		await invalidator.invalidateForTodo(42);
+
+		// Then
+		expect(readRepository.findOwnerId).toHaveBeenCalledWith(42);
+		expect(cache.invalidateFriendTodos).toHaveBeenCalledWith("owner-1");
+	});
+
+	it("할 일이 사라졌으면 지울 캐시도 없다", async () => {
+		// Given
+		const readRepository = createTodoReadRepositoryMock();
+		const cache = createTodoCacheMock();
+		jest.mocked(readRepository.findOwnerId).mockResolvedValue(null);
+		const invalidator = new TodoViewCacheInvalidator(readRepository, cache);
+
+		// When
+		await invalidator.invalidateForTodo(42);
+
+		// Then
+		expect(cache.invalidateFriendTodos).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/todo/application/services/todo-view-cache.invalidator.ts
+++ b/apps/api/src/todo/application/services/todo-view-cache.invalidator.ts
@@ -1,0 +1,29 @@
+import type { TodoCachePort } from "../ports/todo-cache.port";
+import type { TodoReadRepositoryPort } from "../ports/todo-read.repository.port";
+
+/**
+ * 다른 모듈이 쓰는 최소 capability — "이 할 일의 목록 캐시를 버려라".
+ *
+ * 친구 목록만 캐시가 있고(첫 페이지 60초), 그 키는 **소유자 기준**이다.
+ * 소유자가 누구인지는 todo 모듈의 지식이므로, 부르는 쪽은 todoId만 알면 된다.
+ *
+ * 캐시 포트 자체를 공개하지 않는 이유: 인프라 구현을 밖으로 내보내지 않는다는
+ * 모듈 경계 규칙(todo/index.ts) 때문이다.
+ */
+export class TodoViewCacheInvalidator {
+	constructor(
+		private readonly todoReadRepository: TodoReadRepositoryPort,
+		private readonly cache: TodoCachePort,
+	) {}
+
+	/** 할 일이 사라졌으면 지울 캐시도 없다 — 조용히 넘어간다. */
+	async invalidateForTodo(todoId: number): Promise<void> {
+		const ownerUserId = await this.todoReadRepository.findOwnerId(todoId);
+
+		if (ownerUserId === null) {
+			return;
+		}
+
+		await this.cache.invalidateFriendTodos(ownerUserId);
+	}
+}

--- a/apps/api/src/todo/index.ts
+++ b/apps/api/src/todo/index.ts
@@ -8,6 +8,7 @@ export {
 	type CreateRecurringTodosResult,
 	CreateRecurringTodosUseCase,
 } from "./application/use-cases/create-recurring-todos/create-recurring-todos.use-case";
+export { TodoViewCacheInvalidator } from "./application/services/todo-view-cache.invalidator";
 export { CreateTodoUseCase } from "./application/use-cases/create-todo/create-todo.use-case";
 export * from "./domain/events/todo-category-changed.event";
 export * from "./domain/events/todo-created.event";

--- a/apps/api/src/todo/infrastructure/adapters/prisma-todo-read.repository.ts
+++ b/apps/api/src/todo/infrastructure/adapters/prisma-todo-read.repository.ts
@@ -16,6 +16,12 @@ import { TodoRowRepository } from "../persistence/todo-row.repository";
 export class PrismaTodoReadRepository implements TodoReadRepositoryPort {
 	constructor(private readonly todoRepository: TodoRowRepository) {}
 
+	async findOwnerId(id: number): Promise<string | null> {
+		const todo = await this.todoRepository.findOwner(id);
+
+		return todo?.userId ?? null;
+	}
+
 	async findByIdAndUserId(id: number, userId: string): Promise<TodoResponse | null> {
 		const row = await this.todoRepository.findByIdAndUserId(id, userId);
 		return row ? TodoMapper.toResponse(row) : null;

--- a/apps/api/src/todo/infrastructure/persistence/todo-row.repository.ts
+++ b/apps/api/src/todo/infrastructure/persistence/todo-row.repository.ts
@@ -97,6 +97,16 @@ export class TodoRowRepository {
 	}
 
 	/**
+	 * 소유자만 조회 — 목록 캐시 키가 소유자 기준이라 이 한 컬럼이면 충분하다.
+	 */
+	async findOwner(id: number): Promise<{ userId: string } | null> {
+		return this.client.todo.findUnique({
+			where: { id },
+			select: { userId: true },
+		});
+	}
+
+	/**
 	 * 사용자의 Todo 조회 (소유권 확인용)
 	 */
 	async findByIdAndUserId(id: number, userId: string): Promise<TodoWithCategory | null> {

--- a/apps/api/src/todo/todo.module.ts
+++ b/apps/api/src/todo/todo.module.ts
@@ -8,11 +8,15 @@ import { UserSettingsModule } from "../user-settings/user-settings.module";
 import { CATEGORY_OWNERSHIP } from "./application/ports/category-ownership.port";
 import { FRIEND_PORT } from "./application/ports/friend.port";
 import { STREAK_PORT } from "./application/ports/streak.port";
-import { TODO_CACHE } from "./application/ports/todo-cache.port";
+import { TODO_CACHE, type TodoCachePort } from "./application/ports/todo-cache.port";
 import { TODO_NOTIFICATION } from "./application/ports/todo-notification.port";
-import { TODO_READ_REPOSITORY } from "./application/ports/todo-read.repository.port";
+import {
+	TODO_READ_REPOSITORY,
+	type TodoReadRepositoryPort,
+} from "./application/ports/todo-read.repository.port";
 import { TODO_REMINDER } from "./application/ports/todo-reminder.port";
 import { TODO_REPOSITORY } from "./application/ports/todo.repository.port";
+import { TodoViewCacheInvalidator } from "./application/services/todo-view-cache.invalidator";
 import { TODO_PROVIDERS } from "./application/todo.providers";
 import { CreateRecurringTodosUseCase, CreateTodoUseCase } from "./application/use-cases";
 import { CategoryOwnershipAdapter } from "./infrastructure/adapters/category-ownership.adapter";
@@ -68,7 +72,14 @@ import { TodoController } from "./presentation/todo.controller";
 		{ provide: TODO_NOTIFICATION, useClass: TodoNotificationAdapter },
 		{ provide: TODO_REMINDER, useClass: TodoReminderAdapter },
 		...TODO_PROVIDERS,
+		// 크로스 모듈 호환 경계 — 다른 모듈은 이 capability만 본다
+		{
+			provide: TodoViewCacheInvalidator,
+			inject: [TODO_READ_REPOSITORY, TODO_CACHE],
+			useFactory: (readRepository: TodoReadRepositoryPort, cache: TodoCachePort) =>
+				new TodoViewCacheInvalidator(readRepository, cache),
+		},
 	],
-	exports: [CreateTodoUseCase, CreateRecurringTodosUseCase],
+	exports: [CreateTodoUseCase, CreateRecurringTodosUseCase, TodoViewCacheInvalidator],
 })
 export class TodoModule {}

--- a/apps/api/test/mocks/ports/index.ts
+++ b/apps/api/test/mocks/ports/index.ts
@@ -14,6 +14,7 @@ export * from "./memo.mock";
 export * from "./notification.mock";
 export * from "./notification-cache.mock";
 export * from "./retention-repository.mock";
+export * from "./todo-comment.mock";
 export * from "./todo-read-repository.mock";
 export * from "./todo-repository.mock";
 export * from "./unit-of-work.mock";

--- a/apps/api/test/mocks/ports/todo-comment.mock.ts
+++ b/apps/api/test/mocks/ports/todo-comment.mock.ts
@@ -1,0 +1,54 @@
+import type { TodoCommentCachePort } from "@/todo-comment/application/ports/todo-comment-cache.port";
+import type { TodoCommentNotificationPort } from "@/todo-comment/application/ports/todo-comment-notification.port";
+import type { TodoCommentRepositoryPort } from "@/todo-comment/application/ports/todo-comment.repository.port";
+import type { TodoViewCachePort } from "@/todo-comment/application/ports/todo-view-cache.port";
+
+/**
+ * todo-comment 포트 mock 팩토리.
+ * 포트 확장 시 누락을 타입 에러로 잡습니다. 메서드 mock API는
+ * `jest.mocked(mock.method)`로 접근합니다.
+ */
+export function createTodoCommentRepositoryMock(): TodoCommentRepositoryPort {
+	return {
+		findAccessibleTodoDetails: jest.fn(),
+		canAccessTodo: jest.fn(),
+		findComment: jest.fn(),
+		findCommentRecord: jest.fn(),
+		listComments: jest.fn(),
+		findAncestors: jest.fn(),
+		findLikedCommentIds: jest.fn(),
+		findUserDisplayName: jest.fn(),
+		createCommentChain: jest.fn(),
+		updateComment: jest.fn(),
+		deleteComment: jest.fn(),
+		increaseTodoCommentCount: jest.fn(),
+		decrementTodoCommentCount: jest.fn(),
+		incrementReplyCount: jest.fn(),
+		dropDeletedFromAncestors: jest.fn(),
+		setLike: jest.fn(),
+		markLikeNotified: jest.fn(),
+		removeLike: jest.fn(),
+		recordView: jest.fn(),
+	};
+}
+
+export function createTodoCommentCacheMock(): TodoCommentCachePort {
+	return {
+		getTopLevelFirstPage: jest.fn(),
+		setTopLevelFirstPage: jest.fn(),
+		invalidateTopLevelFirstPages: jest.fn(),
+	};
+}
+
+export function createTodoCommentNotificationMock(): TodoCommentNotificationPort {
+	return {
+		notifyCommentsWritten: jest.fn(),
+		notifyCommentLiked: jest.fn(),
+	};
+}
+
+export function createTodoViewCacheMock(): TodoViewCachePort {
+	return {
+		invalidateForTodo: jest.fn(),
+	};
+}

--- a/apps/api/test/mocks/ports/todo-read-repository.mock.ts
+++ b/apps/api/test/mocks/ports/todo-read-repository.mock.ts
@@ -8,6 +8,7 @@ import type { TodoReadRepositoryPort } from "@/todo/application/ports/todo-read.
 export function createTodoReadRepositoryMock(): TodoReadRepositoryPort {
 	return {
 		findByIdAndUserId: jest.fn(),
+		findOwnerId: jest.fn(),
 		findManyByRecurrenceGroupId: jest.fn(),
 		findManyByUserId: jest.fn(),
 		findPublicTodosByUserId: jest.fn(),

--- a/apps/mobile/.claude/ui-components.md
+++ b/apps/mobile/.claude/ui-components.md
@@ -52,6 +52,7 @@ import { ScrollView, FlatList, Image } from 'react-native';
 | `Button`                                      | 기본 버튼                                                             | `src/shared/ui/Button/Button.md`                       |
 | `KeyboardAdaptiveButton`                      | 키보드 반응 버튼                                                      | `src/shared/ui/Button/Button.md`                       |
 | `TextButton`                                  | 텍스트/링크 버튼                                                      | `src/shared/ui/TextButton/TextButton.md`               |
+| `IconCountButton`                             | 아이콘 + 개수 버튼 (좋아요·답글·댓글)                                 | `src/shared/ui/IconCountButton/IconCountButton.md`     |
 | `Input`                                       | 입력 필드                                                             | `src/shared/ui/Input/Input.md`                         |
 | `BottomSheetInput`                            | BottomSheet 내부 입력 필드                                            | `src/shared/ui/Input/Input.md`                         |
 | `Spacing`                                     | 간격 유틸리티                                                         | `src/shared/ui/Spacing/Spacing.md`                     |

--- a/apps/mobile/src/features/todo-comment/models/todo-comment.model.test.ts
+++ b/apps/mobile/src/features/todo-comment/models/todo-comment.model.test.ts
@@ -3,7 +3,12 @@ import {
   createTodoComment,
   createTodoCommentReply,
 } from '../__tests__/todo-comment.factories';
-import { TodoCommentPolicy, mentionedAuthorName } from './todo-comment.model';
+import {
+  TodoCommentDraftPolicy,
+  TodoCommentPolicy,
+  TodoCommentThreadPolicy,
+  mentionedAuthorName,
+} from './todo-comment.model';
 
 describe('mentionedAuthorName', () => {
   test('답글은 부모 작성자를 멘션한다', () => {
@@ -185,5 +190,67 @@ describe('TodoCommentPolicy', () => {
       // Then
       expect(result).toBe(false);
     });
+  });
+});
+
+describe('TodoCommentDraftPolicy', () => {
+  describe('canAddMore — 칸을 하나 더 열 수 있는가', () => {
+    test.each([
+      ['한 칸', 1, true],
+      ['상한 직전', 4, true],
+      ['상한', 5, false],
+      ['상한 초과', 6, false],
+    ])('%s(%i개)이면 %s', (_label, count, expected) => {
+      const contents = Array.from({ length: count }, () => '내용');
+
+      expect(TodoCommentDraftPolicy.canAddMore({ contents, isEditing: false })).toBe(expected);
+    });
+
+    test('수정 중에는 이어 쓰지 않는다 — 수정은 언제나 한 글이다', () => {
+      expect(TodoCommentDraftPolicy.canAddMore({ contents: ['내용'], isEditing: true })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('canPost — 게시할 수 있는가', () => {
+    test('열려 있는 칸이 모두 채워지면 열린다', () => {
+      expect(TodoCommentDraftPolicy.canPost(['첫 글', '이어지는 글'])).toBe(true);
+    });
+
+    test.each([
+      ['빈 칸이 섞이면', ['첫 글', '']],
+      ['공백만 있으면', ['첫 글', '   ']],
+      ['전부 비어 있으면', ['', '']],
+    ])('%s 열리지 않는다', (_label, contents) => {
+      expect(TodoCommentDraftPolicy.canPost(contents)).toBe(false);
+    });
+
+    test('칸이 하나도 없으면 열리지 않는다 — every는 빈 배열에 참이라 따로 막는다', () => {
+      expect(TodoCommentDraftPolicy.canPost([])).toBe(false);
+    });
+  });
+});
+
+describe('TodoCommentThreadPolicy.continuesInto', () => {
+  test('같은 사람이 이어 쓴 댓글은 한 흐름으로 잇는다', () => {
+    const one = createTodoComment();
+
+    expect(TodoCommentThreadPolicy.continuesInto(one, createTodoComment({ id: 'other' }))).toBe(
+      true,
+    );
+  });
+
+  test('답글이 달렸으면 아래로 잇지 않는다 — 선을 답글 가지에 넘겼다', () => {
+    const one = createTodoComment({ hasReplies: true });
+
+    expect(TodoCommentThreadPolicy.continuesInto(one, createTodoComment({ id: 'other' }))).toBe(
+      false,
+    );
+  });
+
+  test('이웃이 없으면 잇지 않는다', () => {
+    expect(TodoCommentThreadPolicy.continuesInto(createTodoComment(), undefined)).toBe(false);
+    expect(TodoCommentThreadPolicy.continuesInto(undefined, createTodoComment())).toBe(false);
   });
 });

--- a/apps/mobile/src/features/todo-comment/models/todo-comment.model.ts
+++ b/apps/mobile/src/features/todo-comment/models/todo-comment.model.ts
@@ -1,4 +1,4 @@
-import { TODO_COMMENT_SORT } from '@aido/validators';
+import { TODO_COMMENT_LIMITS, TODO_COMMENT_SORT } from '@aido/validators';
 import { z } from 'zod';
 
 // ─── Schema & Type ───
@@ -123,6 +123,13 @@ const isConfirmed = (comment: TodoCommentPreview) => !isPendingComment(comment);
 /** 살아 있고 서버가 확인한 댓글에만 무엇이든 할 수 있다 — 모든 규칙의 공통 앞자락. */
 const isActionable = (comment: TodoCommentPreview) => isAlive(comment) && isConfirmed(comment);
 
+/** 같은 사람이 이어 쓴 댓글인지 — 두 행을 한 덩어리로 읽게 하는 기준. */
+const isSameAuthor = (one: TodoComment | undefined, other: TodoComment | undefined) =>
+  one?.author != null && other?.author != null && one.author.id === other.author.id;
+
+/** 답글이 달렸으면 그 아래 흐름은 답글 가지가 이어받는다. */
+const handsOverToReplies = (comment: TodoComment | undefined) => comment?.hasReplies === true;
+
 // ─── Policy ───
 
 /**
@@ -131,6 +138,8 @@ const isActionable = (comment: TodoCommentPreview) => isAlive(comment) && isConf
  * 규칙이 늘어나면 && 한 줄만 추가된다.
  */
 export const TodoCommentPolicy = {
+  /** 이 댓글에 무엇이든 걸 수 있는지 — 액션 줄을 놓을지 정하는 자리도 이걸 묻는다. */
+  canAct: (comment: TodoCommentPreview) => isActionable(comment),
   canLike: (comment: TodoCommentPreview) => isActionable(comment),
   canReply: (comment: TodoCommentPreview) => isActionable(comment) && comment.viewer.canReply,
   canEdit: (comment: TodoCommentPreview) => isActionable(comment) && comment.viewer.canEdit,
@@ -138,4 +147,32 @@ export const TodoCommentPolicy = {
   /** ⋯ 메뉴를 열 수 있는지 — 그 안에 놓일 것이 하나라도 있으면 연다. */
   canManage: (comment: TodoCommentPreview) =>
     TodoCommentPolicy.canEdit(comment) || TodoCommentPolicy.canDelete(comment),
+} as const;
+
+/**
+ * 목록에서 두 댓글이 한 흐름으로 이어지는지 — 스레드 선을 그릴지 정하는 유일한 판정.
+ *
+ * 이웃 관계만 보므로 정렬(최신순↔인기순)이 바뀌어도 옛 판정이 남지 않는다.
+ * 규칙이 늘어나면 && 한 줄만 추가된다.
+ */
+export const TodoCommentDraftPolicy = {
+  /**
+   * 칸을 하나 더 열 수 있는지. 수정은 언제나 한 글이라 이어 쓰지 않는다.
+   */
+  canAddMore: (draft: { contents: readonly string[]; isEditing: boolean }) =>
+    !draft.isEditing && draft.contents.length < TODO_COMMENT_LIMITS.CHAIN_MAX_SIZE,
+
+  /**
+   * 게시할 수 있는지 — 열려 있는 칸이 하나라도 비어 있으면 열리지 않는다.
+   *
+   * 빈 묶음을 따로 막는 이유: `every`는 빈 배열에 참이라, 칸이 하나도 없을 때
+   * 조용히 통과해 버린다.
+   */
+  canPost: (contents: readonly string[]) =>
+    contents.length > 0 && contents.every((content) => content.trim().length > 0),
+} as const;
+
+export const TodoCommentThreadPolicy = {
+  continuesInto: (one: TodoComment | undefined, other: TodoComment | undefined) =>
+    isSameAuthor(one, other) && !handsOverToReplies(one),
 } as const;

--- a/apps/mobile/src/features/todo-comment/presentations/components/CommentArticle.tsx
+++ b/apps/mobile/src/features/todo-comment/presentations/components/CommentArticle.tsx
@@ -1,10 +1,13 @@
 import { useTranslation } from '@src/shared/i18n';
-import { HStack, Text, VStack } from '@src/shared/ui';
+import { HStack, ICON_COUNT_BUTTON_INK_INSET, Text, VStack } from '@src/shared/ui';
 import { formatRelativeTime } from '@src/shared/utils/date';
 import type { ReactNode } from 'react';
 
-import { type TodoCommentPreview, mentionedAuthorName } from '../../models/todo-comment.model';
-import { ICON_COUNT_BUTTON_INK_INSET } from './IconCountButton';
+import {
+  type TodoCommentPreview,
+  TodoCommentPolicy,
+  mentionedAuthorName,
+} from '../../models/todo-comment.model';
 
 interface CommentArticleProps {
   comment: TodoCommentPreview;
@@ -28,7 +31,7 @@ export function CommentArticle({ comment, menu, footer, contentMaxLines }: Comme
       <CommentText comment={comment} maxLines={contentMaxLines} />
 
       {/* 버튼이 품고 있는 여백만큼 되돌려, 아이콘의 잉크가 위 본문의 왼쪽 선과 맞물리게 한다. */}
-      {!comment.isDeleted && footer !== undefined && (
+      {TodoCommentPolicy.canAct(comment) && footer !== undefined && (
         <VStack pt={2} ml={-ICON_COUNT_BUTTON_INK_INSET}>
           {footer}
         </VStack>

--- a/apps/mobile/src/features/todo-comment/presentations/components/CommentComposerSheet.test.tsx
+++ b/apps/mobile/src/features/todo-comment/presentations/components/CommentComposerSheet.test.tsx
@@ -18,7 +18,6 @@ function renderComposer(onSubmit: jest.Mock) {
       author={author}
       target={null}
       isOpen
-      isSubmitting={false}
       onOpenChange={jest.fn()}
       onSubmit={onSubmit}
     />,

--- a/apps/mobile/src/features/todo-comment/presentations/components/CommentComposerSheet.tsx
+++ b/apps/mobile/src/features/todo-comment/presentations/components/CommentComposerSheet.tsx
@@ -1,21 +1,16 @@
-import { TODO_COMMENT_LIMITS } from '@aido/validators';
 import { useTranslation } from '@src/shared/i18n';
 import { Button, HStack, KeyboardBottomSheet, Text, TextButton, VStack } from '@src/shared/ui';
 import { BottomSheetTextArea } from '@src/shared/ui/TextArea/BottomSheetTextArea';
 import { PressableFeedback } from 'heroui-native';
-import type { ComponentProps, ReactNode } from 'react';
+import { type ComponentProps, type ReactNode, useState } from 'react';
 import { Controller, useFieldArray, useWatch } from 'react-hook-form';
 
+import { TodoCommentDraftPolicy } from '../../models/todo-comment.model';
 import type { TodoCommentAuthor, TodoCommentPreview } from '../../models/todo-comment.model';
 import { useCommentForm } from '../hooks/use-comment-form';
 import { CommentArticle } from './CommentArticle';
 import { CommentAuthorAvatar } from './CommentAuthorAvatar';
-import {
-  THREAD_AVATAR_SIZE,
-  THREAD_COLUMN_WIDTH,
-  ThreadConnectorDown,
-  ThreadConnectorUp,
-} from './ThreadLine';
+import { THREAD_COLUMN_WIDTH, ThreadConnectorDown, ThreadConnectorUp } from './ThreadLine';
 
 /** '답글 또 달기' 줄의 작은 아바타(size-5) 지름. 위에서 내려온 선이 이 한가운데서 맺힌다. */
 const ADD_ROW_AVATAR_SIZE = 20;
@@ -36,9 +31,13 @@ interface CommentComposerSheetProps extends Omit<
   target: TodoCommentPreview | null;
   /** 고칠 글의 원문. 주면 수정이 되어 이어 쓰기가 닫힌다. */
   defaultContent?: string;
-  isSubmitting: boolean;
-  /** 위에서 아래 순서의 글 묶음. 빈 묶음은 나갈 수 없고, 수정이면 언제나 하나다. */
-  onSubmit: (contents: [string, ...string[]]) => void;
+  /**
+   * 위에서 아래 순서의 글 묶음. 빈 묶음은 나갈 수 없고, 수정이면 언제나 하나다.
+   *
+   * 보내는 동안의 상태는 이 시트가 스스로 안다 — 오버레이는 열릴 때의 화면을 스냅샷으로
+   * 들고 있어서, 밖에서 넘긴 진행 중 플래그는 갱신되지 않고 얼어붙는다.
+   */
+  onSubmit: (contents: [string, ...string[]]) => Promise<void> | void;
 }
 
 /**
@@ -49,7 +48,6 @@ export function CommentComposerSheet({
   author,
   target,
   defaultContent,
-  isSubmitting,
   onSubmit,
   ...sheetProps
 }: CommentComposerSheetProps) {
@@ -60,14 +58,24 @@ export function CommentComposerSheet({
   const { fields, append } = useFieldArray({ control, name: 'items' });
   const items = useWatch({ control, name: 'items' });
 
-  const canAddMore = !isEditing && fields.length < TODO_COMMENT_LIMITS.CHAIN_MAX_SIZE;
-  const canPost = items.every((item) => item.content.trim().length > 0);
+  const contents = items.map((item) => item.content);
+  const canAddMore = TodoCommentDraftPolicy.canAddMore({ contents, isEditing });
+  const canPost = TodoCommentDraftPolicy.canPost(contents);
   const showsTarget = target !== null && !isEditing;
 
-  const submit = () => {
-    const [first, ...rest] = items.map((item) => item.content.trim());
-    if (first !== undefined) {
-      onSubmit([first, ...rest]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const submit = async () => {
+    const [first, ...rest] = contents.map((content) => content.trim());
+    if (first === undefined) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit([first, ...rest]);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -189,24 +197,26 @@ interface ThreadRowProps {
  */
 function ThreadRow({ avatar, continuesBelow = false, endsAt, children }: ThreadRowProps) {
   return (
-    <HStack
-      gap={10}
-      pb={12}
-      align={endsAt === undefined ? 'stretch' : 'center'}
-      className="relative"
-    >
+    <HStack gap={10} pb={12} align="stretch" className="relative">
       {continuesBelow && <ThreadConnectorDown />}
       {endsAt !== undefined && <ThreadConnectorUp endsAt={endsAt} />}
 
-      <VStack
-        align="center"
-        justify="center"
-        style={{ minHeight: THREAD_AVATAR_SIZE }}
-        className={THREAD_COLUMN_WIDTH}
-      >
+      {/* 아바타는 언제나 행의 맨 위에 붙는다 — 선이 아바타 중심을 기준으로 그려지므로,
+          세로 가운데 정렬하면 글이 길어질수록(글꼴 확대 포함) 아바타가 내려가 선과 어긋난다.
+          목록의 CommentAvatarColumn과 같은 규칙이다. */}
+      <VStack align="center" className={THREAD_COLUMN_WIDTH}>
         {avatar}
       </VStack>
-      {children}
+
+      {/* 선이 맺히는 행은 글을 아바타 높이 안에서 가운데 맞춘다 — 아바타는 위에 붙어 있어야
+          하므로 행 전체를 가운데 정렬할 수는 없다. */}
+      {endsAt === undefined ? (
+        children
+      ) : (
+        <VStack flex={1} justify="center" style={{ minHeight: endsAt * 2 }}>
+          {children}
+        </VStack>
+      )}
     </HStack>
   );
 }

--- a/apps/mobile/src/features/todo-comment/presentations/components/CommentLikeButton.tsx
+++ b/apps/mobile/src/features/todo-comment/presentations/components/CommentLikeButton.tsx
@@ -1,9 +1,13 @@
-import { HeartFilledIcon, HeartIcon } from '@src/shared/ui';
+import {
+  HeartFilledIcon,
+  HeartIcon,
+  ICON_COUNT_BUTTON_ICON_SIZE,
+  IconCountButton,
+} from '@src/shared/ui';
 import { useMutation } from '@tanstack/react-query';
 
 import { type TodoCommentPreview, TodoCommentPolicy } from '../../models/todo-comment.model';
 import { useSetTodoCommentLikeMutationOptions } from '../queries/use-todo-comment-mutation-options';
-import { ICON_COUNT_BUTTON_ICON_SIZE, IconCountButton } from './IconCountButton';
 
 interface CommentLikeButtonProps {
   comment: TodoCommentPreview;

--- a/apps/mobile/src/features/todo-comment/presentations/components/ReplyButton.tsx
+++ b/apps/mobile/src/features/todo-comment/presentations/components/ReplyButton.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from '@src/shared/i18n';
-import { ChatBubbleIcon } from '@src/shared/ui';
+import { ChatBubbleIcon, ICON_COUNT_BUTTON_ICON_SIZE, IconCountButton } from '@src/shared/ui';
 
 import { type TodoCommentPreview, TodoCommentPolicy } from '../../models/todo-comment.model';
 import { useCommentComposer } from '../hooks/use-comment-composer';
 import { useCommentRowScroll } from '../hooks/use-comment-row-scroll';
-import { ICON_COUNT_BUTTON_ICON_SIZE, IconCountButton } from './IconCountButton';
 
 interface ReplyButtonProps {
   comment: TodoCommentPreview;

--- a/apps/mobile/src/features/todo-comment/presentations/components/thread-continuity.test.ts
+++ b/apps/mobile/src/features/todo-comment/presentations/components/thread-continuity.test.ts
@@ -1,0 +1,61 @@
+import { createTodoComment } from '../../__tests__/todo-comment.factories';
+import { resolveThreadContinuity } from './thread-continuity';
+
+/** 판정 자체는 TodoCommentThreadPolicy가 검증한다. 여기서는 행마다 펴는 것만 본다. */
+const byAuthor = (authors: readonly string[]) =>
+  authors.map((authorId, index) =>
+    createTodoComment({
+      id: `comment-${index}`,
+      author: { id: authorId, name: authorId, profileImage: null, isTodoOwner: false },
+    }),
+  );
+
+describe('resolveThreadContinuity', () => {
+  it('첫 행은 위로, 마지막 행은 아래로 잇지 않는다', () => {
+    const result = resolveThreadContinuity(byAuthor(['a', 'a']));
+
+    expect(result[0]?.continuesFromAbove).toBe(false);
+    expect(result.at(-1)?.continuesBelow).toBe(false);
+  });
+
+  it('빈 목록도 다룬다', () => {
+    expect(resolveThreadContinuity([])).toEqual([]);
+  });
+
+  /**
+   * 반쪽 선이 남는 유일한 경로는 위 행의 아래 선과 아래 행의 위 선이 어긋나는 것이다.
+   * 정렬(최신순↔인기순)로 순서가 통째로 바뀌어도 이 불변식은 깨지면 안 된다.
+   */
+  it.each([
+    ['최신순', ['a', 'a', 'b', 'b', 'a']],
+    ['인기순(뒤집힘)', ['a', 'b', 'b', 'a', 'a']],
+    ['한 사람만', ['a', 'a', 'a', 'a']],
+    ['전부 다른 사람', ['a', 'b', 'c', 'd']],
+  ])('%s 순서에서도 위·아래 선 판정이 어긋나지 않는다', (_label, authors) => {
+    const result = resolveThreadContinuity(byAuthor(authors));
+
+    result.forEach((row, index) => {
+      const below = result[index + 1];
+      if (below) {
+        expect(row.continuesBelow).toBe(below.continuesFromAbove);
+      }
+    });
+  });
+
+  it('답글이 섞여 흐름이 끊겨도 위·아래가 어긋나지 않는다', () => {
+    const comments = [
+      createTodoComment({ id: 'c0' }),
+      createTodoComment({ id: 'c1', hasReplies: true }),
+      createTodoComment({ id: 'c2' }),
+    ];
+
+    const result = resolveThreadContinuity(comments);
+
+    result.forEach((row, index) => {
+      const below = result[index + 1];
+      if (below) {
+        expect(row.continuesBelow).toBe(below.continuesFromAbove);
+      }
+    });
+  });
+});

--- a/apps/mobile/src/features/todo-comment/presentations/components/thread-continuity.ts
+++ b/apps/mobile/src/features/todo-comment/presentations/components/thread-continuity.ts
@@ -1,0 +1,24 @@
+import { TodoCommentThreadPolicy } from '../../models/todo-comment.model';
+import type { TodoComment } from '../../models/todo-comment.model';
+
+export interface ThreadContinuity {
+  continuesFromAbove: boolean;
+  continuesBelow: boolean;
+}
+
+/**
+ * 정책의 판정을 행마다 위·아래 플래그로 편다. 판정 자체는 하지 않는다.
+ *
+ * **한 이웃 쌍을 한 번만 묻는다** — 위 행의 아래 선과 아래 행의 위 선이 반드시 같은 값을
+ * 갖게 하기 위해서다. 둘이 어긋나면 한쪽만 그려진 반쪽 선이 화면에 남는다.
+ */
+export function resolveThreadContinuity(comments: readonly TodoComment[]): ThreadContinuity[] {
+  const links = comments.map((comment, index) =>
+    TodoCommentThreadPolicy.continuesInto(comment, comments[index + 1]),
+  );
+
+  return comments.map((_comment, index) => ({
+    continuesFromAbove: index > 0 && links[index - 1] === true,
+    continuesBelow: links[index] === true,
+  }));
+}

--- a/apps/mobile/src/features/todo-comment/presentations/hooks/use-comment-composer.tsx
+++ b/apps/mobile/src/features/todo-comment/presentations/hooks/use-comment-composer.tsx
@@ -32,7 +32,11 @@ export function useCommentComposer() {
   const writeComments = useMutation(useWriteTodoCommentsMutationOptions(todoId, sort));
   const updateComment = useMutation(useUpdateTodoCommentMutationOptions(todoId));
 
-  const closeOnCancel = (close: (result: CommentComposerResult) => void, exit: () => void) => {
+  /**
+   * 시트가 닫혔음을 알려 오는 유일한 통로 — 취소든 게시 후든 여기로 온다.
+   * 게시가 이미 결과로 resolve했다면 Promise는 첫 값을 지키므로 이 호출은 무해하다.
+   */
+  const settleOnClose = (close: (result: CommentComposerResult) => void, exit: () => void) => {
     return (open: boolean) => {
       if (!open) {
         close({ written: [] });
@@ -49,14 +53,16 @@ export function useCommentComposer() {
           author={author}
           target={null}
           isOpen={isOpen}
-          isSubmitting={writeComments.isPending}
-          onOpenChange={closeOnCancel(close, exit)}
-          onSubmit={(contents) =>
-            writeComments.mutate(
-              { parentId: null, draft: { contents } },
-              { onSuccess: ({ comments }) => close({ written: comments }) },
-            )
-          }
+          onOpenChange={settleOnClose(close, exit)}
+          onSubmit={async (contents) => {
+            const result = await writeComments
+              .mutateAsync({ parentId: null, draft: { contents } })
+              .catch(() => null);
+
+            if (result) {
+              close({ written: result.comments });
+            }
+          }}
         />
       )),
 
@@ -67,14 +73,16 @@ export function useCommentComposer() {
           author={author}
           target={target}
           isOpen={isOpen}
-          isSubmitting={writeComments.isPending}
-          onOpenChange={closeOnCancel(close, exit)}
-          onSubmit={(contents) =>
-            writeComments.mutate(
-              { parentId: target.id, draft: { contents } },
-              { onSuccess: ({ comments }) => close({ written: comments }) },
-            )
-          }
+          onOpenChange={settleOnClose(close, exit)}
+          onSubmit={async (contents) => {
+            const result = await writeComments
+              .mutateAsync({ parentId: target.id, draft: { contents } })
+              .catch(() => null);
+
+            if (result) {
+              close({ written: result.comments });
+            }
+          }}
         />
       )),
 
@@ -86,14 +94,16 @@ export function useCommentComposer() {
           target={comment}
           defaultContent={comment.content ?? ''}
           isOpen={isOpen}
-          isSubmitting={updateComment.isPending}
-          onOpenChange={closeOnCancel(close, exit)}
-          onSubmit={([content]) =>
-            updateComment.mutate(
-              { commentId: comment.id, input: { content } },
-              { onSuccess: (updated) => close({ written: [updated] }) },
-            )
-          }
+          onOpenChange={settleOnClose(close, exit)}
+          onSubmit={async ([content]) => {
+            const updated = await updateComment
+              .mutateAsync({ commentId: comment.id, input: { content } })
+              .catch(() => null);
+
+            if (updated) {
+              close({ written: [updated] });
+            }
+          }}
         />
       )),
   };

--- a/apps/mobile/src/features/todo-comment/presentations/queries/use-todo-comment-mutation-options.ts
+++ b/apps/mobile/src/features/todo-comment/presentations/queries/use-todo-comment-mutation-options.ts
@@ -1,5 +1,6 @@
 import type { UpdateTodoCommentInput } from '@aido/validators';
 import { useTodoCommentService } from '@src/bootstrap/providers/di-context';
+import type { TodosResult } from '@src/features/todo/models/todo.model';
 import { TODO_QUERY_KEYS } from '@src/features/todo/presentations/constants/todo-query-keys.constant';
 import type { User } from '@src/features/user/models/user.model';
 import { USER_QUERY_KEYS } from '@src/features/user/presentations/constants/user-query-keys.constant';
@@ -59,8 +60,16 @@ function restoreCommentCaches(queryClient: QueryClient, snapshot: CommentCacheSn
   snapshot.forEach(([queryKey, data]) => queryClient.setQueryData(queryKey, data));
 }
 
-/** 할 일의 댓글 수는 상세 카드가 읽는 값이라 리페치 없이 제자리에서 맞춘다. */
+/**
+ * 같은 댓글 수를 들고 있는 캐시가 셋이다 — 상세 카드, 내 목록, 친구 목록.
+ * 하나만 맞추면 뒤로 갔을 때 캘린더의 숫자가 어긋난다.
+ *
+ * 리페치하지 않는 이유는 상세와 같다 — 목록은 스크롤 위치를 지켜야 하고,
+ * 댓글 한 줄 때문에 하루치 할 일을 다시 받을 이유가 없다.
+ */
 function shiftTodoCommentCount(queryClient: QueryClient, todoId: number, delta: number) {
+  const bump = (count: number) => Math.max(0, count + delta);
+
   queryClient.setQueryData<{ metrics: { commentCount: number } }>(
     TODO_QUERY_KEYS.details(todoId),
     (detail) =>
@@ -68,12 +77,24 @@ function shiftTodoCommentCount(queryClient: QueryClient, todoId: number, delta: 
         ? detail
         : {
             ...detail,
-            metrics: {
-              ...detail.metrics,
-              commentCount: Math.max(0, detail.metrics.commentCount + delta),
-            },
+            metrics: { ...detail.metrics, commentCount: bump(detail.metrics.commentCount) },
           },
   );
+
+  // 카테고리 그룹핑은 select에서 일어나므로 캐시에는 서버 응답 그대로가 들어 있다.
+  // 내 목록과 친구 목록이 같은 모양이라 updater 하나로 둘 다 덮는다.
+  const shiftInList = (list: TodosResult | undefined) =>
+    list === undefined
+      ? list
+      : {
+          ...list,
+          todos: list.todos.map((todo) =>
+            todo.id === todoId ? { ...todo, commentCount: bump(todo.commentCount) } : todo,
+          ),
+        };
+
+  queryClient.setQueriesData<TodosResult>({ queryKey: TODO_QUERY_KEYS.lists() }, shiftInList);
+  queryClient.setQueriesData<TodosResult>({ queryKey: TODO_QUERY_KEYS.friendLists() }, shiftInList);
 }
 
 export function useSetTodoCommentLikeMutationOptions(todoId: number) {

--- a/apps/mobile/src/features/todo/presentations/components/FriendTodoList.tsx
+++ b/apps/mobile/src/features/todo/presentations/components/FriendTodoList.tsx
@@ -2,22 +2,27 @@ import { useGetPreferenceQueryOptions } from '@src/features/auth/presentations/q
 import type { FriendUserViewModel } from '@src/features/friend/presentations/view-models/friend-user.view-model';
 import { TodoNudgePolicy } from '@src/features/todo/models/todo-nudge.model';
 import { useTrack } from '@src/shared/analytics';
+import { useSingleTap } from '@src/shared/hooks/useSingleTap';
 import { useTranslation } from '@src/shared/i18n';
 import {
   Box,
+  ChatBubbleIcon,
   DocsIcon,
   Flex,
   HStack,
+  ICON_COUNT_BUTTON_ICON_SIZE,
+  IconCountButton,
   PawIcon,
   Result,
   Text,
+  VStack,
   useOverlay,
   usePremiumDialog,
-  VStack,
 } from '@src/shared/ui';
 import { formatDate, isSameDay } from '@src/shared/utils/date';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import times from 'es-toolkit/compat/times';
+import { router } from 'expo-router';
 import { Skeleton } from 'heroui-native';
 import { useState } from 'react';
 import { Pressable } from 'react-native';
@@ -116,6 +121,7 @@ interface FriendTodoItemProps {
 function FriendTodoItem({ todo, friend, isLimitReached, date }: FriendTodoItemProps) {
   const { t } = useTranslation('todo');
   const { trackEvent } = useTrack();
+  const push = useSingleTap(router.push);
   const overlay = useOverlay();
   const premiumDialog = usePremiumDialog();
   const [isExpanded, setIsExpanded] = useState(todo.hasSubTodos);
@@ -149,6 +155,9 @@ function FriendTodoItem({ todo, friend, isLimitReached, date }: FriendTodoItemPr
     });
   };
 
+  /** 댓글은 말풍선으로만 들어간다 — 내 할 일과 같은 자리, 같은 화면이다. */
+  const openComments = () => push({ pathname: '/todo/[todoId]', params: { todoId: todo.id } });
+
   const handleNudgePress = () => {
     if (isLimitReached) {
       openLimitDialog();
@@ -174,11 +183,27 @@ function FriendTodoItem({ todo, friend, isLimitReached, date }: FriendTodoItemPr
         ) : undefined
       }
       right={
-        canNudgeTodo ? (
-          <Pressable onPress={handleNudgePress} hitSlop={8}>
-            <PawIcon width={18} height={18} colorClassName="text-gray-6" />
-          </Pressable>
-        ) : undefined
+        // 대화는 날짜와 무관하게 열려 있다 — 콕 찌르기만 그날 할 일인지에 걸린다.
+        <HStack gap={4} align="center">
+          <IconCountButton
+            icon={
+              <ChatBubbleIcon
+                width={ICON_COUNT_BUTTON_ICON_SIZE}
+                height={ICON_COUNT_BUTTON_ICON_SIZE}
+                colorClassName="text-gray-6"
+              />
+            }
+            count={todo.commentCount}
+            onPress={openComments}
+            accessibilityRole="button"
+            accessibilityLabel={t('detail.open')}
+          />
+          {canNudgeTodo && (
+            <Pressable onPress={handleNudgePress} hitSlop={8}>
+              <PawIcon width={18} height={18} colorClassName="text-gray-6" />
+            </Pressable>
+          )}
+        </HStack>
       }
       onPress={todo.hasSubTodos ? () => setIsExpanded((prev) => !prev) : undefined}
     >

--- a/apps/mobile/src/shared/ui/IconCountButton/IconCountButton.md
+++ b/apps/mobile/src/shared/ui/IconCountButton/IconCountButton.md
@@ -1,0 +1,55 @@
+# IconCountButton
+
+아이콘 옆에 숫자를 붙인 버튼입니다. 좋아요·답글·댓글처럼 "무언가가 몇 개 쌓였고 누르면 그리로 간다"는 자리가 반복되는데, 그 반복 단위는 하나면 됩니다. 도메인은 모릅니다 — 무엇을 세는지는 놓는 쪽이 아이콘과 숫자로 말합니다.
+
+## 구조
+
+```
+IconCountButton/
+├── IconCountButton.tsx   # 컴포넌트 + 여백 상수
+└── index.ts
+```
+
+## 기본 사용법
+
+```tsx
+import { ICON_COUNT_BUTTON_ICON_SIZE, IconCountButton } from '@src/shared/ui';
+
+<IconCountButton
+  icon={
+    <ChatBubbleIcon
+      width={ICON_COUNT_BUTTON_ICON_SIZE}
+      height={ICON_COUNT_BUTTON_ICON_SIZE}
+      colorClassName="text-gray-6"
+    />
+  }
+  count={todo.commentCount}
+  onPress={openComments}
+  accessibilityRole="button"
+  accessibilityLabel={t('detail.open')}
+/>;
+```
+
+## API Reference
+
+### Props
+
+`PressableFeedback`의 props를 그대로 받습니다(`children`·`className`·`hitSlop` 제외 — 이 셋은 컴포넌트가 소유합니다).
+
+| Prop    | Type        | Description                                                     |
+| ------- | ----------- | --------------------------------------------------------------- |
+| `icon`  | `ReactNode` | 왼쪽에 놓일 글리프. 크기는 `ICON_COUNT_BUTTON_ICON_SIZE`를 쓴다 |
+| `count` | `number`    | **0이면 숫자를 숨긴다.** 100 이상은 `99+`로 접힌다              |
+
+### 내보내는 상수
+
+| 이름                          | 값   | 용도                                                                  |
+| ----------------------------- | ---- | --------------------------------------------------------------------- |
+| `ICON_COUNT_BUTTON_ICON_SIZE` | `18` | 아이콘 글리프 크기. 나란히 놓았을 때 무게가 맞는다                    |
+| `ICON_COUNT_BUTTON_INK_INSET` | `10` | 버튼이 품은 여백. 아이콘 잉크를 본문 왼쪽 선에 맞추려면 이만큼 당긴다 |
+
+## 설계 노트
+
+- **폭은 내용만큼만 차지합니다.** 최소 폭을 주면 숫자 자릿수에 따라 남는 자리가 달라져 옆 아이콘과의 간격이 매번 달라 보입니다. 숫자는 `99+`에서 멈추므로 옆 아이콘이 밀리는 폭은 세 글자를 넘지 않습니다.
+- **버튼끼리는 붙여 놓습니다.** 사이는 각 버튼이 품은 가로 여백이 벌리므로, 눌리는 영역에 빈틈도 겹침도 생기지 않습니다.
+- `hitSlop`은 세로로만 넓힙니다. 가로는 여백이 이미 벌려 두어 옆 버튼의 영역을 침범하지 않습니다.

--- a/apps/mobile/src/shared/ui/IconCountButton/IconCountButton.tsx
+++ b/apps/mobile/src/shared/ui/IconCountButton/IconCountButton.tsx
@@ -1,7 +1,8 @@
-import { Text } from '@src/shared/ui';
 import { formatCappedCount } from '@src/shared/utils/format';
 import { PressableFeedback } from 'heroui-native';
 import type { ComponentProps, ReactNode } from 'react';
+
+import { Text } from '../Text';
 
 /**
  * 아이콘 글리프의 크기. 하트와 말풍선이 같은 상자를 쓰므로 나란히 놓았을 때 무게가 맞는다.

--- a/apps/mobile/src/shared/ui/IconCountButton/index.ts
+++ b/apps/mobile/src/shared/ui/IconCountButton/index.ts
@@ -1,0 +1,5 @@
+export {
+  ICON_COUNT_BUTTON_ICON_SIZE,
+  ICON_COUNT_BUTTON_INK_INSET,
+  IconCountButton,
+} from './IconCountButton';

--- a/apps/mobile/src/shared/ui/Overlay/useOverlay.tsx
+++ b/apps/mobile/src/shared/ui/Overlay/useOverlay.tsx
@@ -3,6 +3,28 @@ import { useContext, useEffect, useId, useRef } from 'react';
 import { OverlayItem, type OverlayRender } from './OverlayItem';
 import { OverlayContext } from './OverlayProvider';
 
+/**
+ * 화면 밖(루트)에 무언가를 띄우고, 닫힐 때 값을 돌려받는다.
+ *
+ * ⚠️ **열 때의 화면이 스냅샷으로 굳는다.**
+ * `open(render)`는 그 자리에서 element를 만들어 Provider에 넘긴다. 그 뒤 부모가 다시
+ * 렌더돼도 이 element는 갱신되지 않으므로, **부모의 반응형 값을 props로 넘기면 그 값에
+ * 얼어붙는다** — 예를 들어 `isSubmitting={mutation.isPending}`은 영원히 `false`로 남아
+ * 로딩 표시도 중복 탭 방지도 동작하지 않는다.
+ *
+ * 그래서 **띄우는 내용이 자기 상태를 스스로 가져야 한다.** 진행 중 여부가 필요하면
+ * 콜백을 `Promise`로 받아 안에서 `useState`로 재고, 서버 값이 필요하면 안에서 쿼리를 읽는다.
+ * 열 때 정해지고 변하지 않는 것(대상, 초기값)만 인자로 넘긴다.
+ *
+ * @example
+ * ```tsx
+ * // ✅ 시트가 보내는 동안을 스스로 안다
+ * onSubmit={async (value) => { await mutateAsync(value); close(value); }}
+ *
+ * // ❌ 부모의 isPending은 스냅샷에 얼어붙는다
+ * isSubmitting={mutation.isPending}
+ * ```
+ */
 export const useOverlay = () => {
   const controller = useContext(OverlayContext);
 

--- a/apps/mobile/src/shared/ui/index.ts
+++ b/apps/mobile/src/shared/ui/index.ts
@@ -80,6 +80,7 @@ export {
   ToastWarningIcon,
   TrashIcon,
 } from './Icon';
+export * from './IconCountButton';
 export {
   BottomSheetInput,
   Input,


### PR DESCRIPTION
## 📋 개요

친구 화면에는 댓글로 들어가는 길이 **아예 없었습니다.** 내 할 일에는 말풍선이 뜨는데 친구 할 일에는 아무것도 없었고, 댓글을 써도 목록으로 돌아오면 숫자가 어긋났습니다.

원인이 하나가 아니라 셋이고 서로 다른 계층에 있었습니다 — UI 누락, 클라이언트 캐시, 서버 캐시.

이 PR은 **Stack #766의 최하단**입니다.

## 🏷️ 변경 유형

- [x] 🚀 `feat` - 친구 할 일 말풍선, 목록 캐시 정합, 친구 목록 캐시 무효화
- [x] ♻️ `refactor` - IconCountButton을 shared/ui로, 불리언 판정을 Policy로

## 📦 영향 범위

- [x] `apps/mobile` - todo·todo-comment feature, shared/ui
- [x] `apps/api` - todo / todo-comment 모듈

## 서버 권한은 이미 열려 있었습니다 (바꾸지 않음)

`canAccessTodo`가 `소유자 || (PUBLIC && 수락된 친구)`이고, 친구 목록 조회는 `PUBLIC`만 가져오므로 **친구 화면에 뜬 할 일은 전부 댓글 가능**합니다. 응답도 같은 매퍼를 타 `commentCount`가 이미 들어옵니다. **그리는 코드만 없었습니다.**

## Before / After

| 영역 | Before | After |
|---|---|---|
| 친구 할 일 말풍선 | 없음 | 항상 표시 (대화는 날짜와 무관) |
| 콕 찌르기 | 오른쪽 슬롯을 독점, 날짜 조건에 걸려 슬롯째 사라짐 | 말풍선과 나란히, 기존 조건 유지 |
| 말풍선 구현 | 두 곳에서 손으로 만듦 | `shared/ui/IconCountButton` 하나 (99+ 상한 포함) |
| 낙관적 갱신 | 상세 캐시만 | 상세 + 목록 + 친구목록 |
| 서버 캐시 | 댓글 수가 변해도 친구 목록 캐시는 최대 60초 낡음 | 커밋 후 무효화 |
| 커밋 후 부수 작업 | — | `settleAfterCommit`으로 격리 |
| 불리언 판정 | 컴포넌트 안 | `TodoCommentPolicy` / `DraftPolicy` / `ThreadPolicy` |

## 설계 판단

- **행 자체는 합치지 않았습니다.** `TodoItem`은 드래그·하위 항목·낙관적 상태가 얽혀 있어 통합하면 회귀 표면이 너무 넓습니다. 반복되던 **말풍선 하나만** 묶었습니다.
- **`todo` 모듈은 포트를 그대로 열지 않습니다.** `index.ts`가 "리포지토리·인프라 구현은 공개하지 않습니다"라고 못 박고 있어, `NotificationSender`와 같은 모양으로 `TodoViewCacheInvalidator`라는 최소 capability만 공개하고 `todo-comment`가 자기 포트로 받습니다. 소유자 조회는 `todo` 쪽에 둬서 `todo-comment`가 남의 도메인 지식을 갖지 않습니다.
- **커밋 후 부수 작업을 `Promise.all`로 묶으면 안 됩니다.** 트랜잭션이 이미 끝난 뒤라 여기서 던지면 저장된 글에 500이 붙고, 클라이언트가 같은 `clientRequestId`로 재시도하면 멱등 경로가 "새로 쓴 것 없음"을 돌려줘 이 블록을 통째로 건너뜁니다 — 알림도 캐시 무효화도 두 번 다시 시도되지 않습니다. `settleAfterCommit`이 `allSettled` + 실패마다 맥락을 붙여 로깅합니다.
- **작성 시트가 보내는 동안을 스스로 잽니다.** 오버레이는 열 때의 클로저를 붙잡아, 밖에서 넘긴 진행 중 플래그가 `false`에 얼어붙습니다(이 결함의 전면 수습은 #764).
- **선 판정은 이웃 쌍을 한 번만 묻습니다.** 위 행의 아래 선과 아래 행의 위 선이 어긋나면 반쪽 선이 남습니다. 정렬(최신순↔인기순)로 순서가 통째로 바뀌어도 이 불변식이 깨지지 않는지 테스트가 고정합니다.

## ✅ 검증

```
typecheck / lint / format:check   통과
apps/mobile   1,204건 통과
apps/api      2,647건 통과
```

## 📱 기기 확인 권장

- 콕 찌르기가 사라지는 날짜에도 말풍선이 뜨는지
- 친구 할 일에 댓글을 쓰고 뒤로 갔을 때 숫자가 **즉시** 맞는지
- 다른 계정에서 같은 할 일을 열었을 때 60초 안에 숫자가 맞는지
