### PR TITLE
chore(api): migration 이미지 도구 버전을 런타임과 맞춘다

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -53,9 +53,9 @@ COPY apps/api/scripts/migrate.sh ./scripts/migrate.sh
 # prisma.config.ts가 require하는 문지기 — 없으면 이 이미지의 모든 Prisma 명령이 죽는다.
 COPY apps/api/scripts/guard-database-url.cjs ./scripts/guard-database-url.cjs
 
-# 빈 프로젝트에 prisma CLI만 설치 (workspace/catalog 의존 회피)
-# apps/api/package.json의 prisma 버전(^7.8.0)과 함께 올릴 것 — silent major 업그레이드 방지
-RUN pnpm init && pnpm add prisma@7.8.0 pg-boss@12.26.2 && chmod 0755 ./scripts/migrate.sh
+# 빈 프로젝트에 migration CLI만 설치 (workspace/catalog 의존 회피)
+# 정본은 apps/api/package.json이다. 런타임 버전 변경 시 이 exact pin도 같은 PR에서 맞춘다.
+RUN pnpm init && pnpm add prisma@7.9.1 pg-boss@12.27.0 && chmod 0755 ./scripts/migrate.sh
 
 # RDS CA 인증서
 ADD --chmod=644 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /app/certs/rds-ca.pem


### PR DESCRIPTION
## 📋 개요

migration 전용 Docker stage에 남아 있던 Prisma와 pg-boss 구버전 pin을 현재 API runtime 버전과 맞춥니다. application runtime이나 DB schema는 건드리지 않는 선행 정리 PR입니다.

이 PR은 GitHub stack #799의 1/2이며 base는 `develop`입니다.

## 🏷️ 변경 유형

- [x] 🔨 `chore` - 기타 변경사항 (배포 도구 의존성 정렬)

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드 및 migration 이미지

## 📝 변경 내용

- migration image의 Prisma CLI를 7.8.0에서 현재 runtime 7.9.1로 정렬
- migration image의 pg-boss를 12.26.2에서 현재 runtime 12.27.0으로 정렬
- Docker comment에 `apps/api/package.json`을 정본으로 명시
- application code, DB schema, migration SQL, public API는 변경하지 않음

## 🧪 테스트

### 테스트 방법

```bash
pnpm install --frozen-lockfile
pnpm lint
pnpm format:check
pnpm typecheck
pnpm --filter @aido/api build
docker build --target migrate -f apps/api/Dockerfile .
# image 내부 prisma 및 pg-boss 버전 확인
```

### 테스트 결과

- [x] migration Docker target build 성공
- [x] 이미지 내부 Prisma 7.9.1, pg-boss 12.27.0 확인
- [x] API build 및 저장소 lint, format, typecheck 통과
- [x] Prisma schema/migrations 무변경 확인

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 API 아키텍처와 코딩 컨벤션을 따릅니다
- [x] `pnpm lint && pnpm format:check && pnpm typecheck` 검사를 통과했습니다
- [x] 변경사항에 대한 테스트를 작성하거나 기존 회귀 테스트로 검증했습니다
- [x] 관련 테스트가 통과합니다
- [x] API 및 migration 이미지 빌드가 성공합니다
- [x] Prisma schema와 migration SQL이 변경되지 않았습니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

### 리뷰어 확인

- [ ] 코드 로직이 올바릅니다
- [ ] 에러 처리가 적절합니다
- [ ] 보안 취약점이 없습니다
- [ ] 성능 이슈가 없습니다

## 🔗 관련 이슈

- Stack #799
- 다음 PR: #798

## 📸 스크린샷 (UI 변경 시)

해당 없음

## 💬 추가 정보

운영 migration 실행, DB push, schema 변경은 수행하지 않았습니다. 하단 PR부터 순서대로 배포할 수 있습니다.