### PR TITLE
chore(api): ioredis 6에서 Redis 프로토콜 호환성을 유지한다

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -58,7 +58,7 @@
 		"expo-server-sdk": "^6.1.0",
 		"google-auth-library": "^10.9.1",
 		"helmet": "^8.3.0",
-		"ioredis": "5.11.1",
+		"ioredis": "6.0.0",
 		"jose": "^6.2.8",
 		"nestjs-cls": "^6.2.1",
 		"nestjs-pino": "^4.6.1",

--- a/apps/api/src/shared/infrastructure/redis/redis-client.factory.spec.ts
+++ b/apps/api/src/shared/infrastructure/redis/redis-client.factory.spec.ts
@@ -30,6 +30,7 @@ describe("redis-client.factory — Redis 클라이언트 옵션 팩토리", () =
 
 			// Then
 			expect(options.maxRetriesPerRequest).toBeNull();
+			expect(options.protocol).toBe(2);
 			expect(options.enableReadyCheck).toBe(true);
 			expect(options.connectionName).toBe("aido-main");
 		});
@@ -100,6 +101,7 @@ describe("redis-client.factory — Redis 클라이언트 옵션 팩토리", () =
 			expect(options.commandTimeout).toBe(1500);
 			expect(options.connectTimeout).toBe(5000);
 			expect(options.maxRetriesPerRequest).toBe(1);
+			expect(options.protocol).toBe(2);
 			expect(options.enableReadyCheck).toBe(true);
 			expect(options.connectionName).toBe("aido-command");
 		});

