### PR TITLE
chore(api): Google Auth Library를 11.0.2로 올린다

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -57,7 +57,7 @@
 		"dayjs": "catalog:",
 		"es-hangul": "^2.4.0",
 		"expo-server-sdk": "^6.1.0",
-		"google-auth-library": "^10.9.1",
+		"google-auth-library": "^11.0.2",
 		"helmet": "^8.3.0",
 		"ioredis": "5.11.1",
 		"jose": "^6.2.8",

--- a/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.spec.ts
+++ b/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.spec.ts
@@ -127,19 +127,36 @@ describe("OAuthTokenVerifierService — OAuth 토큰 검증 서비스", () => {
 			});
 
 			// When & Then
-			await expect(service.verifyGoogleToken("invalid-token")).rejects.toThrow(
-				ApplicationException,
-			);
+			await expect(service.verifyGoogleToken("invalid-token")).rejects.toMatchObject({
+				errorCode: ErrorCode.SOCIAL_0202,
+				details: { provider: "GOOGLE" },
+			});
 		});
 
 		it("만료된 토큰은 socialTokenExpired 에러를 발생시킨다", async () => {
 			// Given
-			mockGoogleVerifyIdToken.mockRejectedValue(new Error("Token used too late, expired"));
+			mockGoogleVerifyIdToken.mockRejectedValue(
+				new Error('Token used too late, 100 > 90: {"sub":"google-user-123"}'),
+			);
 
 			// When & Then
-			await expect(service.verifyGoogleToken("expired-token")).rejects.toThrow(
-				ApplicationException,
+			await expect(service.verifyGoogleToken("expired-token")).rejects.toMatchObject({
+				errorCode: ErrorCode.SOCIAL_0203,
+				details: { provider: "GOOGLE" },
+			});
+		});
+
+		it("audience가 다른 토큰은 socialTokenInvalid 에러를 발생시킨다", async () => {
+			// Given
+			mockGoogleVerifyIdToken.mockRejectedValue(
+				new Error("Wrong recipient, payload audience != requiredAudience"),
 			);
+
+			// When & Then
+			await expect(service.verifyGoogleToken("wrong-audience-token")).rejects.toMatchObject({
+				errorCode: ErrorCode.SOCIAL_0202,
+				details: { provider: "GOOGLE" },
+			});
 		});
 
 		it("잘못된 토큰은 socialTokenInvalid 에러를 발생시킨다", async () => {
@@ -147,9 +164,10 @@ describe("OAuthTokenVerifierService — OAuth 토큰 검증 서비스", () => {
 			mockGoogleVerifyIdToken.mockRejectedValue(new Error("Invalid signature"));
 
 			// When & Then
-			await expect(service.verifyGoogleToken("malformed-token")).rejects.toThrow(
-				ApplicationException,
-			);
+			await expect(service.verifyGoogleToken("malformed-token")).rejects.toMatchObject({
+				errorCode: ErrorCode.SOCIAL_0202,
+				details: { provider: "GOOGLE" },
+			});
 		});
 	});
 

--- a/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.spec.ts
+++ b/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.spec.ts
@@ -15,6 +15,7 @@ import { createHash } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
 import { ErrorCode } from "@aido/errors";
+import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import type { Mocked } from "@suites/doubles.jest";
 import { TestBed } from "@suites/unit";
@@ -64,6 +65,10 @@ describe("OAuthTokenVerifierService — OAuth 토큰 검증 서비스", () => {
 			};
 			return config[key];
 		});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
 	});
 
 	describe("verifyGoogleToken", () => {
@@ -135,15 +140,24 @@ describe("OAuthTokenVerifierService — OAuth 토큰 검증 서비스", () => {
 
 		it("만료된 토큰은 socialTokenExpired 에러를 발생시킨다", async () => {
 			// Given
+			const loggerErrorSpy = jest.spyOn(Logger.prototype, "error").mockImplementation();
+			const sensitiveSubject = "google-user-123";
 			mockGoogleVerifyIdToken.mockRejectedValue(
-				new Error('Token used too late, 100 > 90: {"sub":"google-user-123"}'),
+				new Error(`Token used too late, 100 > 90: {"sub":"${sensitiveSubject}"}`),
 			);
 
-			// When & Then
-			await expect(service.verifyGoogleToken("expired-token")).rejects.toMatchObject({
+			// When
+			const verification = service.verifyGoogleToken("expired-token");
+
+			// Then
+			await expect(verification).rejects.toMatchObject({
 				errorCode: ErrorCode.SOCIAL_0203,
 				details: { provider: "GOOGLE" },
 			});
+			expect(loggerErrorSpy).toHaveBeenCalledWith(
+				"Google token verification failed (expired): Error",
+			);
+			expect(JSON.stringify(loggerErrorSpy.mock.calls)).not.toContain(sensitiveSubject);
 		});
 
 		it("audience가 다른 토큰은 socialTokenInvalid 에러를 발생시킨다", async () => {

--- a/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.ts
+++ b/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.ts
@@ -184,9 +184,11 @@ export class OAuthTokenVerifierService implements OnModuleInit {
 			};
 		} catch (error) {
 			this.#logger.error(`Google token verification failed: ${error}`);
+			const errorMessage = error instanceof Error ? error.message.toLowerCase() : "";
 
-			// Google Auth Library는 만료된 토큰에 대해 일반 에러를 던짐
-			if (error instanceof Error && error.message.includes("expired")) {
+			// Google Auth Library는 전용 만료 오류 타입 없이 일반 Error를 사용한다.
+			// 실제 서명 검증 경로의 메시지는 "Token used too late"이므로 기존 expired 표현과 함께 처리한다.
+			if (errorMessage.includes("expired") || errorMessage.includes("token used too late")) {
 				throw new ApplicationException(ErrorCode.SOCIAL_0203, {
 					provider: "GOOGLE",
 				});

--- a/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.ts
+++ b/apps/api/src/auth/infrastructure/oauth/verifier/oauth-token-verifier.service.ts
@@ -183,12 +183,19 @@ export class OAuthTokenVerifierService implements OnModuleInit {
 				picture: payload.picture,
 			};
 		} catch (error) {
-			this.#logger.error(`Google token verification failed: ${error}`);
 			const errorMessage = error instanceof Error ? error.message.toLowerCase() : "";
+			const isExpired =
+				errorMessage.includes("expired") || errorMessage.includes("token used too late");
+			const errorType = error instanceof Error ? error.name : "UnknownError";
+
+			// Google v11 오류 문자열에는 decoded payload가 포함될 수 있어 원문을 로그하지 않는다.
+			this.#logger.error(
+				`Google token verification failed (${isExpired ? "expired" : "invalid"}): ${errorType}`,
+			);
 
 			// Google Auth Library는 전용 만료 오류 타입 없이 일반 Error를 사용한다.
 			// 실제 서명 검증 경로의 메시지는 "Token used too late"이므로 기존 expired 표현과 함께 처리한다.
-			if (errorMessage.includes("expired") || errorMessage.includes("token used too late")) {
+			if (isExpired) {
 				throw new ApplicationException(ErrorCode.SOCIAL_0203, {
 					provider: "GOOGLE",
 				});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       google-auth-library:
-        specifier: ^10.9.1
-        version: 10.9.1
+        specifier: ^11.0.2
+        version: 11.0.2
       helmet:
         specifier: ^8.3.0
         version: 8.3.0
@@ -6720,9 +6720,9 @@ packages:
     resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
     engines: {node: '>=18'}
 
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
-    engines: {node: '>=18'}
+  gcp-metadata@9.0.3:
+    resolution: {integrity: sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==}
+    engines: {node: '>=22'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -6817,13 +6817,13 @@ packages:
     resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
 
-  google-auth-library@10.9.1:
-    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
-    engines: {node: '>=18'}
+  google-auth-library@11.0.2:
+    resolution: {integrity: sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==}
+    engines: {node: '>=22'}
 
-  google-logging-utils@1.1.3:
-    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
-    engines: {node: '>=14'}
+  google-logging-utils@2.0.1:
+    resolution: {integrity: sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==}
+    engines: {node: '>=22'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -17355,10 +17355,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.2:
+  gcp-metadata@9.0.3:
     dependencies:
       gaxios: 7.1.5
-      google-logging-utils: 1.1.3
+      google-logging-utils: 2.0.1
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17467,18 +17467,18 @@ snapshots:
       is-windows: 1.0.2
       which: 1.3.1
 
-  google-auth-library@10.9.1:
+  google-auth-library@11.0.2:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
       gaxios: 7.1.5
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
+      gcp-metadata: 9.0.3
+      google-logging-utils: 2.0.1
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
 
-  google-logging-utils@1.1.3: {}
+  google-logging-utils@2.0.1: {}
 
   gopd@1.2.0: {}
 


### PR DESCRIPTION
## 📋 개요

Google OAuth ID token verifier를 `google-auth-library` 11.0.2로 업그레이드합니다. 기존 로그인 사용자에게 노출되는 오류 코드 계약을 유지하면서 v11의 실제 만료 메시지인 `Token used too late`를 만료 토큰으로 정확히 분류합니다.

이 PR은 `develop` 기반의 독립 gh-stack PR입니다.

## 🏷️ 변경 유형

- [x] 🔨 `chore` - 기타 변경사항 (인증 의존성 업데이트)

## 📦 영향 범위

- [x] `apps/api` - NestJS 백엔드

## 📝 변경 내용

- `google-auth-library`를 10.9.1에서 11.0.2로 업데이트
- v11 검증 실패 메시지 `Token used too late`를 기존 `SOCIAL_0203` 만료 오류로 매핑
- 잘못된 audience와 signature는 기존 `SOCIAL_0202` invalid 오류로 유지
- v11 오류 문자열의 decoded payload를 로그하지 않고 분류와 오류 타입만 기록
- OAuth verifier의 public input/output와 모바일 로그인 계약은 변경하지 않음
- 만료, audience, malformed token 회귀 테스트를 오류 코드와 provider까지 검증하도록 강화
- 만료 로그에 decoded subject가 포함되지 않는 비식별화 회귀 assertion 추가

## 🧪 테스트

### 테스트 방법

```bash
pnpm install --frozen-lockfile
pnpm --filter @aido/api test --runInBand
pnpm --filter @aido/api test:integration --runInBand
pnpm --filter @aido/api test:e2e --runInBand
pnpm lint
pnpm format:check
pnpm typecheck
pnpm build
```

### 테스트 결과

- [x] OAuth verifier 집중 테스트 20개 통과
- [x] API 단위 테스트 432 suites / 2,789 tests 통과
- [x] OAuth 통합 테스트 49개 통과
- [x] Auth 및 OpenAPI E2E 88개와 snapshot 통과
- [x] 저장소 lint, format, typecheck, build 통과

## ✅ 체크리스트

### 작성자 확인

- [x] 코드가 프로젝트의 API 아키텍처와 코딩 컨벤션을 따릅니다
- [x] `pnpm lint && pnpm format:check && pnpm typecheck` 검사를 통과했습니다
- [x] 변경사항에 대한 테스트를 작성하거나 보강했습니다
- [x] 관련 테스트가 통과합니다
- [x] 빌드가 성공합니다
- [x] 기존 OAuth 오류 코드 계약을 유지합니다
- [x] 커밋 메시지가 Conventional Commits 규칙을 따릅니다
- [x] PR 라벨이 `type:*` 1개와 필요한 `scope:*`로 정리되어 있습니다

### 리뷰어 확인

- [ ] 코드 로직이 올바릅니다
- [ ] 에러 처리가 적절합니다
- [ ] 보안 취약점이 없습니다
- [ ] 성능 이슈가 없습니다

## 🔗 관련 이슈

- Dependabot #774 대체

## 📸 스크린샷 (UI 변경 시)

해당 없음

## 💬 추가 정보

OAuth client ID, token audience 설정, API response schema에는 변화가 없습니다. production 배포나 인증 설정 변경은 수행하지 않았습니다.