### PR TITLE
chore(ci): Buildx 액션을 4.3으로 올린다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:


### PR DESCRIPTION
## 📋 개요

`docker/setup-buildx-action`을 4.2.0에서 4.3.0으로 올립니다. 최신 `develop`에서 변경을 다시 만들었으며 Dependabot #776을 대체합니다.

- Supersedes #776
- 런타임 애플리케이션 코드와 사용자 API에는 영향이 없습니다.
- 액션은 immutable commit SHA로 고정합니다.

## 🏷️ 변경 유형

- [x] 👷 `ci` - CI/CD 설정 및 스크립트 변경

## 📦 영향 범위

- [x] `tooling/*` - GitHub Actions 빌드 도구

## 📝 변경 내용

- `docker/setup-buildx-action` 4.2.0 → 4.3.0
- SHA `37fe631027851001ddb9b187196cc803df7f5f0e` 고정
- 버전 주석을 `v4.3.0`으로 동기화

## 🧪 테스트

### 테스트 방법

```bash
actionlint .github/workflows/ci.yml
git diff --check
pnpm typecheck
pnpm build
```

### 테스트 결과

- [x] actionlint 통과
- [x] diff whitespace 검사 통과
- [x] 전체 타입체크 통과
- [x] API 및 모바일 build 통과
- [x] GitHub Actions 원격 CI 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm check`에 해당하는 lint/format/typecheck 검사를 통과했습니다
- [x] 변경사항에 필요한 검증을 수행했습니다
- [x] 로컬 build가 성공했습니다
- [x] 필요한 설명을 PR에 기록했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

### 리뷰어 확인

- [ ] 코드 로직이 올바릅니다
- [ ] 보안 취약점이 없습니다
- [ ] 성능 이슈가 없습니다

## 🔗 관련 이슈

- Dependabot #776 대체

## 💬 추가 정보

이 PR은 독립적인 단일 레이어입니다. production 배포나 애플리케이션 dependency 변경은 포함하지 않습니다.