--- a/apps/api/src/shared/infrastructure/redis/redis-client.factory.ts
+++ b/apps/api/src/shared/infrastructure/redis/redis-client.factory.ts
@@ -27,6 +27,9 @@ export interface RedisConnectionSettings {
 export function buildBullRedisOptions(settings: RedisConnectionSettings): RedisOptions {
 	return {
 		...baseHostOptions(settings),
+		// ioredis 6은 RESP3가 기본이지만 기존 Redis/BullMQ wire contract를
+		// 유지해 rolling deployment 중 protocol 차이를 만들지 않는다.
+		protocol: 2,
 		maxRetriesPerRequest: null,
 		enableReadyCheck: true,
 		connectionName: "aido-main",
@@ -48,6 +51,8 @@ export function buildBullRedisOptions(settings: RedisConnectionSettings): RedisO
 export function buildCommandRedisOptions(settings: RedisConnectionSettings): RedisOptions {
 	return {
 		...baseHostOptions(settings),
+		// 캐시·락·스로틀의 응답 shape를 v5와 동일하게 유지한다.
+		protocol: 2,
 		maxRetriesPerRequest: 1,
 		enableOfflineQueue: false,
 		commandTimeout: settings.commandTimeoutMs,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
         version: 0.45.1
       bullmq:
         specifier: ^6.3.2
-        version: 6.3.2(ioredis@5.11.1)(pg@8.22.0)
+        version: 6.3.2(ioredis@6.0.0)(pg@8.22.0)
       dayjs:
         specifier: 'catalog:'
         version: 1.11.22
@@ -182,8 +182,8 @@ importers:
         specifier: ^8.3.0
         version: 8.3.0
       ioredis:
-        specifier: 5.11.1
-        version: 5.11.1
+        specifier: 6.0.0
+        version: 6.0.0
       jose:
         specifier: ^6.2.8
         version: 6.2.9
@@ -283,7 +283,7 @@ importers:
         version: 5.0.6
       '@types/ioredis-mock':
         specifier: ^8.2.8
-        version: 8.2.8(ioredis@5.11.1)
+        version: 8.2.8(ioredis@6.0.0)
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
@@ -313,7 +313,7 @@ importers:
         version: 7.2.1
       ioredis-mock:
         specifier: ^8.13.1
-        version: 8.13.1(@types/ioredis-mock@8.2.8(ioredis@5.11.1))(ioredis@5.11.1)
+        version: 8.13.1(@types/ioredis-mock@8.2.8(ioredis@6.0.0))(ioredis@6.0.0)
       jest:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@22.19.7)(ts-node@10.9.2(@swc/core@1.16.0)(@types/node@22.19.7)(typescript@5.9.3))
@@ -2171,6 +2171,9 @@ packages:
 
   '@ioredis/commands@1.10.0':
     resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+
+  '@ioredis/commands@2.0.0':
+    resolution: {integrity: sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -7065,9 +7068,9 @@ packages:
       '@types/ioredis-mock': ^8
       ioredis: ^5
 
-  ioredis@5.11.1:
-    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
-    engines: {node: '>=12.22.0'}
+  ioredis@6.0.0:
+    resolution: {integrity: sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==}
+    engines: {node: '>=20.0.0'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -9022,10 +9025,6 @@ packages:
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
-
-  redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
   reflect-metadata@0.2.2:
@@ -12264,6 +12263,8 @@ snapshots:
 
   '@ioredis/commands@1.10.0': {}
 
+  '@ioredis/commands@2.0.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -14433,9 +14434,9 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/ioredis-mock@8.2.8(ioredis@5.11.1)':
+  '@types/ioredis-mock@8.2.8(ioredis@6.0.0)':
     dependencies:
-      ioredis: 5.11.1
+      ioredis: 6.0.0
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -15549,7 +15550,7 @@ snapshots:
   buildcheck@0.0.7:
     optional: true
 
-  bullmq@6.3.2(ioredis@5.11.1)(pg@8.22.0):
+  bullmq@6.3.2(ioredis@6.0.0)(pg@8.22.0):
     dependencies:
       cron-parser: 5.10.0
       msgpackr: 2.1.0
@@ -15557,7 +15558,7 @@ snapshots:
       semver: 7.8.5
       tslib: 2.8.1
     optionalDependencies:
-      ioredis: 5.11.1
+      ioredis: 6.0.0
       pg: 8.22.0
 
   busboy@1.6.0:
@@ -17613,24 +17614,23 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.8(ioredis@5.11.1))(ioredis@5.11.1):
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.8(ioredis@6.0.0))(ioredis@6.0.0):
     dependencies:
       '@ioredis/as-callback': 3.0.0
       '@ioredis/commands': 1.10.0
-      '@types/ioredis-mock': 8.2.8(ioredis@5.11.1)
+      '@types/ioredis-mock': 8.2.8(ioredis@6.0.0)
       fengari: 0.1.5
       fengari-interop: 0.1.4(fengari@0.1.5)
-      ioredis: 5.11.1
+      ioredis: 6.0.0
       semver: 7.8.5
 
-  ioredis@5.11.1:
+  ioredis@6.0.0:
     dependencies:
-      '@ioredis/commands': 1.10.0
+      '@ioredis/commands': 2.0.0
       cluster-key-slot: 1.1.1
       debug: 4.4.3
       denque: 2.1.0
       redis-errors: 1.2.0
-      redis-parser: 3.0.0
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -20017,10 +20017,6 @@ snapshots:
       strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
-
-  redis-parser@3.0.0:
-    dependencies:
-      redis-errors: 1.2.0
 
   reflect-metadata@0.2.2: {}
 


### PR DESCRIPTION
## 📋 개요

실제로 cache, distributed lock, throttling, notification rate limit, BullMQ fallback에서 사용하는 ioredis를 6.0.0으로 올립니다. 기존 사용자 트래픽의 응답 형태와 rolling deployment 호환성을 지키기 위해 모든 공용 client 생성 경로에 RESP2를 명시합니다.

이 PR은 GitHub stack #793의 3/4이며 #791 위에 쌓여 있습니다.

## 🏷️ 변경 유형

- [x] 🔨 `chore` - 기타 변경사항 (의존성 업데이트)

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드

## 📝 변경 내용

- `ioredis`를 5.x에서 안정 버전 6.0.0으로 업데이트
- command/cache client와 BullMQ/job client 양쪽에 `protocol: 2` 명시
- RESP3 기본값 전환으로 인한 응답 shape 및 구버전 인스턴스 혼재 위험 차단
- option builder 단위 테스트에 protocol 회귀 assertion 추가

## 🧪 테스트

### 테스트 방법

```bash
pnpm install --frozen-lockfile
pnpm lint
pnpm format:check
pnpm typecheck
pnpm build
pnpm --filter @aido/api test --runInBand
pnpm --filter @aido/api test:integration --runInBand
pnpm --filter @aido/api test:e2e --runInBand
# Redis 8 container에서 실제 cache set/get와 BullMQ job completion smoke
```

### 테스트 결과

- [x] Redis 관련 집중 테스트 50개 통과
- [x] API 단위 테스트 432 suites / 2,788 tests 통과
- [x] API 통합 테스트 41 suites / 423 tests 통과
- [x] Redis 8 cache 및 BullMQ smoke 통과
- [x] 저장소 lint, format, typecheck, build 통과
- [x] 전체 E2E의 일시적 resource-limit 1건은 단독 재실행 4/4 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다
- [x] `pnpm lint && pnpm format:check && pnpm typecheck` 검사를 통과했습니다
- [x] 변경사항에 대한 테스트를 작성하거나 기존 회귀 테스트로 검증했습니다
- [x] 관련 테스트가 통과합니다
- [x] 빌드가 성공합니다 (`pnpm build`)
- [x] 필요한 문서를 정리했습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

### 리뷰어 확인

- [ ] 코드 로직이 올바릅니다
- [ ] 에러 처리가 적절합니다
- [ ] 보안 취약점이 없습니다
- [ ] 성능 이슈가 없습니다

## 🔗 관련 이슈

- Dependabot #775 대체
- Stack #793
- 이전 PR: #791
- 다음 PR: #804

## 📸 스크린샷 (UI 변경 시)

해당 없음

## 💬 추가 정보

`ioredis`는 제거 대상이 아닙니다. pg-boss가 primary queue여도 Redis cache, lock, throttling과 BullMQ fallback 때문에 production에서 사용됩니다. dev-only `ioredis-mock@8.13.1`의 peer metadata는 아직 ioredis 5로 제한되어 있지만 실제 테스트는 통과했으며 운영 dependency에는 포함되지 않습니다.